### PR TITLE
fix(azure): track upstream definition renames; remove pin (#23)

### DIFF
--- a/lexicons/azure/src/codegen/naming.ts
+++ b/lexicons/azure/src/codegen/naming.ts
@@ -82,7 +82,7 @@ const priorityPropertyAliases: Record<string, Record<string, string>> = {
   "Microsoft.Compute/virtualMachines": {
     HardwareProfile: "HardwareProfile",
     StorageProfile: "StorageProfile",
-    OsProfile: "OsProfile",
+    OSProfile: "OsProfile",
     NetworkProfile: "NetworkProfile",
     OSDisk: "OsDisk",
     ImageReference: "ImageReference",
@@ -91,13 +91,13 @@ const priorityPropertyAliases: Record<string, Record<string, string>> = {
     VirtualMachineScaleSetIdentity: "Identity",
   },
   "Microsoft.Network/networkSecurityGroups": {
-    SecurityRule: "SecurityRule",
+    CommonSecurityRule: "SecurityRule",
   },
   "Microsoft.Network/virtualNetworks_subnets": {
-    SubnetPropertiesFormat: "SubnetProperties",
+    CommonSubnetPropertiesFormat: "SubnetProperties",
   },
   "Microsoft.Network/networkInterfaces": {
-    NetworkInterfaceIPConfiguration: "IpConfiguration",
+    CommonNetworkInterfaceIPConfiguration: "IpConfiguration",
   },
   "Microsoft.Sql/servers_databases": {
     Sku: "SqlSku",

--- a/lexicons/azure/src/spec/fetch.ts
+++ b/lexicons/azure/src/spec/fetch.ts
@@ -69,17 +69,10 @@ export interface ArmSchemaDefinition {
   items?: ArmSchemaProperty;
 }
 
-// Pinned to a known-good SHA from before upstream's schema layout changed.
-// Tracking issue: https://github.com/INTENTIUS/chant/issues/23
-// Once the parser is updated to handle the new layout, this can move back
-// to refs/heads/main.tar.gz.
-const SCHEMA_SHA = "5bbb1020775bf57330b4e2c3b0138435e005554f";
 const TARBALL_URL =
-  `https://github.com/Azure/azure-resource-manager-schemas/archive/${SCHEMA_SHA}.tar.gz`;
+  "https://github.com/Azure/azure-resource-manager-schemas/archive/refs/heads/main.tar.gz";
 const CACHE_DIR = join(homedir(), ".chant");
-// Include the SHA in the cache filename so changing the pin invalidates
-// the cache automatically (otherwise a stale tarball would be served until TTL).
-const CACHE_FILE = join(CACHE_DIR, `azure-resource-manager-schemas-${SCHEMA_SHA.slice(0, 12)}.tar.gz`);
+const CACHE_FILE = join(CACHE_DIR, "azure-resource-manager-schemas.tar.gz");
 
 /** Paths to skip (common-types, non-provider files). */
 function isProviderSchema(path: string): boolean {

--- a/lexicons/azure/src/validate.test.ts
+++ b/lexicons/azure/src/validate.test.ts
@@ -22,10 +22,15 @@ describe("validate", () => {
   test.skipIf(!hasGenerated)("validate succeeds with generated artifacts", async () => {
     const { validate } = await import("./validate");
     const result = await validate();
-    // Should return a ValidateResult with checks array
     expect(result).toBeDefined();
     expect(result.checks).toBeDefined();
     expect(Array.isArray(result.checks)).toBe(true);
+
+    // Every check must pass. If any fails, fail the test with a descriptive
+    // message so future upstream schema renames are caught at test time
+    // rather than only at CI generate-and-validate time.
+    const failures = result.checks.filter((c) => !c.ok);
+    expect(failures, `validate checks failed:\n${failures.map((f) => `  ${f.name}: ${f.error ?? "(no message)"}`).join("\n")}`).toEqual([]);
   }, 60_000);
 
   test("handles missing generated files", async () => {


### PR DESCRIPTION
## Summary

Closes #23. The Azure validation failure that's been red on \`main\` since ~2026-04-19 turns out to be simpler than the issue speculated: upstream renamed four definitions, breaking the priority alias lookup keys. There's no parser bug — \`parse.ts\` is unchanged.

| Provider | Old upstream defName | New upstream defName |
|---|---|---|
| Microsoft.Network.NRP | \`NetworkInterfaceIPConfiguration\` | \`CommonNetworkInterfaceIPConfiguration\` |
| Microsoft.Network.NRP | \`SubnetPropertiesFormat\` | \`CommonSubnetPropertiesFormat\` |
| Microsoft.Network.NRP | \`SecurityRule\` | \`CommonSecurityRule\` |
| Microsoft.Compute | \`OsProfile\` | \`OSProfile\` (case change) |

User-facing alias names (\`IpConfiguration\`, \`SubnetProperties\`, \`SecurityRule\`, \`OsProfile\`) are unchanged, so no consumer break.

## Companion changes

- **Revert the schema-fetch pin** introduced in PR #24 — now that the lexicon tracks the new defNames, we go back to \`refs/heads/main.tar.gz\` and benefit from upstream's ongoing schema updates.
- **Strengthen the validate test**: \`validate succeeds with generated artifacts\` now asserts every check passes (not just that the function returned a \`ValidateResult\`). Future upstream renames now trip a fast unit test instead of only the CI generate-and-validate step. Failure messages list which checks failed and why.

## Verification

\`\`\`
cd lexicons/azure
rm -f ~/.chant/azure-resource-manager-schemas*.tar.gz
npm run generate     # → 2035 resources, 311817 property types
npm run validate     # → 5/5 checks pass
\`\`\`

Full Azure test suite: 372/372 pass (\`npx vitest run lexicons/azure/src/\`), including the strengthened \`validate\` test.

## Investigation notes

I initially diagnosed this as a parser layout regression (issue #23 body). When I diffed \`Microsoft.Network.NRP.json\` at \`2025-05-01\` between the pinned SHA \`5bbb1020775b\` and current upstream main, the file had the same top-level shape (\`resourceDefinitions\`, \`definitions\`) and the same counts (111 resources, 519 definitions) — but specific definition keys were renamed:

\`\`\`
< AddressSpace
< ApplicationGatewayBackendAddress
< BackendAddressPool
< NetworkInterfaceIPConfiguration
---
> CommonAddressSpace
> CommonApplicationGatewayBackendAddress
> CommonBackendAddressPool
> CommonNetworkInterfaceIPConfiguration
\`\`\`

Many more defs got the \`Common\` prefix; we only need the four that participate in our priority alias map. The others are still surfaced as long namespaced types (e.g. \`networkInterfaces_CommonAddressSpace\`); they just don't have a friendly bare alias.

## Test plan

- [ ] CI: \`validate\` step passes the \`required-names\` check.
- [ ] CI: \`Generate lexicon artifacts\` runs to completion against current upstream main.
- [ ] After merge, \`main\` CI is green again.