### PR TITLE
feat(state): atomic snapshot push via --force-with-lease (#30)

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -72,6 +72,17 @@ Lexicons that don't yet implement `describeResources()` are warn-skipped — `--
 
 The Temporal lexicon resolves its connection via the chant config: `state snapshot <env>` (or `--live` against `<env>`) looks up `temporal.profiles.<env>` in your `chant.config.ts` and falls back to `temporal.defaultProfile`. The same profile model is used by `chant run`. Server-side identifiers are used as the resource keys (e.g. `namespace/prod`, `searchAttribute/prod/Project`, `schedule/prod/daily-report`).
 
+### Concurrent snapshots
+
+Snapshots are pushed to the orphan `chant/state` branch with `git push --force-with-lease`. If two operators (or a CI job + a human) take a snapshot for the same remote at the same time, the second push is **rejected** rather than silently overwriting the first. You'll see:
+
+```
+error: Another snapshot completed for chant/state after this run started (env: prod).
+hint:  Pull and retry: `git fetch origin chant/state:chant/state` && `chant state snapshot prod`.
+```
+
+Pull the remote ref and re-run — the first snapshot is preserved, the second proceeds against the updated baseline.
+
 ### `state log [env]`
 
 List the history of snapshots. Omit `env` to show all environments.

--- a/packages/core/src/cli/handlers/state.ts
+++ b/packages/core/src/cli/handlers/state.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 import { build } from "../../build";
 import { takeSnapshot } from "../../state/snapshot";
-import { readSnapshot, readEnvironmentSnapshots, listSnapshots, fetchState } from "../../state/git";
+import { readSnapshot, readEnvironmentSnapshots, listSnapshots, fetchState, StaleStateBranchError } from "../../state/git";
 import { computeBuildDigest, diffDigests } from "../../state/digest";
 import { diffLive, type LiveDiffResult } from "../../state/live-diff";
 import { loadChantConfig } from "../../config";
@@ -58,7 +58,19 @@ export async function runStateSnapshot(ctx: CommandContext): Promise<number> {
     return 1;
   }
 
-  const result = await takeSnapshot(environment, pluginsWithDescribe, buildResult);
+  let result;
+  try {
+    result = await takeSnapshot(environment, pluginsWithDescribe, buildResult);
+  } catch (err) {
+    if (err instanceof StaleStateBranchError) {
+      console.error(formatError({
+        message: `Another snapshot completed for chant/state after this run started (env: ${environment}).`,
+        hint: `Pull and retry: \`git fetch origin ${"chant/state"}:${"chant/state"}\` && \`chant state snapshot ${environment}\`.`,
+      }));
+      return 1;
+    }
+    throw err;
+  }
 
   for (const w of result.warnings) {
     console.error(formatWarning({ message: w }));

--- a/packages/core/src/state/git.test.ts
+++ b/packages/core/src/state/git.test.ts
@@ -9,6 +9,8 @@ import {
   readEnvironmentSnapshots,
   listSnapshots,
   getHeadCommit,
+  pushState,
+  StaleStateBranchError,
 } from "./git";
 
 function git(args: string[], cwd: string): { stdout: string; exitCode: number } {
@@ -98,5 +100,92 @@ describe("state/git", () => {
       const head = await getHeadCommit({ cwd: dir });
       expect(head).toMatch(/^[0-9a-f]{40}$/);
     });
+  });
+
+  // ── Concurrent push rejection (#30) ─────────────────────────────────────────
+
+  /**
+   * Build a "remote ↔ clone" pair where `clone` has `remote` configured as
+   * `origin`. Returns the clone path; the caller writes snapshots there.
+   */
+  async function setupClonePair(): Promise<{ clonePath: string; remotePath: string; cleanup: () => Promise<void> }> {
+    const remotePath = join(import.meta.dirname ?? "/tmp", `chant-state-remote-${Date.now()}-${Math.random()}`);
+    const clonePath = join(import.meta.dirname ?? "/tmp", `chant-state-clone-${Date.now()}-${Math.random()}`);
+    const { mkdir, rm } = await import("node:fs/promises");
+    await mkdir(remotePath, { recursive: true });
+    git(["init", "-q", "--bare", "-b", "main"], remotePath);
+    git(["clone", "-q", remotePath, clonePath], import.meta.dirname ?? "/tmp");
+    git(["config", "user.email", "test@chant.dev"], clonePath);
+    git(["config", "user.name", "Test"], clonePath);
+    writeFileSync(join(clonePath, "README.md"), "fixture\n");
+    git(["add", "README.md"], clonePath);
+    git(["commit", "-q", "-m", "init"], clonePath);
+    git(["push", "-q", "origin", "main"], clonePath);
+    return {
+      clonePath,
+      remotePath,
+      cleanup: async () => {
+        await rm(remotePath, { recursive: true, force: true });
+        await rm(clonePath, { recursive: true, force: true });
+      },
+    };
+  }
+
+  test("first push to remote succeeds (no remote ref yet)", async () => {
+    const { clonePath, cleanup } = await setupClonePair();
+    try {
+      await writeSnapshot("prod", "aws", JSON.stringify({ a: 1 }), { cwd: clonePath });
+      const ok = await pushState({ cwd: clonePath });
+      expect(ok).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("subsequent push from same clone (after fetch) succeeds via lease", async () => {
+    const { clonePath, cleanup } = await setupClonePair();
+    try {
+      await writeSnapshot("prod", "aws", JSON.stringify({ a: 1 }), { cwd: clonePath });
+      expect(await pushState({ cwd: clonePath })).toBe(true);
+
+      // Pull the remote ref into local remote-tracking, then commit + push again
+      git(["fetch", "-q", "origin", "+refs/heads/chant/state:refs/remotes/origin/chant/state"], clonePath);
+      await writeSnapshot("prod", "aws", JSON.stringify({ a: 2 }), { cwd: clonePath });
+      expect(await pushState({ cwd: clonePath })).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("concurrent write rejected: second push throws StaleStateBranchError", async () => {
+    // Simulate two concurrent operators by setting up two clones of the same remote.
+    const { clonePath: cloneA, remotePath, cleanup } = await setupClonePair();
+    const cloneB = join(import.meta.dirname ?? "/tmp", `chant-state-clone-b-${Date.now()}-${Math.random()}`);
+    try {
+      git(["clone", "-q", remotePath, cloneB], import.meta.dirname ?? "/tmp");
+      git(["config", "user.email", "test@chant.dev"], cloneB);
+      git(["config", "user.name", "Test"], cloneB);
+
+      // Operator A writes + pushes first.
+      await writeSnapshot("prod", "aws", JSON.stringify({ a: 1 }), { cwd: cloneA });
+      expect(await pushState({ cwd: cloneA })).toBe(true);
+
+      // Operator B writes from the same baseline (chant/state doesn't exist
+      // on cloneB's remote-tracking yet) and tries to push — should fail
+      // with StaleStateBranchError because A's push moved the remote ref.
+      await writeSnapshot("staging", "gcp", JSON.stringify({ b: 2 }), { cwd: cloneB });
+      await expect(pushState({ cwd: cloneB })).rejects.toBeInstanceOf(StaleStateBranchError);
+    } finally {
+      await cleanup();
+      const { rm } = await import("node:fs/promises");
+      await rm(cloneB, { recursive: true, force: true });
+    }
+  });
+
+  test("StaleStateBranchError carries the expected SHA used as the lease", async () => {
+    const err = new StaleStateBranchError(null, "stale info: ...");
+    expect(err.name).toBe("StaleStateBranchError");
+    expect(err.expected).toBeNull();
+    expect(err.message).toContain("moved");
   });
 });

--- a/packages/core/src/state/git.ts
+++ b/packages/core/src/state/git.ts
@@ -174,20 +174,77 @@ export async function listSnapshots(
 }
 
 /**
- * Push the state branch to remote.
+ * Thrown by pushState when the remote chant/state branch has moved since
+ * the local snapshot was prepared — i.e. another snapshot for this or a
+ * different env was pushed concurrently. The caller should fetch and retry.
+ */
+export class StaleStateBranchError extends Error {
+  readonly expected: string | null;
+  constructor(expected: string | null, stderr: string) {
+    super(
+      "chant/state remote branch has moved since this run started — " +
+      "another snapshot was pushed concurrently. " +
+      `git stderr: ${stderr.trim()}`,
+    );
+    this.name = "StaleStateBranchError";
+    this.expected = expected;
+  }
+}
+
+/**
+ * Look up the remote-tracking SHA for chant/state, if any. Returns null when
+ * the remote ref doesn't exist locally yet (e.g. first-ever snapshot).
+ */
+export async function getRemoteStateBranchSha(
+  remote: string,
+  opts?: { cwd?: string },
+): Promise<string | null> {
+  const rt = getRuntime();
+  const ref = `refs/remotes/${remote}/${STATE_BRANCH}`;
+  const result = await rt.spawn(["git", "rev-parse", "--verify", ref], { cwd: opts?.cwd });
+  if (result.exitCode !== 0) return null;
+  return result.stdout.trim() || null;
+}
+
+/**
+ * Push the state branch to remote with --force-with-lease.
+ *
+ * If the remote chant/state ref has advanced past the local remote-tracking
+ * SHA captured at the start of this push, the push is rejected and we throw
+ * StaleStateBranchError so the caller can surface a recovery hint.
+ *
+ * Returns false (without throwing) only when no remote is configured at all.
  */
 export async function pushState(opts?: { cwd?: string }): Promise<boolean> {
   const rt = getRuntime();
-  // Check if remote exists
   const remoteResult = await rt.spawn(["git", "remote"], { cwd: opts?.cwd });
   if (remoteResult.exitCode !== 0 || !remoteResult.stdout.trim()) return false;
 
   const remote = remoteResult.stdout.trim().split("\n")[0];
+
+  // Capture the lease SHA — if null, the remote ref doesn't exist yet
+  // (first-time push) and we send `--force-with-lease=ref:` (empty SHA),
+  // which git interprets as "ref does not exist on remote".
+  const expected = await getRemoteStateBranchSha(remote, opts);
+  const lease = `refs/heads/${STATE_BRANCH}:${expected ?? ""}`;
+
   const pushResult = await rt.spawn(
-    ["git", "push", remote, `${STATE_BRANCH}:${STATE_BRANCH}`],
+    ["git", "push", `--force-with-lease=${lease}`, remote, `${STATE_BRANCH}:${STATE_BRANCH}`],
     { cwd: opts?.cwd },
   );
-  return pushResult.exitCode === 0;
+
+  if (pushResult.exitCode !== 0) {
+    const stderr = pushResult.stderr ?? "";
+    if (
+      stderr.includes("stale info") ||
+      stderr.includes("rejected") ||
+      stderr.includes("non-fast-forward")
+    ) {
+      throw new StaleStateBranchError(expected, stderr);
+    }
+    return false;
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #30. Snapshots are now pushed to `chant/state` with `git push --force-with-lease` against the local remote-tracking SHA captured before the push. If two operators (or a CI job + a human) take a snapshot at the same time, the second push is **rejected** rather than silently overwriting the first.

```
error: Another snapshot completed for chant/state after this run started (env: prod).
hint:  Pull and retry: `git fetch origin chant/state:chant/state` && `chant state snapshot prod`.
```

## Implementation

- New `StaleStateBranchError` class exported from `state/git.ts` carrying the expected (lease) SHA.
- `pushState()` now captures the remote-tracking SHA via `git rev-parse refs/remotes/<remote>/chant/state` and pushes with `--force-with-lease=refs/heads/chant/state:<expected-sha>`. First-ever pushes (no remote ref yet) use an empty SHA in the lease, which git interprets as "ref does not exist on remote".
- Lease-failure detection inspects stderr for `stale info`, `rejected`, or `non-fast-forward` and translates to `StaleStateBranchError`. Non-lease push failures (network, auth) still return `false` as before.
- `runStateSnapshot` catches the structured error and emits the recovery hint with exit 1.

## Test coverage

Adds 4 new cases to `state/git.test.ts` using a real bare remote + two clones to simulate concurrent operators:

| Test | What it verifies |
|---|---|
| First push to remote succeeds (no remote ref) | Empty-SHA lease accepted |
| Subsequent push from same clone (after fetch) succeeds via lease | Normal flow |
| Concurrent write from a second clone is rejected with `StaleStateBranchError` | The race-prevention guarantee |
| `StaleStateBranchError` shape (name, expected, message) | Error class contract |

## Verification

- `just build` clean
- `npx vitest run packages/core/` → 1445/1445 pass (4 new tests)
- Pre-existing 7 git tests still green

## Out of scope

Per-env advisory lock files (a finer-grained mechanism than branch-level lease) — flagged in #30 as optional follow-up; not implemented here.

## Test plan

- [ ] CI green