### PR TITLE
Per-lexicon release infrastructure

### DIFF
--- a/.github/workflows/publish-lexicon.yml
+++ b/.github/workflows/publish-lexicon.yml
@@ -1,0 +1,44 @@
+name: publish-lexicon
+
+on:
+  push:
+    tags: ['lexicon-*-v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+
+      - name: Extract lexicon name from tag
+        id: meta
+        run: |
+          # Tag: lexicon-docker-v0.1.1  →  name=docker
+          tag="${{ github.ref_name }}"
+          name="${tag#lexicon-}"          # strip "lexicon-"
+          name="${name%-v*}"              # strip "-v<version>"
+          echo "name=$name" >> $GITHUB_OUTPUT
+
+      - name: Cache lexicon schemas
+        uses: actions/cache@v4
+        with:
+          path: ~/.chant
+          key: lexicon-schemas-${{ hashFiles('lexicons/*/src/**/fetch.ts', 'lexicons/*/src/**/versions.ts') }}
+          restore-keys: lexicon-schemas-
+
+      - name: Prepack lexicon
+        run: bun run --cwd lexicons/${{ steps.meta.outputs.name }} prepack
+
+      - name: Run tests
+        run: bun test lexicons/${{ steps.meta.outputs.name }}
+
+      - name: Publish
+        working-directory: lexicons/${{ steps.meta.outputs.name }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ../../.npmrc
+          bun publish --access public --tolerate-republish

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ bench:
 smoke-bun:
     docker build -f test/Dockerfile.smoke -t chant-smoke-bun . && docker run -it --rm -v "$HOME/.claude:/root/.claude" -v "$HOME/.claude.json:/root/.claude.json" -v "$HOME/.aws:/root/.aws:ro" chant-smoke-bun
 
-# Build and run npm tarball smoke test (all 6 lexicons, both npm and bun runtimes)
+# Build and run npm tarball smoke test (all 9 lexicons, both npm and bun runtimes)
 smoke-npm:
     ./test/smoke.sh npm
 
@@ -87,6 +87,28 @@ release bump="patch":
     git tag "v$next"
     git push origin main "v$next"
     echo "Released v$next — publish workflow triggered"
+
+# Bump a single lexicon version and tag (e.g. just release-lexicon docker patch)
+release-lexicon name bump="patch":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    current=$(jq -r .version lexicons/{{name}}/package.json)
+    IFS='.' read -r major minor patch <<< "$current"
+    case "{{bump}}" in
+      major) major=$((major + 1)); minor=0; patch=0 ;;
+      minor) minor=$((minor + 1)); patch=0 ;;
+      patch) patch=$((patch + 1)) ;;
+      *) echo "Usage: just release-lexicon <name> [major|minor|patch]"; exit 1 ;;
+    esac
+    next="$major.$minor.$patch"
+    echo "Bumping @intentius/chant-lexicon-{{name}} $current → $next"
+    jq --arg v "$next" '.version = $v' lexicons/{{name}}/package.json \
+      > lexicons/{{name}}/package.json.tmp && mv lexicons/{{name}}/package.json.tmp lexicons/{{name}}/package.json
+    git add lexicons/{{name}}/package.json
+    git commit -m "lexicon-{{name}}: v$next"
+    git tag "lexicon-{{name}}-v$next"
+    git push origin HEAD "lexicon-{{name}}-v$next"
+    echo "Released @intentius/chant-lexicon-{{name}} v$next — publish workflow triggered"
 
 # Build Zed extension (WASM)
 ext-zed-build:

--- a/lexicons/aws/package.json
+++ b/lexicons/aws/package.json
@@ -43,11 +43,14 @@
     "prepack": "bun run generate && bun run bundle && bun run validate"
   },
   "dependencies": {
-    "@intentius/chant": "workspace:*",
     "fflate": "^0.8.2",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
+    "@intentius/chant": "workspace:*",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@intentius/chant": "^0.1.0"
   }
 }

--- a/lexicons/azure/package.json
+++ b/lexicons/azure/package.json
@@ -43,10 +43,13 @@
     "prepack": "bun run generate && bun run bundle && bun run validate"
   },
   "dependencies": {
-    "@intentius/chant": "workspace:*",
     "fflate": "^0.8.2"
   },
   "devDependencies": {
+    "@intentius/chant": "workspace:*",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@intentius/chant": "^0.1.0"
   }
 }

--- a/lexicons/docker/package.json
+++ b/lexicons/docker/package.json
@@ -43,10 +43,11 @@
     "docs": "bun run src/codegen/docs-cli.ts",
     "prepack": "bun run generate && bun run bundle && bun run validate"
   },
-  "dependencies": {
-    "@intentius/chant": "workspace:*"
-  },
   "devDependencies": {
+    "@intentius/chant": "workspace:*",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@intentius/chant": "^0.1.0"
   }
 }

--- a/lexicons/flyway/package.json
+++ b/lexicons/flyway/package.json
@@ -43,10 +43,11 @@
     "docs": "bun run src/codegen/docs-cli.ts",
     "prepack": "bun run generate && bun run bundle && bun run validate"
   },
-  "dependencies": {
-    "@intentius/chant": "workspace:*"
-  },
   "devDependencies": {
+    "@intentius/chant": "workspace:*",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@intentius/chant": "^0.1.0"
   }
 }

--- a/lexicons/gcp/package.json
+++ b/lexicons/gcp/package.json
@@ -43,11 +43,14 @@
     "prepack": "bun run generate && bun run bundle && bun run validate"
   },
   "dependencies": {
-    "@intentius/chant": "workspace:*",
     "fflate": "^0.8.2",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
+    "@intentius/chant": "workspace:*",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@intentius/chant": "^0.1.0"
   }
 }

--- a/lexicons/github/package.json
+++ b/lexicons/github/package.json
@@ -42,10 +42,11 @@
     "docs": "bun run src/codegen/docs-cli.ts",
     "prepack": "bun run generate && bun run bundle && bun run validate"
   },
-  "dependencies": {
-    "@intentius/chant": "workspace:*"
-  },
   "devDependencies": {
+    "@intentius/chant": "workspace:*",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@intentius/chant": "^0.1.0"
   }
 }

--- a/lexicons/gitlab/package.json
+++ b/lexicons/gitlab/package.json
@@ -42,10 +42,11 @@
     "docs": "bun run src/codegen/docs-cli.ts",
     "prepack": "bun run generate && bun run bundle && bun run validate"
   },
-  "dependencies": {
-    "@intentius/chant": "workspace:*"
-  },
   "devDependencies": {
+    "@intentius/chant": "workspace:*",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@intentius/chant": "^0.1.0"
   }
 }

--- a/lexicons/helm/package.json
+++ b/lexicons/helm/package.json
@@ -43,10 +43,13 @@
     "prepack": "bun run generate && bun run bundle && bun run validate"
   },
   "dependencies": {
-    "@intentius/chant": "workspace:*",
     "@intentius/chant-lexicon-k8s": "workspace:*"
   },
   "devDependencies": {
+    "@intentius/chant": "workspace:*",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@intentius/chant": "^0.1.0"
   }
 }

--- a/lexicons/k8s/package.json
+++ b/lexicons/k8s/package.json
@@ -42,10 +42,11 @@
     "docs": "bun run src/codegen/docs-cli.ts",
     "prepack": "bun run generate && bun run bundle && bun run validate"
   },
-  "dependencies": {
-    "@intentius/chant": "workspace:*"
-  },
   "devDependencies": {
+    "@intentius/chant": "workspace:*",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@intentius/chant": "^0.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- **peerDependencies** in all 9 lexicon `package.json` files: `@intentius/chant` moved from `dependencies` to `devDependencies` (monorepo resolution) + `peerDependencies: { "^0.1.0" }` (published range). Lexicons with real runtime deps (fflate, js-yaml) keep those in `dependencies`.
- **`.github/workflows/publish-lexicon.yml`**: new workflow triggered by `lexicon-*-v*` tags (e.g. `lexicon-docker-v0.1.1`) — extracts lexicon name from tag, prepacks, tests, and publishes only that lexicon independently.
- **`just release-lexicon <name> [patch|minor|major]`**: bumps version in the lexicon's `package.json`, commits, tags, and pushes to trigger the new workflow.

> **Merge order**: merge #1 (`feat/docker-lexicon`) first. This PR's diff against main will then show only the release-infra changes.

## Test plan
- [ ] Merge `feat/docker-lexicon` (#1) first, then rebase this branch
- [ ] Verify `lexicons/*/package.json` all have `peerDependencies` and no `@intentius/chant` in `dependencies`
- [ ] After merge, tag `v0.1.0` to publish all 10 packages with correct peer ranges
- [ ] Dry-run `just release-lexicon docker patch` to confirm version bump + tag logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)