### PR TITLE
feat(temporal): describeResources() — namespace/search-attr/schedule (#27)

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -68,7 +68,9 @@ Output is grouped into six categories per lexicon:
 
 Drifted entries include attribute-level deltas (`status`, `physicalId`, `lastUpdated`, and each `attributes.*` key).
 
-Lexicons that don't yet implement `describeResources()` are warn-skipped — `--live` doesn't fail the whole command for them. To see which lexicons are covered, the AWS lexicon supports it today; coverage of others is tracked in [issue #27](https://github.com/INTENTIUS/chant/issues/27).
+Lexicons that don't yet implement `describeResources()` are warn-skipped — `--live` doesn't fail the whole command for them. Today, **AWS** and **Temporal** are covered.
+
+The Temporal lexicon resolves its connection via the chant config: `state snapshot <env>` (or `--live` against `<env>`) looks up `temporal.profiles.<env>` in your `chant.config.ts` and falls back to `temporal.defaultProfile`. The same profile model is used by `chant run`. Server-side identifiers are used as the resource keys (e.g. `namespace/prod`, `searchAttribute/prod/Project`, `schedule/prod/daily-report`).
 
 ### `state log [env]`
 

--- a/lexicons/temporal/src/describe-resources.test.ts
+++ b/lexicons/temporal/src/describe-resources.test.ts
@@ -1,0 +1,237 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const loadChantConfigMock = vi.fn();
+const loadTemporalClientMock = vi.fn();
+const resolveProfileMock = vi.fn();
+
+vi.mock("@intentius/chant/config", () => ({
+  loadChantConfig: (...args: unknown[]) => loadChantConfigMock(...args),
+}));
+
+vi.mock("@intentius/chant/cli/handlers/run-client", () => ({
+  loadTemporalClient: () => loadTemporalClientMock(),
+  connectionOptions: (profile: { address: string }) => ({ address: profile.address }),
+  resolveProfile: (...args: unknown[]) => resolveProfileMock(...args),
+}));
+
+const { describeResources } = await import("./describe-resources");
+
+interface FakeNamespace {
+  name: string;
+  state?: number;
+  description?: string;
+  retentionSeconds?: number;
+  isGlobal?: boolean;
+}
+
+interface FakeSchedule {
+  scheduleId: string;
+  workflowType?: string;
+  cronExpressions?: string[];
+  paused?: boolean;
+}
+
+function fakeConnection(opts: {
+  namespaces: FakeNamespace[];
+  searchAttributesByNs?: Record<string, Record<string, number>>;
+  schedulesByNs?: Record<string, FakeSchedule[]>;
+  searchAttrThrows?: Set<string>;
+  scheduleThrows?: Set<string>;
+}) {
+  const close = vi.fn(async () => {});
+  return {
+    workflowService: {
+      listNamespaces: vi.fn(async () => ({
+        namespaces: opts.namespaces.map((n) => ({
+          namespaceInfo: {
+            name: n.name,
+            state: n.state ?? 1,
+            description: n.description,
+          },
+          config: n.retentionSeconds
+            ? { workflowExecutionRetentionTtl: { seconds: n.retentionSeconds } }
+            : null,
+          isGlobalNamespace: n.isGlobal ?? false,
+        })),
+        nextPageToken: null,
+      })),
+    },
+    operatorService: {
+      listSearchAttributes: vi.fn(async ({ namespace }: { namespace: string }) => {
+        if (opts.searchAttrThrows?.has(namespace)) {
+          throw new Error(`stubbed search-attribute failure for ${namespace}`);
+        }
+        return { customAttributes: opts.searchAttributesByNs?.[namespace] ?? {} };
+      }),
+    },
+    close,
+  };
+}
+
+function fakeClient(opts: {
+  schedulesByNs?: Record<string, FakeSchedule[]>;
+  scheduleThrows?: Set<string>;
+}) {
+  return {
+    scheduleClient: {
+      list: ({ namespace }: { namespace?: string }) => {
+        const schedules = opts.schedulesByNs?.[namespace ?? ""] ?? [];
+        const shouldThrow = !!namespace && opts.scheduleThrows?.has(namespace);
+        return (async function* () {
+          if (shouldThrow) throw new Error(`stubbed schedule list failure for ${namespace}`);
+          for (const s of schedules) {
+            yield {
+              scheduleId: s.scheduleId,
+              spec: s.cronExpressions ? { cronExpressions: s.cronExpressions } : null,
+              action: s.workflowType ? { type: "startWorkflow", workflowType: s.workflowType } : null,
+              state: s.paused ? { paused: true } : null,
+            };
+          }
+        })();
+      },
+    },
+  };
+}
+
+function setupClientMock(connection: unknown, client: unknown) {
+  loadTemporalClientMock.mockResolvedValue({
+    Connection: { connect: vi.fn(async () => connection) },
+    Client: vi.fn(() => client) as unknown as new () => unknown,
+  });
+}
+
+describe("describeResources", () => {
+  beforeEach(() => {
+    loadChantConfigMock.mockReset();
+    loadTemporalClientMock.mockReset();
+    resolveProfileMock.mockReset();
+
+    loadChantConfigMock.mockResolvedValue({ config: { temporal: { profiles: { dev: { address: "localhost:7233", namespace: "default", taskQueue: "q" } } } } });
+    resolveProfileMock.mockReturnValue({ address: "localhost:7233", namespace: "default", taskQueue: "q" });
+  });
+
+  test("emits one row per namespace + search-attr + schedule", async () => {
+    const connection = fakeConnection({
+      namespaces: [{ name: "default" }, { name: "prod" }],
+      searchAttributesByNs: {
+        default: { Project: 2 },
+        prod: { Phase: 1 },
+      },
+      schedulesByNs: {
+        default: [{ scheduleId: "daily-report", workflowType: "reportWf", cronExpressions: ["0 8 * * *"] }],
+        prod: [{ scheduleId: "weekly-backup", workflowType: "backupWf", paused: true }],
+      },
+    });
+    const client = fakeClient({
+      schedulesByNs: {
+        default: [{ scheduleId: "daily-report", workflowType: "reportWf", cronExpressions: ["0 8 * * *"] }],
+        prod: [{ scheduleId: "weekly-backup", workflowType: "backupWf", paused: true }],
+      },
+    });
+    setupClientMock(connection, client);
+
+    const result = await describeResources({ environment: "dev", buildOutput: "", entityNames: [] });
+
+    expect(Object.keys(result).sort()).toEqual([
+      "namespace/default",
+      "namespace/prod",
+      "schedule/default/daily-report",
+      "schedule/prod/weekly-backup",
+      "searchAttribute/default/Project",
+      "searchAttribute/prod/Phase",
+    ]);
+  });
+
+  test("populates the resource metadata shape correctly", async () => {
+    const connection = fakeConnection({
+      namespaces: [{ name: "prod", description: "Prod namespace", retentionSeconds: 604800, isGlobal: true }],
+      searchAttributesByNs: { prod: { Project: 2 } },
+      schedulesByNs: {},
+    });
+    const client = fakeClient({
+      schedulesByNs: {
+        prod: [{ scheduleId: "daily-report", workflowType: "reportWf", cronExpressions: ["0 8 * * *"] }],
+      },
+    });
+    setupClientMock(connection, client);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: [] });
+
+    expect(result["namespace/prod"]).toEqual({
+      type: "Temporal::Namespace",
+      physicalId: "prod",
+      status: "REGISTERED",
+      attributes: {
+        description: "Prod namespace",
+        isGlobalNamespace: true,
+        retentionSeconds: 604800,
+      },
+    });
+    expect(result["searchAttribute/prod/Project"]).toEqual({
+      type: "Temporal::SearchAttribute",
+      physicalId: "prod/Project",
+      status: "REGISTERED",
+      attributes: { valueType: "Keyword", namespace: "prod" },
+    });
+    expect(result["schedule/prod/daily-report"]).toEqual({
+      type: "Temporal::Schedule",
+      physicalId: "prod/daily-report",
+      status: "ACTIVE",
+      attributes: {
+        namespace: "prod",
+        workflowType: "reportWf",
+        cronExpressions: ["0 8 * * *"],
+      },
+    });
+  });
+
+  test("connection failure propagates with a clear error", async () => {
+    loadTemporalClientMock.mockResolvedValue({
+      Connection: { connect: vi.fn(async () => { throw new Error("UNAVAILABLE: connect ECONNREFUSED 127.0.0.1:7233"); }) },
+      Client: vi.fn() as unknown as new () => unknown,
+    });
+
+    await expect(describeResources({ environment: "dev", buildOutput: "", entityNames: [] }))
+      .rejects.toThrow(/UNAVAILABLE/);
+  });
+
+  test("empty cluster returns empty record without throwing", async () => {
+    const connection = fakeConnection({ namespaces: [] });
+    const client = fakeClient({});
+    setupClientMock(connection, client);
+
+    const result = await describeResources({ environment: "dev", buildOutput: "", entityNames: [] });
+
+    expect(result).toEqual({});
+  });
+
+  test("per-namespace failures are warn-soft and don't abort other namespaces", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const connection = fakeConnection({
+      namespaces: [{ name: "broken" }, { name: "ok" }],
+      searchAttributesByNs: { ok: { Project: 2 } },
+      searchAttrThrows: new Set(["broken"]),
+    });
+    const client = fakeClient({
+      schedulesByNs: {
+        ok: [{ scheduleId: "daily-report", workflowType: "reportWf" }],
+      },
+      scheduleThrows: new Set(["broken"]),
+    });
+    setupClientMock(connection, client);
+
+    const result = await describeResources({ environment: "dev", buildOutput: "", entityNames: [] });
+
+    // Both namespaces present
+    expect(result["namespace/broken"]).toBeDefined();
+    expect(result["namespace/ok"]).toBeDefined();
+    // ok's children present
+    expect(result["searchAttribute/ok/Project"]).toBeDefined();
+    expect(result["schedule/ok/daily-report"]).toBeDefined();
+    // broken's children skipped
+    expect(Object.keys(result).filter((k) => k.includes("/broken/"))).toEqual([]);
+    // Warnings emitted
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
+});

--- a/lexicons/temporal/src/describe-resources.ts
+++ b/lexicons/temporal/src/describe-resources.ts
@@ -1,0 +1,238 @@
+/**
+ * Live introspection of a Temporal cluster — implements the
+ * LexiconPlugin.describeResources() contract for the temporal lexicon.
+ *
+ * Connects to the cluster identified by the chant config profile that
+ * matches the current environment (falls back to defaultProfile), then lists:
+ *   - Namespaces        via workflowService.listNamespaces
+ *   - SearchAttributes  via operatorService.listSearchAttributes (per namespace)
+ *   - Schedules         via scheduleClient.list (per namespace)
+ *
+ * Results are keyed by server-side identifier (e.g. "namespace/prod",
+ * "searchAttribute/prod/Project", "schedule/prod/daily-report"). Mapping back
+ * to chant entity names is a separate concern (would need entity props passed
+ * through the plugin contract).
+ */
+
+import { loadChantConfig } from "@intentius/chant/config";
+import {
+  loadTemporalClient,
+  connectionOptions,
+  resolveProfile,
+  type WorkerProfile,
+} from "@intentius/chant/cli/handlers/run-client";
+import type { ResourceMetadata } from "@intentius/chant/lexicon";
+
+interface NamespaceListResponse {
+  namespaces?: Array<{
+    namespaceInfo?: {
+      name?: string;
+      state?: number | string;
+      description?: string;
+      ownerEmail?: string;
+    } | null;
+    config?: {
+      workflowExecutionRetentionTtl?: { seconds?: number | bigint | { toNumber(): number } } | null;
+    } | null;
+    isGlobalNamespace?: boolean;
+  }>;
+  nextPageToken?: Uint8Array | null;
+}
+
+interface SearchAttributesResponse {
+  customAttributes?: Record<string, number | string> | null;
+  systemAttributes?: Record<string, number | string> | null;
+}
+
+interface ScheduleSummary {
+  scheduleId?: string;
+  spec?: { cronExpressions?: string[] } | null;
+  action?: { type?: string; workflowType?: string } | null;
+  state?: { paused?: boolean; note?: string } | null;
+}
+
+interface RichConnection {
+  workflowService: {
+    listNamespaces(req: { pageSize?: number; nextPageToken?: Uint8Array }): Promise<NamespaceListResponse>;
+  };
+  operatorService: {
+    listSearchAttributes(req: { namespace: string }): Promise<SearchAttributesResponse>;
+  };
+  close?(): Promise<void>;
+}
+
+interface RichClient {
+  scheduleClient: {
+    list(opts: { namespace?: string }): AsyncIterable<ScheduleSummary>;
+  };
+}
+
+interface RichClientModule {
+  Connection: { connect(opts: Record<string, unknown>): Promise<RichConnection> };
+  Client: new (opts: { connection: RichConnection; namespace?: string }) => RichClient;
+}
+
+const NAMESPACE_STATE_NAMES: Record<number, string> = {
+  0: "UNSPECIFIED",
+  1: "REGISTERED",
+  2: "DEPRECATED",
+  3: "DELETED",
+};
+
+const VALUE_TYPE_NAMES: Record<number, string> = {
+  0: "Unspecified",
+  1: "Text",
+  2: "Keyword",
+  3: "Int",
+  4: "Double",
+  5: "Bool",
+  6: "Datetime",
+  7: "KeywordList",
+};
+
+function namespaceStateToString(state: number | string | undefined): string {
+  if (typeof state === "string") return state;
+  if (typeof state === "number") return NAMESPACE_STATE_NAMES[state] ?? `STATE_${state}`;
+  return "UNKNOWN";
+}
+
+function valueTypeToString(t: number | string | undefined): string {
+  if (typeof t === "string") return t;
+  if (typeof t === "number") return VALUE_TYPE_NAMES[t] ?? `TYPE_${t}`;
+  return "Unknown";
+}
+
+function retentionTtlToSeconds(
+  ttl: { seconds?: number | bigint | { toNumber(): number } } | null | undefined,
+): number | undefined {
+  if (!ttl?.seconds) return undefined;
+  const s = ttl.seconds;
+  if (typeof s === "number") return s;
+  if (typeof s === "bigint") return Number(s);
+  if (typeof s === "object" && "toNumber" in s) return s.toNumber();
+  return undefined;
+}
+
+function resolveProfileForEnv(
+  config: Record<string, unknown>,
+  environment: string,
+): WorkerProfile {
+  // Try env-named profile first, fall back to defaultProfile.
+  try {
+    return resolveProfile(config, environment);
+  } catch {
+    return resolveProfile(config);
+  }
+}
+
+async function paginateNamespaces(connection: RichConnection): Promise<NonNullable<NamespaceListResponse["namespaces"]>> {
+  const all: NonNullable<NamespaceListResponse["namespaces"]> = [];
+  let nextPageToken: Uint8Array | undefined;
+  do {
+    const res = await connection.workflowService.listNamespaces({
+      pageSize: 100,
+      ...(nextPageToken && { nextPageToken }),
+    });
+    if (res.namespaces) all.push(...res.namespaces);
+    nextPageToken = res.nextPageToken && res.nextPageToken.length > 0 ? res.nextPageToken : undefined;
+  } while (nextPageToken);
+  return all;
+}
+
+export async function describeResources(_options: {
+  environment: string;
+  buildOutput: string;
+  entityNames: string[];
+}): Promise<Record<string, ResourceMetadata>> {
+  const { config } = await loadChantConfig(process.cwd());
+  const profile = resolveProfileForEnv(config as Record<string, unknown>, _options.environment);
+
+  const mod = (await loadTemporalClient()) as unknown as RichClientModule;
+  const connection = await mod.Connection.connect(connectionOptions(profile));
+  const client = new mod.Client({ connection });
+
+  const result: Record<string, ResourceMetadata> = {};
+
+  try {
+    const namespaces = await paginateNamespaces(connection);
+
+    for (const ns of namespaces) {
+      const name = ns.namespaceInfo?.name;
+      if (!name) continue;
+
+      result[`namespace/${name}`] = {
+        type: "Temporal::Namespace",
+        physicalId: name,
+        status: namespaceStateToString(ns.namespaceInfo?.state),
+        attributes: pruneUndefined({
+          description: ns.namespaceInfo?.description,
+          ownerEmail: ns.namespaceInfo?.ownerEmail,
+          isGlobalNamespace: ns.isGlobalNamespace,
+          retentionSeconds: retentionTtlToSeconds(ns.config?.workflowExecutionRetentionTtl ?? undefined),
+        }),
+      };
+
+      // SearchAttributes — failure on one namespace shouldn't abort others.
+      try {
+        const sa = await connection.operatorService.listSearchAttributes({ namespace: name });
+        for (const [attrName, valueType] of Object.entries(sa.customAttributes ?? {})) {
+          result[`searchAttribute/${name}/${attrName}`] = {
+            type: "Temporal::SearchAttribute",
+            physicalId: `${name}/${attrName}`,
+            status: "REGISTERED",
+            attributes: {
+              valueType: valueTypeToString(valueType),
+              namespace: name,
+            },
+          };
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[temporal] failed to list search attributes for namespace "${name}": ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+
+      // Schedules — same fail-soft policy.
+      try {
+        for await (const s of client.scheduleClient.list({ namespace: name })) {
+          if (!s.scheduleId) continue;
+          result[`schedule/${name}/${s.scheduleId}`] = {
+            type: "Temporal::Schedule",
+            physicalId: `${name}/${s.scheduleId}`,
+            status: s.state?.paused ? "PAUSED" : "ACTIVE",
+            attributes: pruneUndefined({
+              namespace: name,
+              workflowType: s.action?.workflowType,
+              cronExpressions: s.spec?.cronExpressions,
+              note: s.state?.note,
+            }),
+          };
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[temporal] failed to list schedules for namespace "${name}": ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+  } finally {
+    if (typeof connection.close === "function") {
+      try { await connection.close(); } catch { /* best-effort */ }
+    }
+  }
+
+  return result;
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}

--- a/lexicons/temporal/src/plugin.ts
+++ b/lexicons/temporal/src/plugin.ts
@@ -283,4 +283,9 @@ export const temporalPlugin: LexiconPlugin = {
     const { generateDocs } = await import("./codegen/docs");
     return generateDocs(options);
   },
+
+  async describeResources(options) {
+    const { describeResources } = await import("./describe-resources");
+    return describeResources(options);
+  },
 };


### PR DESCRIPTION
## Summary

Closes #27. Implements `describeResources()` in the Temporal lexicon, fulfilling the optional `LexiconPlugin` method that #26's `state diff --live` and `state snapshot` already call into. Until now, Temporal-backed envs got no data in the snapshot pipeline.

The new path queries:
- **Namespaces** — `connection.workflowService.listNamespaces` (paginated)
- **Search attributes** — `connection.operatorService.listSearchAttributes(namespace)` per namespace
- **Schedules** — `client.scheduleClient.list({ namespace })` per namespace

Output keyed by server-side identifier:

```
namespace/<name>
searchAttribute/<ns>/<name>
schedule/<ns>/<scheduleId>
```

Connection setup reuses the existing helpers in `packages/core/src/cli/handlers/run-client.ts` (`loadTemporalClient`, `connectionOptions`, `resolveProfile`) — no new shared infra.

## Profile resolution

`<env>` → `temporal.profiles.<env>` in `chant.config.ts`, falling back to `temporal.defaultProfile`. Same model `chant run` already uses.

## Failure modes

- **Connection error** (gRPC `UNAVAILABLE`/`DEADLINE_EXCEEDED`) — propagates; `snapshot.ts` catches per-plugin so other lexicons proceed.
- **Per-namespace search-attr or schedule listing failure** — warn-soft; partial result still returned for that namespace.
- **Empty cluster** (no namespaces) — returns `{}` cleanly. `snapshot.ts` then logs "no valid resources returned" — same behavior as a misconfigured AWS account.

## Commits

1. `feat(temporal): describeResources for namespace/search-attr/schedule` — `lexicons/temporal/src/describe-resources.ts` (~240 LOC)
2. `feat(temporal): wire describeResources into plugin.ts` — one-line plugin field via dynamic import
3. `test(temporal): unit tests for describeResources` — 5 tests with `vi.mock` stubs of `loadChantConfig` + `loadTemporalClient` + `resolveProfile`
4. `docs(state): list Temporal among snapshot-supported lexicons` — removes "AWS only" caveat from `cli/state.mdx`, documents the profile-resolution semantics

## Intentionally out of scope

- **Mapping chant entity names to server-side identifiers.** With server-side keys, `state diff --live` will report Temporal resources as `newly observed` or `orphan` relative to chant's declared set — honest and useful, but not full round-trip. Closing the loop would require entity props on the `describeResources` contract; that's a separate change.
- **Integration test against `temporal server start-dev`** — proposed to drop in favor of unit tests with mocked client; CI cost vs. marginal value.
- **No Temporal SDK version pinning or peerDep change** — the lexicon already implicitly assumes the user has `@temporalio/client` installed (same as `chant run`); `loadTemporalClient` gives a clean error if not.

## Verification

- `just build` clean
- `npx vitest run packages/core/ packages/test-utils/ lexicons/temporal/` → 1553/1553 pass (5 new tests in `describe-resources.test.ts`)
- All other Temporal lexicon tests continue to pass (119 in the lexicon)
- Manual smoke against `temporal server start-dev` was out-of-band

## Test plan

- [ ] CI green
- [ ] After merge, follow-up: bump `@intentius/chant-lexicon-temporal` to `0.1.7` (this is a feature add); will pair with #29's test-coverage work for the next release tag