### PR TITLE
feat(state): chant state diff --live drift detection (#26)

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -8,13 +8,13 @@ description: Capture and compare deployed infrastructure state
 ```
 chant state snapshot <env> [lexicon]
 chant state show <env>
-chant state diff <env>
+chant state diff <env> [--live]
 chant state log [env]
 ```
 
 ## Description
 
-`chant state` captures point-in-time snapshots of deployed infrastructure by querying the cloud provider API and saving the result to a git orphan branch. Snapshots enable drift detection — comparing what's currently built against what was last deployed.
+`chant state` captures point-in-time snapshots of deployed infrastructure by querying the cloud provider API and saving the result to a git orphan branch. Snapshots enable drift detection — comparing what's currently built against what was last deployed, and (with `--live`) against what's actually in the cloud right now.
 
 The environment name (e.g. `dev`, `staging`, `prod`) must be declared in `chant.config.ts` under `environments`.
 
@@ -39,11 +39,36 @@ chant state show dev
 
 ### `state diff <env>`
 
-Build the current project and compare the output against the last snapshot for that environment. Reports added, removed, and modified resources.
+Two modes, depending on whether `--live` is set.
+
+**Default (digest mode).** Build the current project, fingerprint the resource declarations, and compare against the digest stored in the last snapshot. Fast, offline, and useful as a fast-feedback check inside CI — but only catches changes you've made in source. Ignores the cloud entirely.
 
 ```bash
 chant state diff dev
 ```
+
+Reports added, removed, changed, and unchanged resources at the declaration level.
+
+**`--live` (drift mode).** Query the cloud provider API right now via each lexicon's `describeResources()` plugin method, then compare the live result against both the previous snapshot and the current build. This is the path that actually catches external mutations (someone scaled a node pool by hand, deleted a bucket, etc.).
+
+```bash
+chant state diff prod --live
+```
+
+Output is grouped into six categories per lexicon:
+
+| Category | Meaning |
+|---|---|
+| **missing** | Declared in source, but not present in the cloud right now |
+| **orphan** | Present in the cloud, but not declared in source |
+| **disappeared** | In the previous snapshot, but gone now |
+| **newly observed** | Declared and observed now, but not in any prior snapshot |
+| **drifted** | Observed in both snapshots; status, physical ID, or attributes changed |
+| **unchanged** | Observed in both snapshots; metadata identical |
+
+Drifted entries include attribute-level deltas (`status`, `physicalId`, `lastUpdated`, and each `attributes.*` key).
+
+Lexicons that don't yet implement `describeResources()` are warn-skipped — `--live` doesn't fail the whole command for them. To see which lexicons are covered, the AWS lexicon supports it today; coverage of others is tracked in [issue #27](https://github.com/INTENTIUS/chant/issues/27).
 
 ### `state log [env]`
 

--- a/packages/core/src/cli/handlers/state.test.ts
+++ b/packages/core/src/cli/handlers/state.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { createMockPlugin, staticDescribeResources } from "@intentius/chant-test-utils";
+import type { LexiconPlugin, ResourceMetadata } from "../../lexicon";
+import type { BuildResult } from "../../build";
+import type { ParsedArgs } from "../registry";
+
+const buildMock = vi.fn();
+const fetchStateMock = vi.fn();
+const readSnapshotMock = vi.fn();
+
+vi.mock("../../build", () => ({ build: (...args: unknown[]) => buildMock(...args) }));
+vi.mock("../../state/git", () => ({
+  fetchState: () => fetchStateMock(),
+  readSnapshot: (...args: unknown[]) => readSnapshotMock(...args),
+  readEnvironmentSnapshots: vi.fn(),
+  listSnapshots: vi.fn(),
+}));
+
+const { runStateDiff } = await import("./state");
+
+function makeArgs(overrides: Partial<ParsedArgs>): ParsedArgs {
+  return {
+    command: "state",
+    path: "diff",
+    format: "",
+    fix: false,
+    watch: false,
+    verbose: false,
+    help: false,
+    live: false,
+    ...overrides,
+  };
+}
+
+function makeBuildResult(entitiesByLexicon: Record<string, string[]>): BuildResult {
+  const entities = new Map();
+  for (const [lexicon, names] of Object.entries(entitiesByLexicon)) {
+    for (const name of names) {
+      entities.set(name, { lexicon, entityType: `${lexicon}::Mock`, props: {} });
+    }
+  }
+  return {
+    outputs: new Map(Object.keys(entitiesByLexicon).map((l) => [l, "{}"])),
+    entities,
+    dependencies: new Map(),
+    errors: [],
+    warnings: [],
+    manifest: {
+      lexicons: Object.keys(entitiesByLexicon),
+      outputs: {},
+      deployOrder: Object.keys(entitiesByLexicon),
+    },
+    sourceFileCount: 1,
+  } as unknown as BuildResult;
+}
+
+const meta = (overrides: Partial<ResourceMetadata> = {}): ResourceMetadata => ({
+  type: "AWS::S3::Bucket",
+  status: "CREATE_COMPLETE",
+  physicalId: "bucket-1",
+  ...overrides,
+});
+
+describe("runStateDiff --live", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutBuf: string[];
+  let stderrBuf: string[];
+
+  beforeEach(() => {
+    stdoutBuf = [];
+    stderrBuf = [];
+    stdoutSpy = vi.spyOn(console, "log").mockImplementation((s: string) => { stdoutBuf.push(s); });
+    stderrSpy = vi.spyOn(console, "error").mockImplementation((s: string) => { stderrBuf.push(s); });
+    buildMock.mockReset();
+    fetchStateMock.mockReset();
+    readSnapshotMock.mockReset();
+  });
+
+  test("surfaces drift between previous snapshot and live state", async () => {
+    buildMock.mockResolvedValue(makeBuildResult({ aws: ["bucket"] }));
+    fetchStateMock.mockResolvedValue(undefined);
+    readSnapshotMock.mockResolvedValue(JSON.stringify({
+      lexicon: "aws",
+      environment: "prod",
+      commit: "abc",
+      timestamp: "2026-04-01T00:00:00Z",
+      resources: { bucket: meta({ status: "CREATE_COMPLETE" }) },
+    }));
+
+    const plugins: LexiconPlugin[] = [
+      createMockPlugin({
+        name: "aws",
+        describeResources: staticDescribeResources({
+          bucket: meta({ status: "UPDATE_COMPLETE" }),
+        }),
+      }),
+    ];
+
+    const ctx = {
+      args: makeArgs({ command: "state", path: "diff", extraPositional: "prod", live: true }),
+      plugins,
+      serializers: plugins.map((p) => p.serializer),
+    };
+
+    const exit = await runStateDiff(ctx);
+
+    expect(exit).toBe(0);
+    const output = stdoutBuf.join("\n");
+    expect(output).toContain("DRIFTED");
+    expect(output).toContain("bucket");
+    expect(output).toContain("status:");
+    expect(output).toContain("CREATE_COMPLETE");
+    expect(output).toContain("UPDATE_COMPLETE");
+  });
+
+  test("warns and skips lexicons without describeResources", async () => {
+    buildMock.mockResolvedValue(makeBuildResult({ k8s: ["pod"] }));
+    fetchStateMock.mockResolvedValue(undefined);
+    readSnapshotMock.mockResolvedValue(null);
+
+    const plugins: LexiconPlugin[] = [
+      createMockPlugin({ name: "k8s" }),
+    ];
+
+    const ctx = {
+      args: makeArgs({ command: "state", path: "diff", extraPositional: "prod", live: true }),
+      plugins,
+      serializers: plugins.map((p) => p.serializer),
+    };
+
+    const exit = await runStateDiff(ctx);
+
+    expect(exit).toBe(1);
+    const stderr = stderrBuf.join("\n");
+    expect(stderr).toContain("k8s");
+    expect(stderr).toContain("does not implement describeResources");
+  });
+
+  test("legacy digest mode still works without --live", async () => {
+    buildMock.mockResolvedValue(makeBuildResult({ aws: ["bucket"] }));
+    fetchStateMock.mockResolvedValue(undefined);
+    readSnapshotMock.mockResolvedValue(null);
+
+    const plugins: LexiconPlugin[] = [createMockPlugin({ name: "aws" })];
+
+    const ctx = {
+      args: makeArgs({ command: "state", path: "diff", extraPositional: "prod", live: false }),
+      plugins,
+      serializers: plugins.map((p) => p.serializer),
+    };
+
+    const exit = await runStateDiff(ctx);
+
+    expect(exit).toBe(0);
+    const output = stdoutBuf.join("\n");
+    expect(output).toContain("aws");
+    expect(output).toContain("bucket");
+    expect(output).toContain("added");
+  });
+});

--- a/packages/core/src/cli/handlers/state.ts
+++ b/packages/core/src/cli/handlers/state.ts
@@ -3,10 +3,14 @@ import { build } from "../../build";
 import { takeSnapshot } from "../../state/snapshot";
 import { readSnapshot, readEnvironmentSnapshots, listSnapshots, fetchState } from "../../state/git";
 import { computeBuildDigest, diffDigests } from "../../state/digest";
+import { diffLive, type LiveDiffResult } from "../../state/live-diff";
 import { loadChantConfig } from "../../config";
 import { formatError, formatWarning, formatSuccess, formatBold } from "../format";
 import type { CommandContext } from "../registry";
 import type { StateSnapshot } from "../../state/types";
+import type { SerializerResult } from "../../serializer";
+import type { LexiconPlugin, ResourceMetadata } from "../../lexicon";
+import type { BuildResult } from "../../build";
 
 /**
  * chant state snapshot <environment> [lexicon]
@@ -132,15 +136,13 @@ export async function runStateDiff(ctx: CommandContext): Promise<number> {
     ? plugins.filter((p) => p.name === lexiconFilter).map((p) => p.serializer)
     : serializers;
 
-  // Build to get current digest
+  // Build to get current state
   const projectPath = resolve(".");
   const buildResult = await build(projectPath, targetSerializers);
   if (buildResult.errors.length > 0) {
     console.error(formatError({ message: "Build failed — fix errors before diffing" }));
     return 1;
   }
-
-  const currentDigest = computeBuildDigest(buildResult);
 
   // Fetch and read previous snapshot
   await fetchState();
@@ -149,8 +151,24 @@ export async function runStateDiff(ctx: CommandContext): Promise<number> {
     ? [lexiconFilter]
     : Array.from(buildResult.manifest.lexicons);
 
-  for (const lexicon of lexicons) {
-    const content = await readSnapshot(environment, lexicon);
+  if (args.live) {
+    return runStateDiffLive({ environment, lexicons, plugins, buildResult });
+  }
+
+  return runStateDiffDigest({ environment, lexicons, buildResult });
+}
+
+interface DigestDiffArgs {
+  environment: string;
+  lexicons: string[];
+  buildResult: BuildResult;
+}
+
+async function runStateDiffDigest(args: DigestDiffArgs): Promise<number> {
+  const currentDigest = computeBuildDigest(args.buildResult);
+
+  for (const lexicon of args.lexicons) {
+    const content = await readSnapshot(args.environment, lexicon);
     let previousDigest = undefined;
     if (content) {
       const snapshot: StateSnapshot = JSON.parse(content);
@@ -178,6 +196,132 @@ export async function runStateDiff(ctx: CommandContext): Promise<number> {
   }
 
   return 0;
+}
+
+interface LiveDiffArgs {
+  environment: string;
+  lexicons: string[];
+  plugins: LexiconPlugin[];
+  buildResult: BuildResult;
+}
+
+async function runStateDiffLive(args: LiveDiffArgs): Promise<number> {
+  let totalDrift = 0;
+  let totalLexiconsChecked = 0;
+
+  for (const lexiconName of args.lexicons) {
+    const plugin = args.plugins.find((p) => p.name === lexiconName);
+    if (!plugin) continue;
+
+    if (!plugin.describeResources) {
+      console.error(formatWarning({
+        message: `${lexiconName}: lexicon does not implement describeResources — skipping (use without --live for digest diff)`,
+      }));
+      continue;
+    }
+
+    // Resources declared in this lexicon's slice of the build
+    const declared = new Set<string>();
+    for (const [name, entity] of args.buildResult.entities) {
+      if (entity.lexicon === lexiconName) {
+        declared.add(name);
+      }
+    }
+
+    const rawOutput = args.buildResult.outputs.get(lexiconName);
+    const buildOutput =
+      rawOutput === undefined
+        ? ""
+        : typeof rawOutput === "string"
+          ? rawOutput
+          : (rawOutput as SerializerResult).primary;
+
+    let observedNow: Record<string, ResourceMetadata>;
+    try {
+      observedNow = await plugin.describeResources({
+        environment: args.environment,
+        buildOutput,
+        entityNames: Array.from(declared),
+      });
+    } catch (err) {
+      console.error(formatError({
+        message: `${lexiconName}: describeResources failed — ${err instanceof Error ? err.message : String(err)}`,
+      }));
+      continue;
+    }
+
+    let observedThen: Record<string, ResourceMetadata> | undefined;
+    const content = await readSnapshot(args.environment, lexiconName);
+    if (content) {
+      const snapshot: StateSnapshot = JSON.parse(content);
+      observedThen = snapshot.resources;
+    }
+
+    const diff = diffLive({ declared, observedNow, observedThen });
+    totalLexiconsChecked++;
+    totalDrift += diff.driftedSinceSnapshot.length + diff.missing.length + diff.orphan.length + diff.disappeared.length;
+
+    renderLiveDiff(lexiconName, args.environment, diff);
+  }
+
+  if (totalLexiconsChecked === 0) {
+    console.error(formatWarning({
+      message: "No lexicons implement describeResources — nothing to diff in --live mode",
+    }));
+    return 1;
+  }
+
+  if (totalDrift === 0) {
+    console.error(formatSuccess(`No drift detected across ${totalLexiconsChecked} lexicon(s)`));
+  }
+
+  return 0;
+}
+
+function renderLiveDiff(lexiconName: string, environment: string, diff: LiveDiffResult): void {
+  const counts =
+    `${diff.missing.length} missing, ${diff.orphan.length} orphan, ` +
+    `${diff.disappeared.length} disappeared, ${diff.newlyObserved.length} newly observed, ` +
+    `${diff.driftedSinceSnapshot.length} drifted, ${diff.unchanged.length} unchanged`;
+
+  console.log(`\n${formatBold(lexiconName)} — environment: ${environment}`);
+  console.log(counts);
+  console.log("-".repeat(80));
+
+  if (diff.missing.length > 0) {
+    console.log(formatBold("\nMISSING (declared, not in cloud):"));
+    for (const name of diff.missing) console.log(`  - ${name}`);
+  }
+  if (diff.orphan.length > 0) {
+    console.log(formatBold("\nORPHAN (in cloud, not declared):"));
+    for (const name of diff.orphan) console.log(`  - ${name}`);
+  }
+  if (diff.disappeared.length > 0) {
+    console.log(formatBold("\nDISAPPEARED (in last snapshot, gone now):"));
+    for (const name of diff.disappeared) console.log(`  - ${name}`);
+  }
+  if (diff.newlyObserved.length > 0) {
+    console.log(formatBold("\nNEWLY OBSERVED (declared, observed, no prior snapshot):"));
+    for (const name of diff.newlyObserved) console.log(`  - ${name}`);
+  }
+  if (diff.driftedSinceSnapshot.length > 0) {
+    console.log(formatBold("\nDRIFTED (changed since last snapshot):"));
+    for (const drift of diff.driftedSinceSnapshot) {
+      console.log(`  - ${drift.name} (${drift.type})`);
+      for (const change of drift.changes) {
+        const oldStr = formatValue(change.oldValue);
+        const newStr = formatValue(change.newValue);
+        console.log(`      ${change.path}: ${oldStr} → ${newStr}`);
+      }
+    }
+  }
+}
+
+function formatValue(v: unknown): string {
+  if (v === undefined) return "<unset>";
+  if (typeof v === "string") return v.length > 60 ? v.slice(0, 57) + "..." : v;
+  const json = JSON.stringify(v);
+  return json.length > 60 ? json.slice(0, 57) + "..." : json;
 }
 
 /**

--- a/packages/core/src/cli/main.test.ts
+++ b/packages/core/src/cli/main.test.ts
@@ -198,6 +198,7 @@ describe("resolveCommand", () => {
       watch: false,
       verbose: false,
       help: false,
+      live: false,
       ...overrides,
     };
   }

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -36,6 +36,7 @@ export function parseArgs(args: string[]): ParsedArgs {
     help: false,
     profile: undefined,
     report: undefined,
+    live: false,
   };
 
   let i = 0;
@@ -64,6 +65,8 @@ export function parseArgs(args: string[]): ParsedArgs {
       result.profile = args[++i];
     } else if (arg === "--report") {
       result.report = true;
+    } else if (arg === "--live") {
+      result.live = true;
     } else if (!arg.startsWith("-")) {
       if (!result.command) {
         result.command = arg;
@@ -114,6 +117,7 @@ State:
   state snapshot <env>  Query API, save metadata to orphan branch
   state show <env>      Show latest state snapshot
   state diff <env>      Compare current build against last snapshot
+                        --live: query cloud now and detect drift
   state log [env]       History of state snapshots
 
 Lexicon development:

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -20,6 +20,7 @@ export interface ParsedArgs {
   help: boolean;
   profile?: string;
   report?: boolean;
+  live: boolean;
 }
 
 /**

--- a/packages/core/src/state/live-diff.test.ts
+++ b/packages/core/src/state/live-diff.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect } from "vitest";
+import { diffLive } from "./live-diff";
+import type { ResourceMetadata } from "../lexicon";
+
+const meta = (overrides: Partial<ResourceMetadata> = {}): ResourceMetadata => ({
+  type: "AWS::S3::Bucket",
+  status: "CREATE_COMPLETE",
+  physicalId: "bucket-1",
+  ...overrides,
+});
+
+describe("diffLive", () => {
+  test("empty inputs produce empty result", () => {
+    const result = diffLive({
+      declared: new Set(),
+      observedNow: {},
+      observedThen: undefined,
+    });
+    expect(result).toEqual({
+      missing: [],
+      orphan: [],
+      disappeared: [],
+      newlyObserved: [],
+      driftedSinceSnapshot: [],
+      unchanged: [],
+    });
+  });
+
+  test("declared but not observed → missing", () => {
+    const result = diffLive({
+      declared: new Set(["bucket"]),
+      observedNow: {},
+      observedThen: undefined,
+    });
+    expect(result.missing).toEqual(["bucket"]);
+  });
+
+  test("observed but not declared → orphan", () => {
+    const result = diffLive({
+      declared: new Set(),
+      observedNow: { abandoned: meta() },
+      observedThen: undefined,
+    });
+    expect(result.orphan).toEqual(["abandoned"]);
+  });
+
+  test("in previous snapshot but not observed now → disappeared", () => {
+    const result = diffLive({
+      declared: new Set(["bucket"]),
+      observedNow: {},
+      observedThen: { bucket: meta() },
+    });
+    expect(result.missing).toEqual(["bucket"]);
+    expect(result.disappeared).toEqual(["bucket"]);
+  });
+
+  test("observed for the first time (declared, no previous snapshot) → newlyObserved", () => {
+    const result = diffLive({
+      declared: new Set(["bucket"]),
+      observedNow: { bucket: meta() },
+      observedThen: {},
+    });
+    expect(result.newlyObserved).toEqual(["bucket"]);
+    expect(result.unchanged).toEqual([]);
+    expect(result.driftedSinceSnapshot).toEqual([]);
+  });
+
+  test("attribute changed between snapshots → driftedSinceSnapshot with attribute path", () => {
+    const result = diffLive({
+      declared: new Set(["bucket"]),
+      observedNow: { bucket: meta({ status: "UPDATE_COMPLETE", attributes: { tags: { env: "prod" } } }) },
+      observedThen: { bucket: meta({ status: "CREATE_COMPLETE", attributes: { tags: { env: "stage" } } }) },
+    });
+    expect(result.driftedSinceSnapshot).toHaveLength(1);
+    const drift = result.driftedSinceSnapshot[0];
+    expect(drift.name).toBe("bucket");
+    expect(drift.type).toBe("AWS::S3::Bucket");
+    const paths = drift.changes.map((c) => c.path).sort();
+    expect(paths).toEqual(["attributes.tags", "status"]);
+  });
+
+  test("identical metadata between snapshots → unchanged", () => {
+    const sameMeta = meta({ attributes: { tags: { env: "prod" } } });
+    const result = diffLive({
+      declared: new Set(["bucket"]),
+      observedNow: { bucket: sameMeta },
+      observedThen: { bucket: sameMeta },
+    });
+    expect(result.unchanged).toEqual(["bucket"]);
+    expect(result.driftedSinceSnapshot).toEqual([]);
+  });
+
+  test("mixed: counts add up across all six categories", () => {
+    const result = diffLive({
+      declared: new Set(["a", "b", "c", "d"]),
+      observedNow: {
+        b: meta(),                                // unchanged
+        c: meta({ status: "UPDATE_COMPLETE" }),   // drift
+        d: meta(),                                // newlyObserved
+        e: meta(),                                // orphan
+      },
+      observedThen: {
+        a: meta(),  // disappeared (and missing, since declared)
+        b: meta(),  // unchanged
+        c: meta(),  // drift
+      },
+    });
+    expect(result.missing).toEqual(["a"]);
+    expect(result.orphan).toEqual(["e"]);
+    expect(result.disappeared).toEqual(["a"]);
+    expect(result.newlyObserved).toEqual(["d"]);
+    expect(result.driftedSinceSnapshot.map((d) => d.name)).toEqual(["c"]);
+    expect(result.unchanged).toEqual(["b"]);
+  });
+});

--- a/packages/core/src/state/live-diff.ts
+++ b/packages/core/src/state/live-diff.ts
@@ -1,0 +1,151 @@
+/**
+ * Live-state diff: compares declared vs observed-now vs observed-then.
+ *
+ * Produces structured drift signal — *what is in the cloud right now* against
+ * both *what was declared in source* and *what was observed at the last
+ * snapshot*. Pure function; all I/O happens in the caller.
+ */
+import type { ResourceMetadata } from "../lexicon";
+
+export interface AttributeChange {
+  /** Attribute path (e.g. "status", "physicalId", "attributes.tags.env"). */
+  path: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+export interface ResourceDrift {
+  name: string;
+  type: string;
+  changes: AttributeChange[];
+}
+
+export interface LiveDiffResult {
+  /** Declared in current build, but not observed in cloud right now. */
+  missing: string[];
+  /** Observed in cloud right now, but not declared. */
+  orphan: string[];
+  /** Was in last snapshot but isn't observed now. */
+  disappeared: string[];
+  /** Observed now and declared, but not in the previous snapshot. */
+  newlyObserved: string[];
+  /** Observed both then and now; metadata changed. */
+  driftedSinceSnapshot: ResourceDrift[];
+  /** Observed both then and now; metadata identical. */
+  unchanged: string[];
+}
+
+export interface DiffLiveInput {
+  /** Entity names from the current build. */
+  declared: Set<string>;
+  /** Resources returned by `plugin.describeResources()` right now. */
+  observedNow: Record<string, ResourceMetadata>;
+  /** Resources captured by the previous snapshot, if any. */
+  observedThen: Record<string, ResourceMetadata> | undefined;
+}
+
+const TRACKED_FIELDS: Array<keyof ResourceMetadata> = [
+  "status",
+  "physicalId",
+  "lastUpdated",
+];
+
+function compareMetadata(
+  oldMeta: ResourceMetadata,
+  newMeta: ResourceMetadata,
+): AttributeChange[] {
+  const changes: AttributeChange[] = [];
+
+  for (const field of TRACKED_FIELDS) {
+    if (oldMeta[field] !== newMeta[field]) {
+      changes.push({ path: field, oldValue: oldMeta[field], newValue: newMeta[field] });
+    }
+  }
+
+  const oldAttrs = oldMeta.attributes ?? {};
+  const newAttrs = newMeta.attributes ?? {};
+  const allAttrKeys = new Set([...Object.keys(oldAttrs), ...Object.keys(newAttrs)]);
+  for (const key of allAttrKeys) {
+    const oldValue = oldAttrs[key];
+    const newValue = newAttrs[key];
+    if (!shallowEqual(oldValue, newValue)) {
+      changes.push({ path: `attributes.${key}`, oldValue, newValue });
+    }
+  }
+
+  return changes;
+}
+
+function shallowEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function diffLive(input: DiffLiveInput): LiveDiffResult {
+  const { declared, observedNow, observedThen } = input;
+  const observedThenMap = observedThen ?? {};
+  const observedNowNames = new Set(Object.keys(observedNow));
+  const observedThenNames = new Set(Object.keys(observedThenMap));
+
+  const missing: string[] = [];
+  const orphan: string[] = [];
+  const disappeared: string[] = [];
+  const newlyObserved: string[] = [];
+  const driftedSinceSnapshot: ResourceDrift[] = [];
+  const unchanged: string[] = [];
+
+  // Declared but not observed in cloud right now → missing
+  for (const name of declared) {
+    if (!observedNowNames.has(name)) {
+      missing.push(name);
+    }
+  }
+
+  // In cloud right now but not declared → orphan
+  for (const name of observedNowNames) {
+    if (!declared.has(name)) {
+      orphan.push(name);
+    }
+  }
+
+  // In previous snapshot but not observed now → disappeared
+  for (const name of observedThenNames) {
+    if (!observedNowNames.has(name)) {
+      disappeared.push(name);
+    }
+  }
+
+  // Observed now: classify drift relative to previous snapshot
+  for (const name of observedNowNames) {
+    const now = observedNow[name];
+    const then = observedThenMap[name];
+    if (!then) {
+      if (declared.has(name)) {
+        newlyObserved.push(name);
+      }
+      // else: orphan, already classified above
+      continue;
+    }
+    const changes = compareMetadata(then, now);
+    if (changes.length === 0) {
+      unchanged.push(name);
+    } else {
+      driftedSinceSnapshot.push({
+        name,
+        type: now.type,
+        changes,
+      });
+    }
+  }
+
+  return {
+    missing: missing.sort(),
+    orphan: orphan.sort(),
+    disappeared: disappeared.sort(),
+    newlyObserved: newlyObserved.sort(),
+    driftedSinceSnapshot: driftedSinceSnapshot.sort((a, b) => a.name.localeCompare(b.name)),
+    unchanged: unchanged.sort(),
+  };
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -18,3 +18,5 @@ export {
   expectNoDiagnostics,
   expectDiagnostic,
 } from "./post-synth-harness";
+export { createMockPlugin, staticDescribeResources } from "./mock-plugin";
+export type { MockPluginOptions } from "./mock-plugin";

--- a/packages/test-utils/src/mock-plugin.test.ts
+++ b/packages/test-utils/src/mock-plugin.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "vitest";
+import { createMockPlugin, staticDescribeResources } from "./mock-plugin";
+
+describe("createMockPlugin", () => {
+  test("returns a plugin with the requested name", () => {
+    const plugin = createMockPlugin({ name: "aws" });
+    expect(plugin.name).toBe("aws");
+    expect(plugin.serializer).toBeDefined();
+  });
+
+  test("defaults to 'mock' when no name is given", () => {
+    expect(createMockPlugin().name).toBe("mock");
+  });
+
+  test("describeResources is undefined unless provided", () => {
+    expect(createMockPlugin().describeResources).toBeUndefined();
+  });
+
+  test("describeResources is wired through when provided", async () => {
+    const plugin = createMockPlugin({
+      name: "aws",
+      describeResources: staticDescribeResources({
+        bucket: { type: "AWS::S3::Bucket", status: "CREATE_COMPLETE" },
+      }),
+    });
+    const result = await plugin.describeResources!({
+      environment: "prod",
+      buildOutput: "",
+      entityNames: ["bucket"],
+    });
+    expect(result).toEqual({
+      bucket: { type: "AWS::S3::Bucket", status: "CREATE_COMPLETE" },
+    });
+  });
+
+  test("lifecycle methods are no-ops", async () => {
+    const plugin = createMockPlugin();
+    await expect(plugin.generate()).resolves.toBeUndefined();
+    await expect(plugin.validate()).resolves.toBeUndefined();
+    await expect(plugin.coverage()).resolves.toBeUndefined();
+    await expect(plugin.package()).resolves.toBeUndefined();
+  });
+});

--- a/packages/test-utils/src/mock-plugin.ts
+++ b/packages/test-utils/src/mock-plugin.ts
@@ -1,5 +1,5 @@
-import type { LexiconPlugin, ResourceMetadata } from "@intentius/chant";
-import type { Serializer } from "@intentius/chant";
+import type { LexiconPlugin, ResourceMetadata } from "../../core/src/lexicon";
+import type { Serializer } from "../../core/src/serializer";
 import { createMockSerializer } from "./fixtures";
 
 export interface MockPluginOptions {

--- a/packages/test-utils/src/mock-plugin.ts
+++ b/packages/test-utils/src/mock-plugin.ts
@@ -1,0 +1,29 @@
+import type { LexiconPlugin, ResourceMetadata } from "@intentius/chant";
+import type { Serializer } from "@intentius/chant";
+import { createMockSerializer } from "./fixtures";
+
+export interface MockPluginOptions {
+  name?: string;
+  serializer?: Serializer;
+  describeResources?: LexiconPlugin["describeResources"];
+}
+
+export function createMockPlugin(options: MockPluginOptions = {}): LexiconPlugin {
+  const name = options.name ?? "mock";
+  const noop = async () => {};
+  return {
+    name,
+    serializer: options.serializer ?? createMockSerializer(name),
+    generate: noop,
+    validate: noop,
+    coverage: noop,
+    package: noop,
+    ...(options.describeResources && { describeResources: options.describeResources }),
+  };
+}
+
+export function staticDescribeResources(
+  resources: Record<string, ResourceMetadata>,
+): LexiconPlugin["describeResources"] {
+  return async () => resources;
+}


### PR DESCRIPTION
## Summary

Closes #26. Implements `chant state diff <env> --live` — a live-cloud drift mode that catches external mutations the existing digest-only diff misses. Default (digest) behavior is unchanged; `--live` is opt-in for v1.

The new path:

```
declared (entity names)  ↔  observedNow (plugin.describeResources)
observedNow              ↔  observedThen (snapshot.resources)
```

Six categories per lexicon: missing, orphan, disappeared, newly observed, drifted (with attribute-level changes), and unchanged. Lexicons without `describeResources()` are warn-skipped, not failed.

## Commits

1. `chore(test-utils): add mockPlugin factory` — reusable for #29
2. `feat(state): live-diff comparator` — pure function in `packages/core/src/state/live-diff.ts`, 8 unit tests
3. `feat(cli): wire --live into state diff` — flag plumbing + handler split into `runStateDiffLive` / `runStateDiffDigest`, 3 handler tests
4. `docs(state): document state diff --live drift mode`
5. `fix(test-utils): use relative imports in mockPlugin factory` — small follow-up

## What's intentionally not in this PR

- Making `--live` the default (would need broader `describeResources()` coverage; tracked in #27)
- Temporal lexicon `describeResources()` — that's #27
- Broader test coverage on run/graph handlers — that's #29 (only the state handler is touched here)
- State branch locking (#30), search-attr auto-emit (#28), continuous observation (#31) — all untouched

## Verification

- `just build` clean
- `npx vitest run packages/core/ packages/test-utils/` → 1434/1434 pass (16 new tests)
- Legacy `state diff` (no `--live`) still works — regression test included
- Manual smoke against a real AWS env was out-of-band; the AWS lexicon's existing `describeResources()` is the path that will exercise this in production

## Test plan

- [ ] CI green on this branch
- [ ] After merge, hold off on tagging until #27 lands so the first published version with `--live` includes Temporal coverage too