### PR TITLE
test: cover state/run/graph handlers + state internals (#29)

### DIFF
--- a/packages/core/src/cli/handlers/graph.test.ts
+++ b/packages/core/src/cli/handlers/graph.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import type { ParsedArgs } from "../registry";
+
+const discoverOpsMock = vi.fn();
+vi.mock("../../op/discover", () => ({
+  discoverOps: () => discoverOpsMock(),
+}));
+
+const { runGraph } = await import("./graph");
+
+function makeArgs(overrides: Partial<ParsedArgs> = {}): ParsedArgs {
+  return {
+    command: "graph", path: ".",
+    format: "", fix: false, watch: false, verbose: false, help: false, live: false,
+    ...overrides,
+  };
+}
+
+function makeOp(name: string, depends: string[] = []): [string, { config: { name: string; depends?: string[] } }] {
+  return [name, { config: { name, depends } }];
+}
+
+describe("runGraph", () => {
+  let stdoutBuf: string[];
+  let stderrBuf: string[];
+
+  beforeEach(() => {
+    stdoutBuf = [];
+    stderrBuf = [];
+    vi.spyOn(console, "log").mockImplementation((s: string) => { stdoutBuf.push(s); });
+    vi.spyOn(console, "error").mockImplementation((s: string) => { stderrBuf.push(s); });
+    discoverOpsMock.mockReset();
+  });
+
+  test("prints 'No Ops found' when discovery is empty", async () => {
+    discoverOpsMock.mockResolvedValue({ ops: new Map(), errors: [] });
+    const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
+    expect(exit).toBe(0);
+    expect(stdoutBuf.join("\n")).toContain("No Ops found");
+  });
+
+  test("prints 'No Op dependencies' when ops have no depends", async () => {
+    discoverOpsMock.mockResolvedValue({
+      ops: new Map([makeOp("solo")]),
+      errors: [],
+    });
+    const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
+    expect(exit).toBe(0);
+    expect(stdoutBuf.join("\n")).toContain("No Op dependencies");
+  });
+
+  test("prints `dep -> name` edge per dependency", async () => {
+    discoverOpsMock.mockResolvedValue({
+      ops: new Map([
+        makeOp("infra"),
+        makeOp("app", ["infra"]),
+      ]),
+      errors: [],
+    });
+    const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
+    expect(exit).toBe(0);
+    const out = stdoutBuf.join("\n");
+    expect(out).toContain("infra → app");
+  });
+
+  test("handles multi-edge graphs", async () => {
+    discoverOpsMock.mockResolvedValue({
+      ops: new Map([
+        makeOp("a"),
+        makeOp("b", ["a"]),
+        makeOp("c", ["a", "b"]),
+      ]),
+      errors: [],
+    });
+    await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
+    const out = stdoutBuf.join("\n");
+    expect(out).toContain("a → b");
+    expect(out).toContain("a → c");
+    expect(out).toContain("b → c");
+  });
+
+  test("forwards discovery errors to stderr", async () => {
+    discoverOpsMock.mockResolvedValue({
+      ops: new Map(),
+      errors: ["failed to parse ops/bad.op.ts"],
+    });
+    const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
+    expect(exit).toBe(0);
+    expect(stderrBuf.join("\n")).toContain("failed to parse ops/bad.op.ts");
+  });
+});

--- a/packages/core/src/cli/handlers/run.test.ts
+++ b/packages/core/src/cli/handlers/run.test.ts
@@ -1,0 +1,258 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { createMockTemporalClient } from "@intentius/chant-test-utils";
+import type { ParsedArgs } from "../registry";
+
+const discoverOpsMock = vi.fn();
+const loadChantConfigMock = vi.fn();
+const loadTemporalClientMock = vi.fn();
+const resolveProfileMock = vi.fn();
+
+vi.mock("../../op/discover", () => ({ discoverOps: () => discoverOpsMock() }));
+vi.mock("../../config", () => ({ loadChantConfig: (...args: unknown[]) => loadChantConfigMock(...args) }));
+vi.mock("./run-client", () => ({
+  loadTemporalClient: () => loadTemporalClientMock(),
+  connectionOptions: (profile: { address: string }) => ({ address: profile.address }),
+  resolveProfile: (...args: unknown[]) => resolveProfileMock(...args),
+  resolveWorkflowId: (name: string) => `chant-op-${name}`,
+}));
+
+const { runOpList, runOpStatus, runOpLog, runOpSignal, runOpCancel } = await import("./run");
+
+function makeArgs(overrides: Partial<ParsedArgs> = {}): ParsedArgs {
+  return {
+    command: "run", path: ".",
+    format: "", fix: false, watch: false, verbose: false, help: false, live: false,
+    ...overrides,
+  };
+}
+
+function makeOp(name: string, depends: string[] = []): [string, { config: { name: string; phases: unknown[]; taskQueue?: string; depends?: string[]; overview: string } }] {
+  return [name, { config: { name, phases: [], depends, overview: `${name} overview` } }];
+}
+
+function setupTemporalClient(mock: ReturnType<typeof createMockTemporalClient>) {
+  loadTemporalClientMock.mockResolvedValue({
+    Connection: { connect: vi.fn(async () => ({})) },
+    Client: vi.fn(() => mock.client) as unknown as new () => unknown,
+  });
+  loadChantConfigMock.mockResolvedValue({ config: {} });
+  resolveProfileMock.mockReturnValue({ address: "localhost:7233", namespace: "default", taskQueue: "q" });
+}
+
+function makeStdoutSpy() {
+  const buf: string[] = [];
+  vi.spyOn(console, "log").mockImplementation((s: string) => { buf.push(s); });
+  return buf;
+}
+
+function makeStderrSpy() {
+  const buf: string[] = [];
+  vi.spyOn(console, "error").mockImplementation((s: string) => { buf.push(s); });
+  return buf;
+}
+
+describe("runOpList", () => {
+  beforeEach(() => {
+    discoverOpsMock.mockReset();
+    loadTemporalClientMock.mockReset();
+    loadChantConfigMock.mockReset();
+    resolveProfileMock.mockReset();
+  });
+
+  test("warns when no Ops discovered, returns 0", async () => {
+    discoverOpsMock.mockResolvedValue({ ops: new Map(), errors: [] });
+    const stderr = makeStderrSpy();
+    const exit = await runOpList({ args: makeArgs(), plugins: [], serializers: [] });
+    expect(exit).toBe(0);
+    expect(stderr.join("\n")).toContain("No Op definitions found");
+  });
+
+  test("prints table with one row per Op when Temporal connection fails", async () => {
+    discoverOpsMock.mockResolvedValue({
+      ops: new Map([makeOp("alb-deploy"), makeOp("infra")]),
+      errors: [],
+    });
+    // No Temporal — make loadTemporalClient throw so degraded path is exercised
+    loadTemporalClientMock.mockRejectedValue(new Error("not installed"));
+    const stdout = makeStdoutSpy();
+    const exit = await runOpList({ args: makeArgs(), plugins: [], serializers: [] });
+    expect(exit).toBe(0);
+    const out = stdout.join("\n");
+    expect(out).toContain("NAME");
+    expect(out).toContain("alb-deploy");
+    expect(out).toContain("infra");
+  });
+
+  test("annotates Ops with Temporal status when client is available", async () => {
+    discoverOpsMock.mockResolvedValue({ ops: new Map([makeOp("alb-deploy")]), errors: [] });
+    setupTemporalClient(createMockTemporalClient({
+      describeByWorkflowId: {
+        "chant-op-alb-deploy": {
+          workflowId: "chant-op-alb-deploy", runId: "r1",
+          status: { name: "RUNNING" }, startTime: new Date(),
+          taskQueue: "alb-deploy", type: { name: "albDeployWorkflow" },
+        },
+      },
+    }));
+    const stdout = makeStdoutSpy();
+    const exit = await runOpList({ args: makeArgs(), plugins: [], serializers: [] });
+    expect(exit).toBe(0);
+    expect(stdout.join("\n")).toContain("RUNNING");
+  });
+});
+
+describe("runOpStatus", () => {
+  beforeEach(() => {
+    discoverOpsMock.mockReset();
+    loadTemporalClientMock.mockReset();
+    loadChantConfigMock.mockReset();
+    resolveProfileMock.mockReset();
+  });
+
+  test("missing op name → exit 1", async () => {
+    const stderr = makeStderrSpy();
+    const exit = await runOpStatus({ args: makeArgs({ extraPositional: undefined }), plugins: [], serializers: [] });
+    expect(exit).toBe(1);
+    expect(stderr.join("\n")).toContain("Op name is required");
+  });
+
+  test("connection error → exit 1 with message", async () => {
+    loadTemporalClientMock.mockRejectedValue(new Error("UNAVAILABLE"));
+    loadChantConfigMock.mockResolvedValue({ config: {} });
+    resolveProfileMock.mockReturnValue({ address: "localhost:7233", namespace: "default", taskQueue: "q" });
+    const stderr = makeStderrSpy();
+    const exit = await runOpStatus({ args: makeArgs({ extraPositional: "alb-deploy" }), plugins: [], serializers: [] });
+    expect(exit).toBe(1);
+    expect(stderr.join("\n")).toContain("UNAVAILABLE");
+  });
+
+  test("happy path: prints workflow id, run id, status, activity counts", async () => {
+    setupTemporalClient(createMockTemporalClient({
+      describeByWorkflowId: {
+        "chant-op-alb-deploy": {
+          workflowId: "chant-op-alb-deploy", runId: "r1",
+          status: { name: "COMPLETED" },
+          startTime: new Date("2026-05-01T00:00:00Z"),
+          closeTime: new Date("2026-05-01T01:00:00Z"),
+          taskQueue: "alb-deploy", type: { name: "albDeployWorkflow" },
+        },
+      },
+      historyByWorkflowId: {
+        "chant-op-alb-deploy": [
+          { eventType: "ActivityTaskScheduled" },
+          { eventType: "ActivityTaskScheduled" },
+          { eventType: "ActivityTaskCompleted" },
+        ],
+      },
+    }));
+    const stdout = makeStdoutSpy();
+    const exit = await runOpStatus({ args: makeArgs({ extraPositional: "alb-deploy" }), plugins: [], serializers: [] });
+    expect(exit).toBe(0);
+    const out = stdout.join("\n");
+    expect(out).toContain("chant-op-alb-deploy");
+    expect(out).toContain("COMPLETED");
+    expect(out).toContain("1/2 completed");
+  });
+});
+
+describe("runOpLog", () => {
+  beforeEach(() => {
+    loadTemporalClientMock.mockReset();
+    loadChantConfigMock.mockReset();
+    resolveProfileMock.mockReset();
+  });
+
+  test("missing op name → exit 1", async () => {
+    const stderr = makeStderrSpy();
+    const exit = await runOpLog({ args: makeArgs({ extraPositional: undefined }), plugins: [], serializers: [] });
+    expect(exit).toBe(1);
+    expect(stderr.join("\n")).toContain("Op name is required");
+  });
+
+  test("prints one row per matching workflow execution", async () => {
+    setupTemporalClient(createMockTemporalClient({
+      list: [
+        { workflowId: "chant-op-alb-deploy", runId: "r1", type: { name: "albDeployWorkflow" }, status: { name: "COMPLETED" }, startTime: new Date("2026-05-01T00:00:00Z"), closeTime: new Date("2026-05-01T01:00:00Z") },
+        { workflowId: "chant-op-alb-deploy", runId: "r2", type: { name: "albDeployWorkflow" }, status: { name: "RUNNING" }, startTime: new Date("2026-05-02T00:00:00Z") },
+      ],
+    }));
+    const stdout = makeStdoutSpy();
+    const exit = await runOpLog({ args: makeArgs({ extraPositional: "alb-deploy" }), plugins: [], serializers: [] });
+    expect(exit).toBe(0);
+    const out = stdout.join("\n");
+    expect(out).toContain("RUN-ID");
+    expect(out).toContain("r1");
+    expect(out).toContain("r2");
+    expect(out).toContain("COMPLETED");
+    expect(out).toContain("RUNNING");
+  });
+});
+
+describe("runOpSignal", () => {
+  beforeEach(() => {
+    loadTemporalClientMock.mockReset();
+    loadChantConfigMock.mockReset();
+    resolveProfileMock.mockReset();
+  });
+
+  test("missing op or signal name → exit 1", async () => {
+    const stderr = makeStderrSpy();
+    const exit = await runOpSignal({ args: makeArgs({ extraPositional: "op-only" }), plugins: [], serializers: [] });
+    expect(exit).toBe(1);
+    expect(stderr.join("\n")).toContain("Usage:");
+  });
+
+  test("happy path: signal is sent and success message logged", async () => {
+    const mockClient = createMockTemporalClient();
+    setupTemporalClient(mockClient);
+    const stderr = makeStderrSpy();
+    const exit = await runOpSignal({
+      args: makeArgs({ extraPositional: "alb-deploy", extraPositional2: "gate-dns" }),
+      plugins: [], serializers: [],
+    });
+    expect(exit).toBe(0);
+    expect(mockClient.calls.signalCalls).toEqual([
+      { workflowId: "chant-op-alb-deploy", signalName: "gate-dns" },
+    ]);
+    expect(stderr.join("\n")).toContain("Signal");
+    expect(stderr.join("\n")).toContain("gate-dns");
+  });
+});
+
+describe("runOpCancel", () => {
+  beforeEach(() => {
+    loadTemporalClientMock.mockReset();
+    loadChantConfigMock.mockReset();
+    resolveProfileMock.mockReset();
+  });
+
+  test("missing op name → exit 1", async () => {
+    const stderr = makeStderrSpy();
+    const exit = await runOpCancel({ args: makeArgs({ extraPositional: undefined }), plugins: [], serializers: [] });
+    expect(exit).toBe(1);
+    expect(stderr.join("\n")).toContain("Op name is required");
+  });
+
+  test("requires --force → exit 1 without it", async () => {
+    const stderr = makeStderrSpy();
+    const exit = await runOpCancel({
+      args: makeArgs({ extraPositional: "alb-deploy", force: false }),
+      plugins: [], serializers: [],
+    });
+    expect(exit).toBe(1);
+    expect(stderr.join("\n")).toContain("--force");
+  });
+
+  test("with --force: cancel is sent and success logged", async () => {
+    const mockClient = createMockTemporalClient();
+    setupTemporalClient(mockClient);
+    const stderr = makeStderrSpy();
+    const exit = await runOpCancel({
+      args: makeArgs({ extraPositional: "alb-deploy", force: true }),
+      plugins: [], serializers: [],
+    });
+    expect(exit).toBe(0);
+    expect(mockClient.calls.cancelCalls).toEqual([{ workflowId: "chant-op-alb-deploy" }]);
+    expect(stderr.join("\n")).toContain("Cancellation requested");
+  });
+});

--- a/packages/core/src/cli/handlers/state.test.ts
+++ b/packages/core/src/cli/handlers/state.test.ts
@@ -7,16 +7,26 @@ import type { ParsedArgs } from "../registry";
 const buildMock = vi.fn();
 const fetchStateMock = vi.fn();
 const readSnapshotMock = vi.fn();
+const readEnvironmentSnapshotsMock = vi.fn();
+const listSnapshotsMock = vi.fn();
+const takeSnapshotMock = vi.fn();
+const loadChantConfigMock = vi.fn();
 
 vi.mock("../../build", () => ({ build: (...args: unknown[]) => buildMock(...args) }));
 vi.mock("../../state/git", () => ({
   fetchState: () => fetchStateMock(),
   readSnapshot: (...args: unknown[]) => readSnapshotMock(...args),
-  readEnvironmentSnapshots: vi.fn(),
-  listSnapshots: vi.fn(),
+  readEnvironmentSnapshots: (...args: unknown[]) => readEnvironmentSnapshotsMock(...args),
+  listSnapshots: (...args: unknown[]) => listSnapshotsMock(...args),
+}));
+vi.mock("../../state/snapshot", () => ({
+  takeSnapshot: (...args: unknown[]) => takeSnapshotMock(...args),
+}));
+vi.mock("../../config", () => ({
+  loadChantConfig: (...args: unknown[]) => loadChantConfigMock(...args),
 }));
 
-const { runStateDiff } = await import("./state");
+const { runStateDiff, runStateSnapshot, runStateShow, runStateLog, runStateUnknown } = await import("./state");
 
 function makeArgs(overrides: Partial<ParsedArgs>): ParsedArgs {
   return {
@@ -157,5 +167,207 @@ describe("runStateDiff --live", () => {
     expect(output).toContain("aws");
     expect(output).toContain("bucket");
     expect(output).toContain("added");
+  });
+});
+
+describe("runStateSnapshot", () => {
+  let stdoutBuf: string[];
+  let stderrBuf: string[];
+
+  beforeEach(() => {
+    stdoutBuf = [];
+    stderrBuf = [];
+    vi.spyOn(console, "log").mockImplementation((s: string) => { stdoutBuf.push(s); });
+    vi.spyOn(console, "error").mockImplementation((s: string) => { stderrBuf.push(s); });
+    buildMock.mockReset();
+    takeSnapshotMock.mockReset();
+    loadChantConfigMock.mockReset();
+    loadChantConfigMock.mockResolvedValue({ config: { environments: ["prod"] } });
+  });
+
+  test("missing environment arg → exit 1 with helpful message", async () => {
+    const ctx = {
+      args: makeArgs({ command: "state", path: "snapshot" }),
+      plugins: [],
+      serializers: [],
+    };
+    const exit = await runStateSnapshot(ctx);
+    expect(exit).toBe(1);
+    expect(stderrBuf.join("\n")).toContain("Environment is required");
+  });
+
+  test("environment not in config → exit 1", async () => {
+    const ctx = {
+      args: makeArgs({ command: "state", path: "snapshot", extraPositional: "unknown" }),
+      plugins: [],
+      serializers: [],
+    };
+    const exit = await runStateSnapshot(ctx);
+    expect(exit).toBe(1);
+    expect(stderrBuf.join("\n")).toContain('Unknown environment "unknown"');
+  });
+
+  test("no plugins implement describeResources → exit 1 with hint", async () => {
+    buildMock.mockResolvedValue(makeBuildResult({ aws: ["x"] }));
+    const plugins: LexiconPlugin[] = [createMockPlugin({ name: "aws" })];
+    const ctx = {
+      args: makeArgs({ command: "state", path: "snapshot", extraPositional: "prod" }),
+      plugins,
+      serializers: plugins.map((p) => p.serializer),
+    };
+    const exit = await runStateSnapshot(ctx);
+    expect(exit).toBe(1);
+    expect(stderrBuf.join("\n")).toContain("No plugins implement describeResources");
+  });
+
+  test("happy path: writes snapshot via takeSnapshot and reports counts", async () => {
+    buildMock.mockResolvedValue(makeBuildResult({ aws: ["bucket"] }));
+    takeSnapshotMock.mockResolvedValue({
+      snapshots: [{ lexicon: "aws", environment: "prod", resources: { bucket: meta() } }],
+      commit: "sha",
+      warnings: [],
+      errors: [],
+    });
+    const plugins: LexiconPlugin[] = [
+      createMockPlugin({
+        name: "aws",
+        describeResources: staticDescribeResources({ bucket: meta() }),
+      }),
+    ];
+    const ctx = {
+      args: makeArgs({ command: "state", path: "snapshot", extraPositional: "prod" }),
+      plugins,
+      serializers: plugins.map((p) => p.serializer),
+    };
+    const exit = await runStateSnapshot(ctx);
+    expect(exit).toBe(0);
+    expect(stderrBuf.join("\n")).toContain("Snapshot saved");
+    expect(takeSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runStateShow", () => {
+  let stdoutBuf: string[];
+  let stderrBuf: string[];
+
+  beforeEach(() => {
+    stdoutBuf = [];
+    stderrBuf = [];
+    vi.spyOn(console, "log").mockImplementation((s: string) => { stdoutBuf.push(s); });
+    vi.spyOn(console, "error").mockImplementation((s: string) => { stderrBuf.push(s); });
+    fetchStateMock.mockReset();
+    readSnapshotMock.mockReset();
+    readEnvironmentSnapshotsMock.mockReset();
+  });
+
+  test("missing environment arg → exit 1", async () => {
+    const ctx = {
+      args: makeArgs({ command: "state", path: "show" }),
+      plugins: [], serializers: [],
+    };
+    expect(await runStateShow(ctx)).toBe(1);
+    expect(stderrBuf.join("\n")).toContain("Environment is required");
+  });
+
+  test("specific lexicon: prints snapshot table when found", async () => {
+    fetchStateMock.mockResolvedValue(undefined);
+    readSnapshotMock.mockResolvedValue(JSON.stringify({
+      lexicon: "aws", environment: "prod", commit: "x", timestamp: "t",
+      resources: { bucket: { type: "AWS::S3::Bucket", physicalId: "b-1", status: "OK" } },
+    }));
+    const ctx = {
+      args: makeArgs({ command: "state", path: "show", extraPositional: "prod", extraPositional2: "aws" }),
+      plugins: [], serializers: [],
+    };
+    expect(await runStateShow(ctx)).toBe(0);
+    const out = stdoutBuf.join("\n");
+    expect(out).toContain("bucket");
+    expect(out).toContain("AWS::S3::Bucket");
+  });
+
+  test("specific lexicon: returns 1 when no snapshot found", async () => {
+    fetchStateMock.mockResolvedValue(undefined);
+    readSnapshotMock.mockResolvedValue(null);
+    const ctx = {
+      args: makeArgs({ command: "state", path: "show", extraPositional: "prod", extraPositional2: "aws" }),
+      plugins: [], serializers: [],
+    };
+    expect(await runStateShow(ctx)).toBe(1);
+    expect(stderrBuf.join("\n")).toContain("No snapshot found");
+  });
+
+  test("no lexicon: lists all lexicons in env", async () => {
+    fetchStateMock.mockResolvedValue(undefined);
+    readEnvironmentSnapshotsMock.mockResolvedValue(new Map([
+      ["aws", JSON.stringify({ lexicon: "aws", environment: "prod", commit: "x", timestamp: "t", resources: {} })],
+      ["gcp", JSON.stringify({ lexicon: "gcp", environment: "prod", commit: "x", timestamp: "t", resources: {} })],
+    ]));
+    const ctx = {
+      args: makeArgs({ command: "state", path: "show", extraPositional: "prod" }),
+      plugins: [], serializers: [],
+    };
+    expect(await runStateShow(ctx)).toBe(0);
+    const out = stdoutBuf.join("\n");
+    expect(out).toContain("prod/aws");
+    expect(out).toContain("prod/gcp");
+  });
+});
+
+describe("runStateLog", () => {
+  let stdoutBuf: string[];
+  let stderrBuf: string[];
+
+  beforeEach(() => {
+    stdoutBuf = [];
+    stderrBuf = [];
+    vi.spyOn(console, "log").mockImplementation((s: string) => { stdoutBuf.push(s); });
+    vi.spyOn(console, "error").mockImplementation((s: string) => { stderrBuf.push(s); });
+    fetchStateMock.mockReset();
+    listSnapshotsMock.mockReset();
+  });
+
+  test("returns 1 with message when no entries exist", async () => {
+    fetchStateMock.mockResolvedValue(undefined);
+    listSnapshotsMock.mockResolvedValue([]);
+    const ctx = {
+      args: makeArgs({ command: "state", path: "log" }),
+      plugins: [], serializers: [],
+    };
+    expect(await runStateLog(ctx)).toBe(1);
+    expect(stderrBuf.join("\n")).toContain("No state snapshots");
+  });
+
+  test("prints commit / date / message rows for each entry", async () => {
+    fetchStateMock.mockResolvedValue(undefined);
+    listSnapshotsMock.mockResolvedValue([
+      { commit: "abcdef1234567890", date: "2026-05-01T00:00:00Z", message: "Snapshot prod" },
+      { commit: "fedcba9876543210", date: "2026-05-02T00:00:00Z", message: "Snapshot staging" },
+    ]);
+    const ctx = {
+      args: makeArgs({ command: "state", path: "log" }),
+      plugins: [], serializers: [],
+    };
+    expect(await runStateLog(ctx)).toBe(0);
+    const out = stdoutBuf.join("\n");
+    expect(out).toContain("abcdef1");
+    expect(out).toContain("Snapshot prod");
+    expect(out).toContain("Snapshot staging");
+  });
+});
+
+describe("runStateUnknown", () => {
+  test("returns 1 with subcommand list", async () => {
+    const stderrBuf: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((s: string) => { stderrBuf.push(s); });
+    const ctx = {
+      args: makeArgs({ command: "state", path: "garbage" }),
+      plugins: [], serializers: [],
+    };
+    expect(await runStateUnknown(ctx)).toBe(1);
+    const stderr = stderrBuf.join("\n");
+    expect(stderr).toContain("snapshot");
+    expect(stderr).toContain("show");
+    expect(stderr).toContain("diff");
+    expect(stderr).toContain("log");
   });
 });

--- a/packages/core/src/state/digest.test.ts
+++ b/packages/core/src/state/digest.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect } from "vitest";
+import { computeBuildDigest, diffDigests, hashProps } from "./digest";
+import type { BuildResult } from "../build";
+import type { BuildDigest } from "./types";
+
+function makeBuildResult(entitiesByLexicon: Record<string, Array<{ name: string; type: string; props: unknown }>>): BuildResult {
+  const entities = new Map();
+  for (const [lexicon, list] of Object.entries(entitiesByLexicon)) {
+    for (const item of list) {
+      entities.set(item.name, { lexicon, entityType: item.type, props: item.props });
+    }
+  }
+  return {
+    outputs: new Map(Object.keys(entitiesByLexicon).map((l) => [l, "{}"])),
+    entities,
+    dependencies: new Map(),
+    errors: [],
+    warnings: [],
+    manifest: {
+      lexicons: Object.keys(entitiesByLexicon),
+      outputs: {},
+      deployOrder: Object.keys(entitiesByLexicon),
+    },
+    sourceFileCount: 1,
+  } as unknown as BuildResult;
+}
+
+describe("hashProps", () => {
+  test("produces the same hash for identical props", () => {
+    expect(hashProps({ a: 1, b: 2 })).toBe(hashProps({ a: 1, b: 2 }));
+  });
+
+  test("is order-independent (sorted JSON serialization)", () => {
+    expect(hashProps({ a: 1, b: 2 })).toBe(hashProps({ b: 2, a: 1 }));
+  });
+
+  test("produces different hashes for different props", () => {
+    expect(hashProps({ a: 1 })).not.toBe(hashProps({ a: 2 }));
+  });
+});
+
+describe("computeBuildDigest", () => {
+  test("emits one entry per entity with type, lexicon, and propsHash", () => {
+    const buildResult = makeBuildResult({
+      aws: [{ name: "bucket", type: "AWS::S3::Bucket", props: { name: "data" } }],
+    });
+    const digest = computeBuildDigest(buildResult);
+    expect(digest.resources["bucket"]).toMatchObject({
+      type: "AWS::S3::Bucket",
+      lexicon: "aws",
+      propsHash: expect.any(String),
+    });
+  });
+
+  test("missing props default to empty object", () => {
+    const buildResult = makeBuildResult({ aws: [{ name: "x", type: "T", props: undefined }] });
+    const digest = computeBuildDigest(buildResult);
+    expect(digest.resources["x"].propsHash).toBe(hashProps({}));
+  });
+
+  test("mirrors the build manifest's deployOrder and outputs", () => {
+    const buildResult = makeBuildResult({
+      aws: [{ name: "b", type: "T", props: {} }],
+      gcp: [{ name: "g", type: "T", props: {} }],
+    });
+    const digest = computeBuildDigest(buildResult);
+    expect(digest.deployOrder).toEqual(["aws", "gcp"]);
+    expect(digest.outputs).toEqual({});
+  });
+});
+
+describe("diffDigests", () => {
+  function makeDigest(resources: Record<string, string>): BuildDigest {
+    const out: BuildDigest["resources"] = {};
+    for (const [name, propsHash] of Object.entries(resources)) {
+      out[name] = { type: "T", lexicon: "aws", propsHash };
+    }
+    return { resources: out, dependencies: {}, outputs: {}, deployOrder: [] };
+  }
+
+  test("no previous digest → everything is added", () => {
+    const result = diffDigests(makeDigest({ a: "x", b: "y" }), undefined);
+    expect(result.added).toEqual(["a", "b"]);
+    expect(result.removed).toEqual([]);
+    expect(result.changed).toEqual([]);
+    expect(result.unchanged).toEqual([]);
+  });
+
+  test("identical digests → all unchanged", () => {
+    const d = makeDigest({ a: "x" });
+    const result = diffDigests(d, d);
+    expect(result.unchanged).toEqual(["a"]);
+    expect(result.added).toEqual([]);
+    expect(result.changed).toEqual([]);
+    expect(result.removed).toEqual([]);
+  });
+
+  test("different propsHash → changed", () => {
+    const result = diffDigests(makeDigest({ a: "x2" }), makeDigest({ a: "x1" }));
+    expect(result.changed).toEqual(["a"]);
+  });
+
+  test("resource gone from current → removed", () => {
+    const result = diffDigests(makeDigest({}), makeDigest({ a: "x" }));
+    expect(result.removed).toEqual(["a"]);
+  });
+
+  test("mixed: added + removed + changed + unchanged", () => {
+    const previous = makeDigest({ a: "x1", b: "y", c: "z" });
+    const current = makeDigest({ a: "x2", b: "y", d: "w" });
+    const result = diffDigests(current, previous);
+    expect(result.added.sort()).toEqual(["d"]);
+    expect(result.changed.sort()).toEqual(["a"]);
+    expect(result.unchanged.sort()).toEqual(["b"]);
+    expect(result.removed.sort()).toEqual(["c"]);
+  });
+});

--- a/packages/core/src/state/git.test.ts
+++ b/packages/core/src/state/git.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect } from "vitest";
+import { withTestDir } from "@intentius/chant-test-utils";
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  writeSnapshot,
+  readSnapshot,
+  readEnvironmentSnapshots,
+  listSnapshots,
+  getHeadCommit,
+} from "./git";
+
+function git(args: string[], cwd: string): { stdout: string; exitCode: number } {
+  const r = spawnSync("git", args, { cwd, encoding: "utf-8" });
+  return { stdout: r.stdout ?? "", exitCode: r.status ?? -1 };
+}
+
+async function initRepo(dir: string): Promise<void> {
+  git(["init", "-q", "-b", "main"], dir);
+  git(["config", "user.email", "test@chant.dev"], dir);
+  git(["config", "user.name", "Test"], dir);
+  // Need at least one commit so HEAD exists.
+  writeFileSync(join(dir, "README.md"), "fixture\n");
+  git(["add", "README.md"], dir);
+  git(["commit", "-q", "-m", "init"], dir);
+}
+
+describe("state/git", () => {
+  test("writeSnapshot creates the orphan branch and writes JSON addressable by readSnapshot", async () => {
+    await withTestDir(async (dir) => {
+      await initRepo(dir);
+      const json = JSON.stringify({ resources: { bucket: { type: "T", status: "OK" } } });
+      const sha = await writeSnapshot("prod", "aws", json, { cwd: dir });
+      expect(sha).toMatch(/^[0-9a-f]{40}$/);
+
+      const out = await readSnapshot("prod", "aws", { cwd: dir });
+      expect(out).not.toBeNull();
+      expect(JSON.parse(out!)).toEqual(JSON.parse(json));
+    });
+  });
+
+  test("readSnapshot returns null for missing env/lexicon", async () => {
+    await withTestDir(async (dir) => {
+      await initRepo(dir);
+      const out = await readSnapshot("prod", "aws", { cwd: dir });
+      expect(out).toBeNull();
+    });
+  });
+
+  test("subsequent writes preserve other env+lexicon entries", async () => {
+    await withTestDir(async (dir) => {
+      await initRepo(dir);
+      await writeSnapshot("prod", "aws", JSON.stringify({ a: 1 }), { cwd: dir });
+      await writeSnapshot("prod", "gcp", JSON.stringify({ b: 2 }), { cwd: dir });
+      await writeSnapshot("staging", "aws", JSON.stringify({ c: 3 }), { cwd: dir });
+
+      expect(await readSnapshot("prod", "aws", { cwd: dir })).toBeTruthy();
+      expect(await readSnapshot("prod", "gcp", { cwd: dir })).toBeTruthy();
+      expect(await readSnapshot("staging", "aws", { cwd: dir })).toBeTruthy();
+    });
+  });
+
+  test("re-writing the same env+lexicon updates the entry rather than duplicating", async () => {
+    await withTestDir(async (dir) => {
+      await initRepo(dir);
+      await writeSnapshot("prod", "aws", JSON.stringify({ v: 1 }), { cwd: dir });
+      await writeSnapshot("prod", "aws", JSON.stringify({ v: 2 }), { cwd: dir });
+      const out = await readSnapshot("prod", "aws", { cwd: dir });
+      expect(JSON.parse(out!)).toEqual({ v: 2 });
+    });
+  });
+
+  test("readEnvironmentSnapshots returns all lexicons for an env", async () => {
+    await withTestDir(async (dir) => {
+      await initRepo(dir);
+      await writeSnapshot("prod", "aws", JSON.stringify({ a: 1 }), { cwd: dir });
+      await writeSnapshot("prod", "gcp", JSON.stringify({ b: 2 }), { cwd: dir });
+      const all = await readEnvironmentSnapshots("prod", { cwd: dir });
+      expect([...all.keys()].sort()).toEqual(["aws", "gcp"]);
+    });
+  });
+
+  test("listSnapshots returns commit history of the orphan branch", async () => {
+    await withTestDir(async (dir) => {
+      await initRepo(dir);
+      await writeSnapshot("prod", "aws", JSON.stringify({ v: 1 }), { cwd: dir });
+      await writeSnapshot("prod", "aws", JSON.stringify({ v: 2 }), { cwd: dir });
+      const log = await listSnapshots({ cwd: dir });
+      expect(log.length).toBe(2);
+      expect(log[0].commit).toMatch(/^[0-9a-f]{40}$/);
+    });
+  });
+
+  test("getHeadCommit returns the working-branch HEAD sha", async () => {
+    await withTestDir(async (dir) => {
+      await initRepo(dir);
+      const head = await getHeadCommit({ cwd: dir });
+      expect(head).toMatch(/^[0-9a-f]{40}$/);
+    });
+  });
+});

--- a/packages/core/src/state/git.ts
+++ b/packages/core/src/state/git.ts
@@ -22,13 +22,8 @@ export async function writeSnapshot(
   const rt = getRuntime();
   const cwd = opts?.cwd;
 
-  // 1. Write blob
-  const hashResult = await rt.spawn(
-    ["git", "hash-object", "-w", "--stdin"],
-    { cwd },
-  );
-  // hash-object reads from stdin, but spawn doesn't support piping directly.
-  // Use a shell pipeline instead.
+  // 1. Write blob — hash-object reads from stdin, but spawn() doesn't expose
+  // a stdin handle, so we run via a shell pipeline (`echo … | git hash-object`).
   const blobResult = await rt.spawn(
     ["sh", "-c", `echo '${json.replace(/'/g, "'\\''")}' | git hash-object -w --stdin`],
     { cwd },

--- a/packages/core/src/state/snapshot.test.ts
+++ b/packages/core/src/state/snapshot.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { createMockPlugin, staticDescribeResources } from "@intentius/chant-test-utils";
+import type { BuildResult } from "../build";
+
+const writeSnapshotMock = vi.fn();
+const getHeadCommitMock = vi.fn();
+const pushStateMock = vi.fn();
+
+vi.mock("./git", () => ({
+  writeSnapshot: (...args: unknown[]) => writeSnapshotMock(...args),
+  getHeadCommit: () => getHeadCommitMock(),
+  pushState: () => pushStateMock(),
+}));
+
+const { takeSnapshot } = await import("./snapshot");
+
+function makeBuildResult(entitiesByLexicon: Record<string, string[]>): BuildResult {
+  const entities = new Map();
+  for (const [lexicon, names] of Object.entries(entitiesByLexicon)) {
+    for (const name of names) entities.set(name, { lexicon, entityType: `${lexicon}::Mock`, props: {} });
+  }
+  return {
+    outputs: new Map(Object.keys(entitiesByLexicon).map((l) => [l, "{}"])),
+    entities,
+    dependencies: new Map(),
+    errors: [],
+    warnings: [],
+    manifest: { lexicons: Object.keys(entitiesByLexicon), outputs: {}, deployOrder: [] },
+    sourceFileCount: 1,
+  } as unknown as BuildResult;
+}
+
+describe("takeSnapshot", () => {
+  beforeEach(() => {
+    writeSnapshotMock.mockReset();
+    getHeadCommitMock.mockReset();
+    pushStateMock.mockReset();
+    writeSnapshotMock.mockResolvedValue("commit-sha");
+    getHeadCommitMock.mockResolvedValue("head-sha");
+    pushStateMock.mockResolvedValue(true);
+  });
+
+  test("happy path: writes snapshot per plugin with describeResources", async () => {
+    const plugin = createMockPlugin({
+      name: "aws",
+      describeResources: staticDescribeResources({
+        bucket: { type: "AWS::S3::Bucket", status: "CREATE_COMPLETE", physicalId: "bucket-1" },
+      }),
+    });
+    const result = await takeSnapshot("prod", [plugin], makeBuildResult({ aws: ["bucket"] }));
+    expect(result.snapshots).toHaveLength(1);
+    expect(result.snapshots[0]).toMatchObject({
+      lexicon: "aws",
+      environment: "prod",
+      commit: "head-sha",
+      resources: { bucket: { type: "AWS::S3::Bucket", status: "CREATE_COMPLETE" } },
+    });
+    expect(writeSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(pushStateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("plugin without describeResources is skipped", async () => {
+    const plugin = createMockPlugin({ name: "aws" });
+    const result = await takeSnapshot("prod", [plugin], makeBuildResult({ aws: ["x"] }));
+    expect(result.snapshots).toEqual([]);
+    expect(writeSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  test("plugin throws → captured as error, other plugins still proceed", async () => {
+    const broken = createMockPlugin({
+      name: "broken",
+      describeResources: async () => { throw new Error("boom"); },
+    });
+    const ok = createMockPlugin({
+      name: "ok",
+      describeResources: staticDescribeResources({ x: { type: "T", status: "OK" } }),
+    });
+    const result = await takeSnapshot("prod", [broken, ok], makeBuildResult({ broken: ["b"], ok: ["x"] }));
+    expect(result.errors.some((e) => e.includes("broken") && e.includes("boom"))).toBe(true);
+    expect(result.snapshots.map((s) => s.lexicon)).toEqual(["ok"]);
+  });
+
+  test("plugin returns no valid resources → error and no snapshot", async () => {
+    const plugin = createMockPlugin({
+      name: "aws",
+      describeResources: async () => ({}), // empty
+    });
+    const result = await takeSnapshot("prod", [plugin], makeBuildResult({ aws: [] }));
+    expect(result.snapshots).toEqual([]);
+    expect(result.errors.some((e) => e.includes("aws") && e.includes("no valid"))).toBe(true);
+  });
+
+  test("resources missing required type/status are dropped with warning", async () => {
+    const plugin = createMockPlugin({
+      name: "aws",
+      describeResources: staticDescribeResources({
+        valid:   { type: "T", status: "OK" },
+        bad:     { type: "", status: "OK" } as never,
+      }),
+    });
+    const result = await takeSnapshot("prod", [plugin], makeBuildResult({ aws: ["valid"] }));
+    expect(result.snapshots[0].resources).toEqual({ valid: { type: "T", status: "OK" } });
+    expect(result.warnings.some((w) => w.includes("Dropped bad"))).toBe(true);
+  });
+
+  test("emits sensitive-data warnings for suspect attribute names", async () => {
+    const plugin = createMockPlugin({
+      name: "aws",
+      describeResources: staticDescribeResources({
+        cred: {
+          type: "T",
+          status: "OK",
+          attributes: { connectionString: "redacted", regularAttr: "x" },
+        },
+      }),
+    });
+    const result = await takeSnapshot("prod", [plugin], makeBuildResult({ aws: ["cred"] }));
+    expect(result.warnings.some((w) => w.toLowerCase().includes("sensitive"))).toBe(true);
+  });
+});

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -20,3 +20,12 @@ export {
 } from "./post-synth-harness";
 export { createMockPlugin, staticDescribeResources } from "./mock-plugin";
 export type { MockPluginOptions } from "./mock-plugin";
+export { createMockTemporalClient } from "./mock-temporal-client";
+export type {
+  MockTemporalClientOptions,
+  MockTemporalClient,
+  MockWorkflowDescription,
+  MockHistoryEvent,
+  MockWorkflowSummary,
+  RecordedCalls,
+} from "./mock-temporal-client";

--- a/packages/test-utils/src/mock-temporal-client.test.ts
+++ b/packages/test-utils/src/mock-temporal-client.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "vitest";
+import { createMockTemporalClient } from "./mock-temporal-client";
+
+describe("createMockTemporalClient", () => {
+  test("getHandle().describe() returns the configured description", async () => {
+    const mock = createMockTemporalClient({
+      describeByWorkflowId: {
+        "chant-op-deploy": {
+          workflowId: "chant-op-deploy",
+          runId: "run-1",
+          status: { name: "RUNNING" },
+          startTime: new Date("2026-05-01T00:00:00Z"),
+          taskQueue: "deploy",
+          type: { name: "deployWorkflow" },
+        },
+      },
+    });
+    const desc = await mock.client.workflow.getHandle("chant-op-deploy").describe();
+    expect(desc.status.name).toBe("RUNNING");
+    expect(desc.taskQueue).toBe("deploy");
+  });
+
+  test("getHandle().describe() throws for unknown workflow", async () => {
+    const mock = createMockTemporalClient();
+    await expect(mock.client.workflow.getHandle("missing").describe()).rejects.toThrow(/not found/);
+  });
+
+  test("describeError takes precedence over per-workflow descriptions", async () => {
+    const mock = createMockTemporalClient({
+      describeError: new Error("UNAVAILABLE: cluster offline"),
+      describeByWorkflowId: {
+        wf: { workflowId: "wf", runId: "r", status: { name: "RUNNING" }, startTime: new Date(), taskQueue: "tq", type: { name: "t" } },
+      },
+    });
+    await expect(mock.client.workflow.getHandle("wf").describe()).rejects.toThrow(/UNAVAILABLE/);
+  });
+
+  test("workflow.start records call args and produces a usable handle", async () => {
+    const mock = createMockTemporalClient();
+    const handle = await mock.client.workflow.start({}, { workflowId: "chant-op-foo", taskQueue: "foo" });
+    expect(handle.workflowId).toBe("chant-op-foo");
+    expect(mock.calls.startCalls).toHaveLength(1);
+    expect(mock.calls.startCalls[0].opts.taskQueue).toBe("foo");
+  });
+
+  test("signal and cancel are recorded against the workflow id", async () => {
+    const mock = createMockTemporalClient();
+    const handle = mock.client.workflow.getHandle("chant-op-foo");
+    await handle.signal("gate-dns");
+    await handle.cancel();
+    expect(mock.calls.signalCalls).toEqual([{ workflowId: "chant-op-foo", signalName: "gate-dns" }]);
+    expect(mock.calls.cancelCalls).toEqual([{ workflowId: "chant-op-foo" }]);
+  });
+
+  test("workflow.list yields configured summaries", async () => {
+    const mock = createMockTemporalClient({
+      list: [
+        { workflowId: "a", runId: "r1", type: { name: "t" }, status: { name: "COMPLETED" }, startTime: new Date() },
+        { workflowId: "b", runId: "r2", type: { name: "t" }, status: { name: "RUNNING" }, startTime: new Date() },
+      ],
+    });
+    const seen: string[] = [];
+    for await (const wf of mock.client.workflow.list()) seen.push(wf.workflowId);
+    expect(seen).toEqual(["a", "b"]);
+  });
+});

--- a/packages/test-utils/src/mock-temporal-client.ts
+++ b/packages/test-utils/src/mock-temporal-client.ts
@@ -1,0 +1,137 @@
+/**
+ * mockTemporalClient — minimal Client surface for testing the chant run
+ * handlers and any other code that depends on @temporalio/client without a
+ * real cluster.
+ *
+ * Returned shape mirrors the subset used by run-client.ts: { client, profile,
+ * config }-style access patterns plus client.workflow.{getHandle,start,list}
+ * call recorders.
+ */
+
+export interface MockWorkflowDescription {
+  workflowId: string;
+  runId: string;
+  status: { name: string };
+  startTime: Date;
+  closeTime?: Date;
+  taskQueue: string;
+  type: { name: string };
+}
+
+export interface MockHistoryEvent {
+  eventType?: string;
+  eventTime?: Date;
+  activityTaskScheduledEventAttributes?: {
+    activityId?: string;
+    activityType?: { name?: string };
+  };
+  activityTaskCompletedEventAttributes?: { scheduledEventId?: string | number };
+  activityTaskFailedEventAttributes?: { failure?: { message?: string } };
+}
+
+export interface MockWorkflowSummary {
+  workflowId: string;
+  runId: string;
+  type: { name: string };
+  status: { name: string };
+  startTime: Date;
+  closeTime?: Date;
+}
+
+export interface MockTemporalClientOptions {
+  /** Map of workflowId -> description for getHandle(...).describe() */
+  describeByWorkflowId?: Record<string, MockWorkflowDescription>;
+  /** Map of workflowId -> history events for getHandle(...).fetchHistory() */
+  historyByWorkflowId?: Record<string, MockHistoryEvent[]>;
+  /** Workflows returned by client.workflow.list() */
+  list?: MockWorkflowSummary[];
+  /** If set, getHandle().describe() throws this error (simulates not-found / no cluster) */
+  describeError?: Error;
+}
+
+export interface RecordedCalls {
+  startCalls: Array<{ workflowFn: unknown; opts: Record<string, unknown> }>;
+  signalCalls: Array<{ workflowId: string; signalName: string }>;
+  cancelCalls: Array<{ workflowId: string }>;
+}
+
+export interface MockTemporalClient {
+  client: {
+    workflow: {
+      start(workflowFn: unknown, opts: Record<string, unknown>): Promise<{
+        workflowId: string;
+        firstExecutionRunId?: string;
+        result(): Promise<unknown>;
+        describe(): Promise<MockWorkflowDescription>;
+        fetchHistory(): Promise<{ events?: MockHistoryEvent[] }>;
+        signal(signalName: string): Promise<void>;
+        cancel(): Promise<void>;
+      }>;
+      getHandle(workflowId: string): {
+        workflowId: string;
+        describe(): Promise<MockWorkflowDescription>;
+        fetchHistory(): Promise<{ events?: MockHistoryEvent[] }>;
+        signal(signalName: string): Promise<void>;
+        cancel(): Promise<void>;
+        result(): Promise<unknown>;
+      };
+      list(opts?: Record<string, unknown>): AsyncIterable<MockWorkflowSummary>;
+    };
+  };
+  /** Records of calls made through the client — useful for assertions. */
+  calls: RecordedCalls;
+}
+
+export function createMockTemporalClient(opts: MockTemporalClientOptions = {}): MockTemporalClient {
+  const calls: RecordedCalls = { startCalls: [], signalCalls: [], cancelCalls: [] };
+
+  const makeHandle = (workflowId: string) => ({
+    workflowId,
+    async describe(): Promise<MockWorkflowDescription> {
+      if (opts.describeError) throw opts.describeError;
+      const desc = opts.describeByWorkflowId?.[workflowId];
+      if (!desc) {
+        throw new Error(`Workflow not found: ${workflowId}`);
+      }
+      return desc;
+    },
+    async fetchHistory(): Promise<{ events?: MockHistoryEvent[] }> {
+      return { events: opts.historyByWorkflowId?.[workflowId] ?? [] };
+    },
+    async signal(signalName: string): Promise<void> {
+      calls.signalCalls.push({ workflowId, signalName });
+    },
+    async cancel(): Promise<void> {
+      calls.cancelCalls.push({ workflowId });
+    },
+    async result(): Promise<unknown> {
+      return undefined;
+    },
+  });
+
+  return {
+    client: {
+      workflow: {
+        async start(workflowFn: unknown, startOpts: Record<string, unknown>) {
+          calls.startCalls.push({ workflowFn, opts: startOpts });
+          const workflowId = String(startOpts.workflowId ?? "mock-wf");
+          return {
+            workflowId,
+            firstExecutionRunId: "mock-run-id",
+            ...makeHandle(workflowId),
+          };
+        },
+        getHandle(workflowId: string) {
+          return makeHandle(workflowId);
+        },
+        list(_listOpts?: Record<string, unknown>): AsyncIterable<MockWorkflowSummary> {
+          const items = opts.list ?? [];
+          return (async function* () {
+            for (const item of items) yield item;
+          })();
+        },
+      },
+    },
+    calls,
+  };
+}

--- a/packages/test-utils/src/mock-temporal-client.ts
+++ b/packages/test-utils/src/mock-temporal-client.ts
@@ -115,11 +115,7 @@ export function createMockTemporalClient(opts: MockTemporalClientOptions = {}): 
         async start(workflowFn: unknown, startOpts: Record<string, unknown>) {
           calls.startCalls.push({ workflowFn, opts: startOpts });
           const workflowId = String(startOpts.workflowId ?? "mock-wf");
-          return {
-            workflowId,
-            firstExecutionRunId: "mock-run-id",
-            ...makeHandle(workflowId),
-          };
+          return { ...makeHandle(workflowId), firstExecutionRunId: "mock-run-id" };
         },
         getHandle(workflowId: string) {
           return makeHandle(workflowId);


### PR DESCRIPTION
## Summary

Closes #29. Goes from **0 tests** on `cli/handlers/{state,run,graph}.ts` and the state internals to a layered, mock-backed test surface that makes the area refactorable. Six new test files + two mock factories + a small pre-existing-bug fix that surfaced during the work.

## Coverage delta

| Source file | LOC | Before | After |
|---|---|---|---|
| `packages/core/src/state/digest.ts` | 88 | 0 tests | 11 tests |
| `packages/core/src/state/snapshot.ts` | 179 | 0 tests | 6 tests |
| `packages/core/src/state/git.ts` | 317 | 0 tests | 7 tests |
| `packages/core/src/cli/handlers/state.ts` | 374 | 3 tests (from #32) | 14 tests |
| `packages/core/src/cli/handlers/graph.ts` | 23 | 0 tests | 5 tests |
| `packages/core/src/cli/handlers/run.ts` | 453 | 0 tests | 13 tests |

Workspace test totals: **1434 → 1493** (+59 new tests).

## Commits

1. `chore(test-utils): add mockTemporalClient factory` — configurable describe/history/list responses + `mock.calls` recorder for signal/cancel/start. 6 self-tests.
2. `test(state): cover digest + snapshot internals` — pure-function and orchestration tests using the existing `mockPlugin` factory.
3. `test(state/git): orphan-branch operations against a real temp git repo` — uses `withTestDir` + `git init`. **Found and fixed a pre-existing dead-call hang** in `writeSnapshot`: a `git hash-object -w --stdin` invocation with nothing piped to stdin that hung tests forever. The actual blob write happens via the shell-pipeline call directly below it; the dead call was harmless in production where the chant CLI inherits a closed-stdin terminal but blocked test contexts.
4. `test(cli): graph handler + extended state handler coverage` — covers `runStateSnapshot/Show/Log/Unknown` (existing `--live` diff tests preserved) and the small `runGraph` handler.
5. `test(cli): cover run handlers with mockTemporalClient` — covers `runOpList/Status/Log/Signal/Cancel` happy paths and error paths.

## Intentionally out of scope

**`runOp` itself** — the main `chant run <name>` command — is not covered. It spawns a worker subprocess (`spawn(['npx', 'tsx', ...])`) and connects to a live Temporal server. Mocking those side effects is a much bigger harness than the rest of the run handlers needed, and would partly duplicate `examples/temporal-self-hosted` smoke testing. Worth a follow-up issue if priorities shift.

## Verification

- `just build` clean
- `npx vitest run` → 1493/1493 pass (workspace-wide)
- All new test files follow the structure of `packages/core/src/cli/commands/build.test.ts`

## Mock factories now available from `@intentius/chant-test-utils`

- `createMockPlugin({ name, describeResources?, ... })` — added in #32, expanded usage here
- `createMockTemporalClient({ describeByWorkflowId?, historyByWorkflowId?, list?, describeError? })` — new in this PR; consumed by `run.test.ts`

## Test plan

- [ ] CI green
- [ ] Coverage report shows nonzero coverage on each of the six target files (per `npx vitest run --coverage`)