### PR TITLE
fix(azure): pin schema fetch to known-good SHA (#23)

### DIFF
--- a/lexicons/azure/src/spec/fetch.ts
+++ b/lexicons/azure/src/spec/fetch.ts
@@ -69,10 +69,17 @@ export interface ArmSchemaDefinition {
   items?: ArmSchemaProperty;
 }
 
+// Pinned to a known-good SHA from before upstream's schema layout changed.
+// Tracking issue: https://github.com/INTENTIUS/chant/issues/23
+// Once the parser is updated to handle the new layout, this can move back
+// to refs/heads/main.tar.gz.
+const SCHEMA_SHA = "5bbb1020775bf57330b4e2c3b0138435e005554f";
 const TARBALL_URL =
-  "https://github.com/Azure/azure-resource-manager-schemas/archive/refs/heads/main.tar.gz";
+  `https://github.com/Azure/azure-resource-manager-schemas/archive/${SCHEMA_SHA}.tar.gz`;
 const CACHE_DIR = join(homedir(), ".chant");
-const CACHE_FILE = join(CACHE_DIR, "azure-resource-manager-schemas.tar.gz");
+// Include the SHA in the cache filename so changing the pin invalidates
+// the cache automatically (otherwise a stale tarball would be served until TTL).
+const CACHE_FILE = join(CACHE_DIR, `azure-resource-manager-schemas-${SCHEMA_SHA.slice(0, 12)}.tar.gz`);
 
 /** Paths to skip (common-types, non-provider files). */
 function isProviderSchema(path: string): boolean {


### PR DESCRIPTION
## Summary

CI on \`main\` has been red since ~2026-04-19 because upstream \`Azure/azure-resource-manager-schemas\` reorganized its schema layout and \`lexicons/azure/src/spec/parse.ts\` doesn't yet handle the new shape. Symptom: \`required-names\` validation fails on \`IpConfiguration\`, \`SecurityRule\`, \`SubnetProperties\`. Root cause and a real-fix proposal are tracked in #23.

This PR is a temporary mitigation only: pin the upstream tarball to SHA \`5bbb1020775b\` (2026-04-16, last commit before the green CI window closed) and bake the SHA into the cache filename so future pin changes invalidate cache automatically.

## Verification

\`\`\`
cd lexicons/azure
rm -f ~/.chant/azure-resource-manager-schemas*.tar.gz
npm run generate    # → 1970 resources, 308287 property types (down from a bloated 2035 / 311817)
npm run validate    # → all 5 checks pass
\`\`\`

Azure parser/validate tests (15 tests) pass.

## Follow-ups

- #23 — rework parser for the new upstream schema layout, then revert this pin.

## Test plan

- [ ] CI: \`validate\` step passes the \`required-names\` check.
- [ ] CI: \`test\` step's \`Generate lexicon artifacts\` runs to completion.
- [ ] After merging this, rebase #22 on the new main and re-check that PR's CI.