### PR TITLE
feat(run): chant run CLI for Op workflow execution

### DIFF
--- a/packages/core/src/cli/handlers/run-client.ts
+++ b/packages/core/src/cli/handlers/run-client.ts
@@ -1,0 +1,134 @@
+/** Subset of WorkerProfile fields used by `chant run`. */
+export interface WorkerProfile {
+  address: string;
+  namespace: string;
+  taskQueue: string;
+  tls?: boolean | { serverNameOverride?: string };
+  apiKey?: string | { env: string };
+  autoStart?: boolean;
+}
+
+export interface TemporalClientModule {
+  Connection: {
+    connect(opts: Record<string, unknown>): Promise<unknown>;
+  };
+  Client: new (opts: Record<string, unknown>) => TemporalClientHandle;
+}
+
+export interface TemporalClientHandle {
+  workflow: {
+    start(workflowFn: unknown, opts: Record<string, unknown>): Promise<WorkflowHandleRaw>;
+    getHandle(workflowId: string): WorkflowHandleRaw;
+    list(opts?: Record<string, unknown>): AsyncIterable<WorkflowExecutionInfo>;
+  };
+}
+
+export interface WorkflowHandleRaw {
+  workflowId: string;
+  firstExecutionRunId?: string;
+  result(): Promise<unknown>;
+  describe(): Promise<WorkflowExecutionDescription>;
+  fetchHistory(): Promise<WorkflowHistoryRaw>;
+  signal(signalName: string): Promise<void>;
+  cancel(): Promise<void>;
+}
+
+export interface WorkflowExecutionDescription {
+  workflowId: string;
+  runId: string;
+  status: { name: string };
+  startTime: Date;
+  closeTime?: Date;
+  taskQueue: string;
+  type: { name: string };
+}
+
+export interface WorkflowExecutionInfo {
+  workflowId: string;
+  runId: string;
+  type: { name: string };
+  status: { name: string };
+  startTime: Date;
+  closeTime?: Date;
+}
+
+export interface WorkflowHistoryRaw {
+  events?: HistoryEvent[];
+}
+
+export interface HistoryEvent {
+  eventType?: string;
+  eventTime?: Date;
+  activityTaskCompletedEventAttributes?: { scheduledEventId?: string | number };
+  activityTaskScheduledEventAttributes?: { activityId?: string; activityType?: { name?: string } };
+  activityTaskFailedEventAttributes?: { failure?: { message?: string } };
+  workflowExecutionCompletedEventAttributes?: unknown;
+  workflowExecutionFailedEventAttributes?: { failure?: { message?: string } };
+}
+
+/**
+ * Dynamically import @temporalio/client from the user's project node_modules.
+ * Fails with a helpful message if not installed.
+ */
+export async function loadTemporalClient(): Promise<TemporalClientModule> {
+  try {
+    // Use variable to prevent tsc from statically resolving the optional dep
+    const mod = "@temporalio/client";
+    return await import(mod) as unknown as TemporalClientModule;
+  } catch {
+    throw new Error(
+      '@temporalio/client is not installed. Run: npm install @temporalio/client',
+    );
+  }
+}
+
+/**
+ * Build a Temporal Connection.connect() options object from a worker profile.
+ */
+export function connectionOptions(profile: WorkerProfile): Record<string, unknown> {
+  const apiKey =
+    typeof profile.apiKey === "object" && profile.apiKey !== null
+      ? process.env[(profile.apiKey as { env: string }).env]
+      : (profile.apiKey as string | undefined);
+
+  return {
+    address: profile.address,
+    ...(profile.tls && {
+      tls: typeof profile.tls === "object" ? profile.tls : {},
+      metadata: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+    }),
+  };
+}
+
+/**
+ * Deterministic workflow ID for an Op — allows status/signal/cancel/log
+ * without storing run IDs locally.
+ */
+export function resolveWorkflowId(opName: string): string {
+  return `chant-op-${opName}`;
+}
+
+/**
+ * Resolve a named profile from the chant config.
+ * Falls back to defaultProfile then "local".
+ */
+export function resolveProfile(
+  config: Record<string, unknown>,
+  profileName?: string,
+): WorkerProfile {
+  const temporal = config.temporal as Record<string, unknown> | undefined;
+  if (!temporal?.profiles) {
+    throw new Error(
+      'No temporal.profiles found in chant.config.ts. Add a profile to use `chant run`.',
+    );
+  }
+  const profiles = temporal.profiles as Record<string, WorkerProfile>;
+  const name = profileName ?? (temporal.defaultProfile as string | undefined) ?? "local";
+  const profile = profiles[name];
+  if (!profile) {
+    throw new Error(
+      `Temporal profile "${name}" not found. Available: ${Object.keys(profiles).join(", ")}`,
+    );
+  }
+  return profile;
+}

--- a/packages/core/src/cli/handlers/run-report.ts
+++ b/packages/core/src/cli/handlers/run-report.ts
@@ -1,0 +1,160 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import type { OpConfig } from "../../op/types";
+import type { WorkflowExecutionDescription, WorkflowHistoryRaw, HistoryEvent } from "./run-client";
+
+interface ActivityRecord {
+  name: string;
+  startTime?: Date;
+  endTime?: Date;
+  durationMs?: number;
+  status: "completed" | "failed" | "running";
+  error?: string;
+}
+
+interface PhaseRecord {
+  name: string;
+  activities: ActivityRecord[];
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const mins = Math.floor(ms / 60_000);
+  const secs = Math.round((ms % 60_000) / 1000);
+  return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
+}
+
+function extractPhaseRecords(config: OpConfig, history: WorkflowHistoryRaw): PhaseRecord[] {
+  const events = history.events ?? [];
+
+  // Build map: scheduled event ID → activity name
+  const scheduledActivities = new Map<string, string>();
+  const scheduledTimes = new Map<string, Date>();
+  const completedTimes = new Map<string, Date>();
+  const failedActivities = new Map<string, string>();
+
+  for (const event of events) {
+    if (event.eventType === "ActivityTaskScheduled" && event.activityTaskScheduledEventAttributes) {
+      const attrs = event.activityTaskScheduledEventAttributes;
+      const id = String(attrs.activityId ?? "");
+      const name = attrs.activityType?.name ?? "unknown";
+      scheduledActivities.set(id, name);
+      if (event.eventTime) scheduledTimes.set(id, new Date(event.eventTime));
+    }
+    if (event.eventType === "ActivityTaskCompleted" && event.activityTaskCompletedEventAttributes) {
+      const scheduledId = String(event.activityTaskCompletedEventAttributes.scheduledEventId ?? "");
+      if (event.eventTime) completedTimes.set(scheduledId, new Date(event.eventTime));
+    }
+    if (event.eventType === "ActivityTaskFailed" && event.activityTaskFailedEventAttributes) {
+      const msg = event.activityTaskFailedEventAttributes.failure?.message ?? "unknown error";
+      failedActivities.set(String(events.indexOf(event)), msg);
+    }
+  }
+
+  return config.phases.map((phase) => {
+    const activities: ActivityRecord[] = phase.steps
+      .filter((s) => s.kind === "activity")
+      .map((step) => {
+        if (step.kind !== "activity") return null;
+        const fn = step.fn;
+        // Find this activity by name in the history
+        let record: ActivityRecord | null = null;
+        for (const [id, name] of scheduledActivities) {
+          if (name === fn) {
+            const start = scheduledTimes.get(id);
+            const end = completedTimes.get(id);
+            const durationMs = start && end ? end.getTime() - start.getTime() : undefined;
+            record = {
+              name: fn,
+              startTime: start,
+              endTime: end,
+              durationMs,
+              status: end ? "completed" : "running",
+            };
+          }
+        }
+        return record ?? { name: fn, status: "running" };
+      })
+      .filter((r): r is ActivityRecord => r !== null);
+
+    return { name: phase.name, activities };
+  });
+}
+
+export function generateReport(
+  opName: string,
+  config: OpConfig,
+  description: WorkflowExecutionDescription,
+  history: WorkflowHistoryRaw,
+): string {
+  const lines: string[] = [];
+
+  const status = description.status.name;
+  const startTime = description.startTime;
+  const closeTime = description.closeTime;
+  const durationMs = closeTime ? closeTime.getTime() - startTime.getTime() : undefined;
+
+  lines.push(`# Deployment Report: ${opName}`);
+  lines.push("");
+  lines.push("## Overview");
+  lines.push("");
+  lines.push(`| Field | Value |`);
+  lines.push(`|---|---|`);
+  lines.push(`| Op | ${opName} |`);
+  lines.push(`| Overview | ${config.overview} |`);
+  lines.push(`| Status | **${status}** |`);
+  lines.push(`| Workflow ID | ${description.workflowId} |`);
+  lines.push(`| Run ID | ${description.runId} |`);
+  lines.push(`| Start | ${startTime.toISOString()} |`);
+  if (closeTime) lines.push(`| End | ${closeTime.toISOString()} |`);
+  if (durationMs !== undefined) lines.push(`| Duration | ${formatDuration(durationMs)} |`);
+  lines.push("");
+
+  lines.push("## Timeline");
+  lines.push("");
+  lines.push("| Phase | Activity | Duration | Status |");
+  lines.push("|---|---|---|---|");
+
+  const phases = extractPhaseRecords(config, history);
+  for (const phase of phases) {
+    if (phase.activities.length === 0) {
+      lines.push(`| ${phase.name} | — | — | — |`);
+    }
+    for (const act of phase.activities) {
+      const dur = act.durationMs !== undefined ? formatDuration(act.durationMs) : "—";
+      const statusEmoji = act.status === "completed" ? "✓" : act.status === "failed" ? "✗" : "…";
+      lines.push(`| ${phase.name} | ${act.name} | ${dur} | ${statusEmoji} ${act.status} |`);
+    }
+  }
+  lines.push("");
+
+  // Errors section
+  const failedEvents = (history.events ?? []).filter(
+    (e): e is HistoryEvent & Required<Pick<HistoryEvent, "activityTaskFailedEventAttributes">> =>
+      e.eventType === "ActivityTaskFailed" && !!e.activityTaskFailedEventAttributes,
+  );
+
+  if (failedEvents.length > 0) {
+    lines.push("## Errors");
+    lines.push("");
+    for (const event of failedEvents) {
+      const msg = event.activityTaskFailedEventAttributes?.failure?.message ?? "unknown";
+      lines.push(`- ${msg}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(`---`);
+  lines.push(`*Generated by chant at ${new Date().toISOString()}*`);
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export function writeReport(opName: string, markdown: string): string {
+  const outPath = join("dist", `${opName}-report.md`);
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, markdown, "utf-8");
+  return outPath;
+}

--- a/packages/core/src/cli/handlers/run.ts
+++ b/packages/core/src/cli/handlers/run.ts
@@ -1,0 +1,453 @@
+import { resolve, join } from "node:path";
+import { existsSync } from "node:fs";
+import { createConnection } from "node:net";
+import { spawn as spawnChild, type ChildProcess } from "node:child_process";
+import { loadChantConfig } from "../../config";
+import { discoverOps } from "../../op/discover";
+import { formatError, formatWarning, formatSuccess, formatBold, formatInfo } from "../format";
+import type { CommandContext } from "../registry";
+import {
+  loadTemporalClient,
+  connectionOptions,
+  resolveWorkflowId,
+  resolveProfile,
+  type WorkflowHandleRaw,
+  type WorkflowExecutionDescription,
+  type WorkflowHistoryRaw,
+} from "./run-client";
+import { generateReport, writeReport } from "./run-report";
+
+function kebabToCamel(s: string): string {
+  return s.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+function workflowFnName(opName: string): string {
+  return kebabToCamel(opName) + "Workflow";
+}
+
+async function makeTemporalClient(profileName: string | undefined, projectPath: string) {
+  const { config } = await loadChantConfig(projectPath);
+  const profile = resolveProfile(config as Record<string, unknown>, profileName);
+  const { Connection, Client } = await loadTemporalClient();
+  const connection = await Connection.connect(connectionOptions(profile));
+  const client = new Client({ connection, namespace: profile.namespace });
+  return { client, profile, config };
+}
+
+// ── chant run list ──────────────────────────────────���─────────────────────────
+
+export async function runOpList(ctx: CommandContext): Promise<number> {
+  const { ops, errors } = await discoverOps();
+
+  for (const err of errors) {
+    console.error(formatError({ message: err }));
+  }
+
+  if (ops.size === 0) {
+    console.error(formatWarning({ message: "No Op definitions found (*.op.ts)" }));
+    return 0;
+  }
+
+  console.log(
+    "NAME".padEnd(22) +
+    "PHASES".padEnd(8) +
+    "TASK-QUEUE".padEnd(20) +
+    "DEPENDS".padEnd(20) +
+    "OVERVIEW",
+  );
+
+  let runStatus: Map<string, string> | undefined;
+  try {
+    const projectPath = resolve(".");
+    const { config } = await loadChantConfig(projectPath);
+    const profile = resolveProfile(config as Record<string, unknown>, ctx.args.profile);
+    const { Connection, Client } = await loadTemporalClient();
+    const connection = await Connection.connect(connectionOptions(profile));
+    const client = new Client({ connection, namespace: profile.namespace });
+    runStatus = new Map();
+    for (const [name] of ops) {
+      try {
+        const desc = await client.workflow.getHandle(resolveWorkflowId(name)).describe();
+        runStatus.set(name, desc.status.name);
+      } catch {
+        runStatus.set(name, "—");
+      }
+    }
+  } catch {
+    // Temporal not available — degrade gracefully
+  }
+
+  for (const [name, { config }] of ops) {
+    const phases = String(config.phases.length);
+    const tq = config.taskQueue ?? config.name;
+    const deps = config.depends?.join(",") ?? "—";
+    const overview = config.overview.length > 36
+      ? config.overview.slice(0, 33) + "..."
+      : config.overview;
+    const status = runStatus?.get(name);
+    const statusStr = status ? ` [${status}]` : "";
+
+    console.log(
+      (name + statusStr).padEnd(22) +
+      phases.padEnd(8) +
+      tq.padEnd(20) +
+      deps.padEnd(20) +
+      overview,
+    );
+  }
+
+  return 0;
+}
+
+// ── chant run status <name> ───────────────────────────────────────────────────
+
+export async function runOpStatus(ctx: CommandContext): Promise<number> {
+  const name = ctx.args.extraPositional;
+  if (!name) {
+    console.error(formatError({ message: "Op name is required: chant run status <name>" }));
+    return 1;
+  }
+
+  const projectPath = resolve(".");
+  let client, desc: WorkflowExecutionDescription, history: WorkflowHistoryRaw;
+  try {
+    ({ client } = await makeTemporalClient(ctx.args.profile, projectPath));
+    const handle = client.workflow.getHandle(resolveWorkflowId(name));
+    desc = await handle.describe();
+    history = await handle.fetchHistory();
+  } catch (err) {
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  }
+
+  console.log(formatBold(`Op: ${name}`));
+  console.log(`  Workflow ID : ${desc.workflowId}`);
+  console.log(`  Run ID      : ${desc.runId}`);
+  console.log(`  Status      : ${desc.status.name}`);
+  console.log(`  Task Queue  : ${desc.taskQueue}`);
+  console.log(`  Started     : ${desc.startTime.toISOString()}`);
+  if (desc.closeTime) console.log(`  Closed      : ${desc.closeTime.toISOString()}`);
+
+  const events = history.events ?? [];
+  const completed = events.filter((e) => e.eventType === "ActivityTaskCompleted").length;
+  const scheduled = events.filter((e) => e.eventType === "ActivityTaskScheduled").length;
+  if (scheduled > 0) {
+    console.log(`  Activities  : ${completed}/${scheduled} completed`);
+  }
+
+  return 0;
+}
+
+// ── chant run log <name> ──────────────────────────────────────────────────────
+
+export async function runOpLog(ctx: CommandContext): Promise<number> {
+  const name = ctx.args.extraPositional;
+  if (!name) {
+    console.error(formatError({ message: "Op name is required: chant run log <name>" }));
+    return 1;
+  }
+
+  const projectPath = resolve(".");
+  let client;
+  try {
+    ({ client } = await makeTemporalClient(ctx.args.profile, projectPath));
+  } catch (err) {
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  }
+
+  console.log(
+    "RUN-ID".padEnd(36) +
+    "STATUS".padEnd(16) +
+    "STARTED".padEnd(26) +
+    "CLOSED",
+  );
+
+  try {
+    const fnName = workflowFnName(name);
+    for await (const run of client.workflow.list({ query: `WorkflowType = "${fnName}"` })) {
+      const start = run.startTime.toISOString().slice(0, 19).replace("T", " ");
+      const close = run.closeTime ? run.closeTime.toISOString().slice(0, 19).replace("T", " ") : "—";
+      console.log(
+        run.runId.padEnd(36) +
+        run.status.name.padEnd(16) +
+        start.padEnd(26) +
+        close,
+      );
+    }
+  } catch (err) {
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  }
+
+  return 0;
+}
+
+// ── chant run signal <name> <signal> ─────────────────────────────────────────
+
+export async function runOpSignal(ctx: CommandContext): Promise<number> {
+  const name = ctx.args.extraPositional;
+  const signalName = ctx.args.extraPositional2;
+
+  if (!name || !signalName) {
+    console.error(formatError({ message: "Usage: chant run signal <op-name> <signal-name>" }));
+    return 1;
+  }
+
+  const projectPath = resolve(".");
+  let handle: WorkflowHandleRaw;
+  try {
+    const { client } = await makeTemporalClient(ctx.args.profile, projectPath);
+    handle = client.workflow.getHandle(resolveWorkflowId(name));
+    await handle.signal(signalName);
+  } catch (err) {
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  }
+
+  console.error(formatSuccess(`Signal "${signalName}" sent to Op "${name}"`));
+  return 0;
+}
+
+// ── chant run cancel <name> ───────────────────────────────────────────────────
+
+export async function runOpCancel(ctx: CommandContext): Promise<number> {
+  const name = ctx.args.extraPositional;
+  if (!name) {
+    console.error(formatError({ message: "Op name is required: chant run cancel <name>" }));
+    return 1;
+  }
+
+  if (!ctx.args.force) {
+    console.error(formatWarning({
+      message: `Cancelling "${name}" will stop the active workflow run`,
+      hint: "Use --force to confirm cancellation",
+    }));
+    return 1;
+  }
+
+  const projectPath = resolve(".");
+  let handle: WorkflowHandleRaw;
+  try {
+    const { client } = await makeTemporalClient(ctx.args.profile, projectPath);
+    handle = client.workflow.getHandle(resolveWorkflowId(name));
+    await handle.cancel();
+  } catch (err) {
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  }
+
+  console.error(formatSuccess(`Cancellation requested for Op "${name}"`));
+  return 0;
+}
+
+// ── chant run <name> — main command ───────────────────────────────────────────
+
+const TERMINAL_STATUSES = new Set(["COMPLETED", "FAILED", "CANCELLED", "TERMINATED", "TIMED_OUT"]);
+const POLL_INTERVAL_MS = 3000;
+
+async function waitForTemporalServer(address: string, maxWaitMs = 30_000): Promise<void> {
+  const [host, portStr] = address.split(":");
+  const port = parseInt(portStr ?? "7233", 10);
+  const deadline = Date.now() + maxWaitMs;
+  while (Date.now() < deadline) {
+    try {
+      await new Promise<void>((res, rej) => {
+        const socket = createConnection({ host, port }, () => { socket.destroy(); res(); });
+        socket.on("error", rej);
+        socket.setTimeout(1000, () => { socket.destroy(); rej(new Error("timeout")); });
+      });
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+  }
+  throw new Error(`Temporal server at ${address} did not become ready within ${maxWaitMs / 1000}s`);
+}
+
+function renderProgress(opName: string, history: WorkflowHistoryRaw): void {
+  const events = history.events ?? [];
+  const completed = events.filter((e) => e.eventType === "ActivityTaskCompleted").length;
+  const scheduled = events.filter((e) => e.eventType === "ActivityTaskScheduled").length;
+  process.stderr.write(
+    `\r${formatInfo(`[${opName}]`)} ${completed}/${scheduled} activities completed`,
+  );
+}
+
+export async function runOp(ctx: CommandContext): Promise<number> {
+  const opName = ctx.args.path;
+
+  if (!opName || opName === ".") {
+    console.error(formatError({
+      message: "Op name is required: chant run <name>",
+      hint: "Run `chant run list` to see available Ops",
+    }));
+    return 1;
+  }
+
+  // Discover Ops
+  const { ops, errors } = await discoverOps();
+  for (const err of errors) console.error(formatWarning({ message: err }));
+
+  const discovered = ops.get(opName);
+  if (!discovered) {
+    const names = [...ops.keys()];
+    console.error(formatError({
+      message: `Op "${opName}" not found`,
+      hint: names.length > 0
+        ? `Available: ${names.join(", ")}`
+        : "No *.op.ts files found — create one or run `chant run list`",
+    }));
+    return 1;
+  }
+
+  const { config } = discovered;
+  const projectPath = resolve(".");
+
+  // Load config + profile
+  const { config: chantConfig } = await loadChantConfig(projectPath);
+  let profile;
+  try {
+    profile = resolveProfile(chantConfig as Record<string, unknown>, ctx.args.profile);
+  } catch (err) {
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  }
+
+  // Handle --report flag: just print the last run report
+  if (ctx.args.report) {
+    let client, desc: WorkflowExecutionDescription, history: WorkflowHistoryRaw;
+    try {
+      ({ client } = await makeTemporalClient(ctx.args.profile, projectPath));
+      const handle = client.workflow.getHandle(resolveWorkflowId(opName));
+      desc = await handle.describe();
+      history = await handle.fetchHistory();
+    } catch (err) {
+      console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+      return 1;
+    }
+    const md = generateReport(opName, config, desc, history);
+    process.stdout.write(md);
+    return 0;
+  }
+
+  // Check built worker exists
+  const workerPath = join(projectPath, "dist", "ops", opName, "worker.ts");
+  if (!existsSync(workerPath)) {
+    console.error(formatError({
+      message: `dist/ops/${opName}/worker.ts not found`,
+      hint: "Run `chant build` first to generate the worker",
+    }));
+    return 1;
+  }
+
+  // autoStart: spin up temporal server if needed
+  if (profile.autoStart) {
+    console.error(formatInfo("autoStart: checking Temporal server..."));
+    try {
+      await waitForTemporalServer(profile.address, 2000);
+      console.error(formatInfo("Temporal server already running."));
+    } catch {
+      console.error(formatInfo("Starting temporal server start-dev..."));
+      spawnChild("temporal", ["server", "start-dev"], {
+        cwd: projectPath,
+        stdio: "ignore",
+        detached: true,
+      }).unref();
+      await waitForTemporalServer(profile.address, 30_000);
+      console.error(formatSuccess("Temporal server ready."));
+    }
+  }
+
+  // Load Temporal client
+  let client;
+  try {
+    ({ client } = await makeTemporalClient(ctx.args.profile, projectPath));
+  } catch (err) {
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  }
+
+  // Spawn worker process
+  const profileName = ctx.args.profile ??
+    (((chantConfig as Record<string, unknown>).temporal as Record<string, unknown> | undefined)?.defaultProfile as string | undefined) ??
+    "local";
+
+  console.error(formatInfo(`Spawning worker for Op "${opName}" (profile: ${profileName})...`));
+  const workerProcess: ChildProcess = spawnChild("npx", ["tsx", workerPath], {
+    cwd: projectPath,
+    env: { ...process.env, TEMPORAL_PROFILE: profileName },
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+
+  // Submit workflow
+  const workflowId = resolveWorkflowId(opName);
+  const fnName = workflowFnName(opName);
+  const taskQueue = profile.taskQueue ?? opName;
+
+  let handle: WorkflowHandleRaw;
+  try {
+    handle = await client.workflow.start(fnName, {
+      taskQueue,
+      workflowId,
+      workflowIdConflictPolicy: "FAIL",
+    });
+    console.error(formatSuccess(`Workflow started: ${workflowId}`));
+  } catch (err) {
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  }
+
+  // Poll for progress until terminal state
+  let finalDesc: WorkflowExecutionDescription | undefined;
+  let finalHistory: WorkflowHistoryRaw | undefined;
+
+  try {
+    while (true) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      const desc = await handle.describe();
+      const history = await handle.fetchHistory();
+
+      renderProgress(opName, history);
+
+      if (TERMINAL_STATUSES.has(desc.status.name)) {
+        process.stderr.write("\n");
+        finalDesc = desc;
+        finalHistory = history;
+        break;
+      }
+    }
+  } catch (err) {
+    process.stderr.write("\n");
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  } finally {
+    // Kill worker process (best-effort)
+    try { workerProcess.kill(); } catch { /* ignore */ }
+  }
+
+  if (!finalDesc || !finalHistory) return 1;
+
+  const status = finalDesc.status.name;
+  console.error(status === "COMPLETED"
+    ? formatSuccess(`Op "${opName}" completed successfully.`)
+    : formatError({ message: `Op "${opName}" ended with status: ${status}` }),
+  );
+
+  // Write deployment report
+  const md = generateReport(opName, config, finalDesc, finalHistory);
+  const reportPath = writeReport(opName, md);
+  console.error(formatInfo(`Report written to ${reportPath}`));
+
+  return status === "COMPLETED" ? 0 : 1;
+}
+
+// ── fallback ────────────────────────────────────────────────────────────────���─
+
+export function runOpUnknown(ctx: CommandContext): Promise<number> {
+  console.error(formatError({
+    message: `Unknown run subcommand: ${ctx.args.extraPositional ?? ctx.args.path}`,
+    hint: "Available: chant run <name>, run list, run status, run signal, run cancel, run log",
+  }));
+  return Promise.resolve(1);
+}

--- a/packages/core/src/cli/handlers/spell.ts
+++ b/packages/core/src/cli/handlers/spell.ts
@@ -3,6 +3,7 @@ import { writeFileSync, unlinkSync, readFileSync } from "node:fs";
 import { mkdirSync, existsSync } from "node:fs";
 import { getRuntime } from "../../runtime-adapter";
 import { discoverSpells } from "../../spell/discovery";
+import { discoverOps } from "../../op/discover";
 import { generatePrompt } from "../../spell/prompt";
 import { formatError, formatWarning, formatSuccess, formatBold } from "../format";
 import { loadPlugin } from "../plugins";
@@ -352,32 +353,54 @@ function markTaskDone(source: string, taskNum: number): string {
 }
 
 /**
- * chant graph — show dependency graph
+ * chant graph — show dependency graph for spells and Ops
  */
 export async function runGraph(ctx: CommandContext): Promise<number> {
-  const { spells, errors } = await discoverSpells();
+  const [{ spells, errors: spellErrors }, { ops, errors: opErrors }] = await Promise.all([
+    discoverSpells(),
+    discoverOps(),
+  ]);
 
-  for (const err of errors) {
-    console.error(formatError({ message: err }));
-  }
-
-  if (spells.size === 0) {
-    console.error(formatWarning({ message: "No spells found" }));
-    return 0;
-  }
+  for (const err of spellErrors) console.error(formatError({ message: err }));
+  for (const err of opErrors) console.error(formatError({ message: err }));
 
   let hasEdges = false;
-  for (const [name, spell] of spells) {
-    const deps = spell.definition.depends;
-    if (deps && deps.length > 0) {
-      for (const dep of deps) {
-        console.log(`${dep} → ${name}`);
-        hasEdges = true;
+
+  if (spells.size > 0) {
+    for (const [name, spell] of spells) {
+      const deps = spell.definition.depends;
+      if (deps && deps.length > 0) {
+        for (const dep of deps) {
+          console.log(`${dep} → ${name}`);
+          hasEdges = true;
+        }
       }
     }
   }
 
-  if (!hasEdges) {
+  if (ops.size > 0) {
+    let hasOpEdges = false;
+    for (const [name, { config }] of ops) {
+      const deps = config.depends;
+      if (deps && deps.length > 0) {
+        if (!hasOpEdges) {
+          console.log("\nOps:");
+          hasOpEdges = true;
+        }
+        for (const dep of deps) {
+          console.log(`  ${dep} → ${name}`);
+          hasEdges = true;
+        }
+      }
+    }
+    if (!hasOpEdges && ops.size > 0) {
+      console.log("\nOps: No dependencies");
+    }
+  }
+
+  if (!hasEdges && spells.size === 0 && ops.size === 0) {
+    console.log("No spells or Ops found");
+  } else if (!hasEdges) {
     console.log("No dependencies");
   }
 

--- a/packages/core/src/cli/main.test.ts
+++ b/packages/core/src/cli/main.test.ts
@@ -254,4 +254,68 @@ describe("resolveCommand", () => {
     expect(result!.def.name).toBe("dev generate");
     expect(result!.compound).toBe(true);
   });
+
+  test("resolves run status as compound command", () => {
+    const registry: CommandDef[] = [
+      { name: "run list", handler: noop },
+      { name: "run status", handler: noop },
+      { name: "run signal", handler: noop },
+      { name: "run cancel", handler: noop },
+      { name: "run log", handler: noop },
+      { name: "run", handler: noop },
+    ];
+    const result = resolveCommand(makeArgs({ command: "run", path: "status" }), registry);
+    expect(result!.def.name).toBe("run status");
+    expect(result!.compound).toBe(true);
+  });
+
+  test("resolves run <name> as simple command", () => {
+    const registry: CommandDef[] = [
+      { name: "run list", handler: noop },
+      { name: "run status", handler: noop },
+      { name: "run", handler: noop },
+    ];
+    const result = resolveCommand(makeArgs({ command: "run", path: "alb-deploy" }), registry);
+    expect(result!.def.name).toBe("run");
+    expect(result!.compound).toBe(false);
+  });
+});
+
+describe("parseArgs — run flags", () => {
+  test("parses --profile flag", () => {
+    const result = parseArgs(["run", "alb-deploy", "--profile", "local"]);
+    expect(result.command).toBe("run");
+    expect(result.path).toBe("alb-deploy");
+    expect(result.profile).toBe("local");
+  });
+
+  test("parses -p shorthand for --profile", () => {
+    const result = parseArgs(["run", "alb-deploy", "-p", "cloud"]);
+    expect(result.profile).toBe("cloud");
+  });
+
+  test("parses --report flag", () => {
+    const result = parseArgs(["run", "alb-deploy", "--report"]);
+    expect(result.command).toBe("run");
+    expect(result.path).toBe("alb-deploy");
+    expect(result.report).toBe(true);
+  });
+
+  test("report is undefined when not provided", () => {
+    const result = parseArgs(["run", "alb-deploy"]);
+    expect(result.report).toBe(undefined);
+  });
+
+  test("profile is undefined when not provided", () => {
+    const result = parseArgs(["run", "alb-deploy"]);
+    expect(result.profile).toBe(undefined);
+  });
+
+  test("run signal parses op name and signal into positionals", () => {
+    const result = parseArgs(["run", "signal", "alb-deploy", "gate-dns"]);
+    expect(result.command).toBe("run");
+    expect(result.path).toBe("signal");
+    expect(result.extraPositional).toBe("alb-deploy");
+    expect(result.extraPositional2).toBe("gate-dns");
+  });
 });

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -14,6 +14,7 @@ import { runInit, runInitLexicon } from "./handlers/init";
 import { runList, runImport, runUpdate, runDoctor } from "./handlers/misc";
 import { runStateSnapshot, runStateShow, runStateDiff, runStateLog, runStateUnknown } from "./handlers/state";
 import { runSpellAdd, runSpellRm, runSpellList, runSpellShow, runSpellCast, runSpellDone, runGraph, runSpellUnknown } from "./handlers/spell";
+import { runOp, runOpList, runOpStatus, runOpSignal, runOpCancel, runOpLog } from "./handlers/run";
 
 /**
  * Parse command line arguments
@@ -33,6 +34,8 @@ export function parseArgs(args: string[]): ParsedArgs {
     watch: false,
     verbose: false,
     help: false,
+    profile: undefined,
+    report: undefined,
   };
 
   let i = 0;
@@ -57,6 +60,10 @@ export function parseArgs(args: string[]): ParsedArgs {
       result.watch = true;
     } else if (arg === "--verbose" || arg === "-v") {
       result.verbose = true;
+    } else if (arg === "--profile" || arg === "-p") {
+      result.profile = args[++i];
+    } else if (arg === "--report") {
+      result.report = true;
     } else if (!arg.startsWith("-")) {
       if (!result.command) {
         result.command = arg;
@@ -92,6 +99,14 @@ Commands:
   lint                  Check specifications for issues
   list                  List discovered entities
   import                Import external template into TypeScript
+
+Ops:
+  run <name>            Start an Op workflow (spawns worker + submits to Temporal)
+  run list              List all Ops with current run status
+  run status <name>     Show current workflow run state
+  run signal <name> <signal>  Send a named signal to unblock a gate
+  run cancel <name>     Cancel the active workflow run (requires --force)
+  run log <name>        Show run history for an Op
 
 Spells:
   spell add <name>      Create a new spell
@@ -135,6 +150,8 @@ Options:
   -w, --watch           Watch for changes and rebuild/re-lint (build, lint)
   -v, --verbose         Show stack traces on errors
   -h, --help            Show this help message
+  -p, --profile <name>  Temporal worker profile to use (run command)
+  --report              Print deployment report instead of running (run command)
 
 Examples:
   chant build ./infra/
@@ -193,6 +210,14 @@ const registry: CommandDef[] = [
   { name: "dev publish", requiresPlugins: true, handler: runDevPublish },
   { name: "dev onboard", handler: runDevOnboard },
   { name: "dev check-lexicon", handler: runDevCheckLexicon },
+
+  // Op / run subcommands
+  { name: "run list", handler: runOpList },
+  { name: "run status", handler: runOpStatus },
+  { name: "run signal", handler: runOpSignal },
+  { name: "run cancel", handler: runOpCancel },
+  { name: "run log", handler: runOpLog },
+  { name: "run", handler: runOp },
 
   // Spell subcommands
   { name: "spell add", handler: runSpellAdd },

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -18,6 +18,8 @@ export interface ParsedArgs {
   watch: boolean;
   verbose: boolean;
   help: boolean;
+  profile?: string;
+  report?: boolean;
 }
 
 /**

--- a/packages/core/src/op/discover.test.ts
+++ b/packages/core/src/op/discover.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { discoverOps } from "./discover";
+
+// Mock getRuntime to return git root pointing at the repo root
+vi.mock("../runtime-adapter", () => ({
+  getRuntime: () => ({
+    spawn: async (cmd: string[]) => {
+      if (cmd[0] === "git" && cmd[1] === "rev-parse") {
+        // Return the actual repo root so the test can find the example op file
+        const { execFile } = await import("node:child_process");
+        const { promisify } = await import("node:util");
+        const execFileAsync = promisify(execFile);
+        const { stdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"]);
+        return { stdout: stdout.trim(), stderr: "", exitCode: 0 };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    },
+  }),
+}));
+
+describe("discoverOps", () => {
+  test("discovers alb-deploy.op.ts from examples/", async () => {
+    const { ops, errors } = await discoverOps();
+    expect(errors).toHaveLength(0);
+    expect(ops.has("alb-deploy")).toBe(true);
+  });
+
+  test("discovered Op has correct config shape", async () => {
+    const { ops } = await discoverOps();
+    const op = ops.get("alb-deploy");
+    expect(op).toBeDefined();
+    expect(op!.config.name).toBe("alb-deploy");
+    expect(Array.isArray(op!.config.phases)).toBe(true);
+    expect(op!.config.phases.length).toBeGreaterThan(0);
+    expect(typeof op!.config.overview).toBe("string");
+  });
+
+  test("filePath points to the .op.ts source file", async () => {
+    const { ops } = await discoverOps();
+    const op = ops.get("alb-deploy");
+    expect(op!.filePath).toMatch(/alb-deploy\.op\.ts$/);
+  });
+});

--- a/packages/core/src/op/discover.ts
+++ b/packages/core/src/op/discover.ts
@@ -1,0 +1,89 @@
+import { getRuntime } from "../runtime-adapter";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { OpConfig } from "./types";
+
+export interface DiscoveredOp {
+  config: OpConfig;
+  filePath: string;
+}
+
+export interface OpDiscoveryResult {
+  ops: Map<string, DiscoveredOp>;
+  errors: string[];
+}
+
+async function findGitRoot(cwd?: string): Promise<string> {
+  const rt = getRuntime();
+  const result = await rt.spawn(["git", "rev-parse", "--show-toplevel"], { cwd });
+  if (result.exitCode !== 0) throw new Error("Not in a git repository");
+  return result.stdout.trim();
+}
+
+async function collectOpFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules" && entry.name !== "dist") {
+      files.push(...await collectOpFiles(fullPath));
+    } else if (
+      entry.isFile() &&
+      entry.name.endsWith(".op.ts") &&
+      !entry.name.endsWith(".test.ts") &&
+      !entry.name.endsWith(".spec.ts")
+    ) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+/**
+ * Discover all Op definitions from *.op.ts files under the git root.
+ */
+export async function discoverOps(opts?: { cwd?: string }): Promise<OpDiscoveryResult> {
+  const errors: string[] = [];
+  const ops = new Map<string, DiscoveredOp>();
+
+  const gitRoot = await findGitRoot(opts?.cwd);
+  const files = await collectOpFiles(gitRoot);
+
+  const nameToFile = new Map<string, string>();
+
+  for (const filePath of files) {
+    try {
+      const mod = await import(filePath);
+      const entity = mod.default;
+
+      if (!entity || typeof entity !== "object") {
+        errors.push(`${filePath}: default export is not an object`);
+        continue;
+      }
+
+      const config = entity.props as OpConfig | undefined;
+
+      if (!config || typeof config.name !== "string" || !Array.isArray(config.phases)) {
+        errors.push(`${filePath}: default export is not a valid Op (missing name or phases)`);
+        continue;
+      }
+
+      if (nameToFile.has(config.name)) {
+        errors.push(`Duplicate Op name "${config.name}" in ${filePath} and ${nameToFile.get(config.name)}`);
+        continue;
+      }
+
+      nameToFile.set(config.name, filePath);
+      ops.set(config.name, { config, filePath });
+    } catch (err) {
+      errors.push(`${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return { ops, errors };
+}

--- a/packages/core/src/op/index.ts
+++ b/packages/core/src/op/index.ts
@@ -2,3 +2,5 @@ export { Op, phase, activity, gate, build, kubectlApply, helmInstall, waitForSta
          gitlabPipeline, stateSnapshot, shell, teardown } from "./builders";
 export { OpResource } from "./resource";
 export type { OpConfig, PhaseDefinition, StepDefinition, ActivityStep, GateStep, RetryPolicy } from "./types";
+export { discoverOps } from "./discover";
+export type { DiscoveredOp, OpDiscoveryResult } from "./discover";


### PR DESCRIPTION
## Summary

- Adds `chant run <name>` — spawns the built worker, submits the Temporal workflow, polls phase progress, writes a deployment report on completion
- Adds `chant run list / status / signal / cancel / log` subcommands
- Extends `chant graph` to show Op dependency edges alongside spell edges
- Adds `--profile` / `--report` flags to `ParsedArgs`

## New files

| File | Purpose |
|---|---|
| `op/discover.ts` | `discoverOps()` — scans `*.op.ts` from git root, extracts `OpConfig` |
| `handlers/run-client.ts` | `WorkerProfile`, `loadTemporalClient()`, `resolveWorkflowId()`, `resolveProfile()` |
| `handlers/run-report.ts` | Markdown report generator from workflow event history |
| `handlers/run.ts` | All `chant run *` handlers |
| `op/discover.test.ts` | Op discovery tests against `alb-deploy.op.ts` fixture |

## Architecture notes

- `@temporalio/client` is dynamically imported from the user's project (not a core dep); fails gracefully with install hint
- Workflow ID is deterministic: `chant-op-<name>` — no local state needed for status/signal/cancel
- Worker process uses `child_process.spawn` with `TEMPORAL_PROFILE` env var; `autoStart` profiles spin up `temporal server start-dev`
- No cross-package type imports from `@intentius/chant-lexicon-temporal` in core (avoids core→temporal→core tsc cycle)

## Test plan

- [ ] `npx tsc --noEmit -p packages/core/tsconfig.json` — clean
- [ ] `npx vitest run` — 5525 tests, 469 files, all passing
- [ ] `chant run list` in a project with `*.op.ts` files
- [ ] `chant run alb-deploy --profile local` (requires Temporal server + built worker)

Closes #8.