### PR TITLE
fix(cli/build): mkdir -p for output paths (#38)

### DIFF
--- a/packages/core/src/cli/commands/build.test.ts
+++ b/packages/core/src/cli/commands/build.test.ts
@@ -132,18 +132,71 @@ export const testEntity = {
     expect(result.fileCount).toBeDefined();
   });
 
-  test("handles invalid output path", async () => {
+  test("creates parent directories for the primary output path (#38)", async () => {
+    // Write into a nested temp path whose parent dirs don't yet exist —
+    // chant build should mkdir -p the parents rather than fail with ENOENT.
+    const nestedOutput = join(testDir, "deep", "nested", "out", "file.json");
+
     const options: BuildOptions = {
       path: testDir,
-      output: "/nonexistent/directory/file.json",
+      output: nestedOutput,
       format: "json",
       serializers: [mockSerializer],
     };
 
     const result = await buildCommand(options);
 
-    // Should report error about output file
-    expect(result.errors.length).toBeGreaterThan(0);
-    expect(result.errors.some((e) => e.includes("output"))).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(existsSync(nestedOutput)).toBe(true);
+  });
+
+  test("creates parent directories for nested additional-files (#38)", async () => {
+    // Simulate a multi-file serializer (like the Op codegen) that emits
+    // additional files under nested subpaths.
+    const multiFileSerializer: Serializer = {
+      name: "multi",
+      rulePrefix: "MULTI",
+      serialize: () => ({
+        primary: "{}",
+        files: {
+          "ops/alb-deploy/workflow.ts": "// workflow\n",
+          "ops/alb-deploy/activities.ts": "// activities\n",
+          "ops/alb-deploy/worker.ts": "// worker\n",
+        },
+      }),
+    };
+
+    // Need at least one entity in the "multi" lexicon so the build pipeline
+    // invokes the serializer and the additional files surface.
+    await writeFile(
+      join(testDir, "infra.ts"),
+      [
+        `export const x = {`,
+        `  [Symbol.for("chant.declarable")]: true,`,
+        `  entityType: "X",`,
+        `  lexicon: "multi",`,
+        `  kind: "resource",`,
+        `  props: {},`,
+        `  attributes: {},`,
+        `};`,
+      ].join("\n"),
+    );
+
+    const outputPath = join(testDir, "dist", "manifest.json");
+
+    const options: BuildOptions = {
+      path: testDir,
+      output: outputPath,
+      format: "json",
+      serializers: [multiFileSerializer],
+    };
+
+    const result = await buildCommand(options);
+
+    expect(result.errors).toEqual([]);
+    expect(existsSync(outputPath)).toBe(true);
+    expect(existsSync(join(testDir, "dist", "ops", "alb-deploy", "workflow.ts"))).toBe(true);
+    expect(existsSync(join(testDir, "dist", "ops", "alb-deploy", "activities.ts"))).toBe(true);
+    expect(existsSync(join(testDir, "dist", "ops", "alb-deploy", "worker.ts"))).toBe(true);
   });
 });

--- a/packages/core/src/cli/commands/build.ts
+++ b/packages/core/src/cli/commands/build.ts
@@ -5,7 +5,7 @@ import { runPostSynthChecks } from "../../lint/post-synth";
 import type { PostSynthCheck } from "../../lint/post-synth";
 import { sortedJsonReplacer } from "../../utils";
 import { formatError, formatWarning, formatSuccess, formatBold, formatInfo } from "../format";
-import { writeFileSync } from "fs";
+import { writeFileSync, mkdirSync } from "fs";
 import { resolve, dirname, join } from "path";
 import { watchDirectory, formatTimestamp, formatChangedFiles } from "../watch";
 
@@ -188,9 +188,11 @@ export async function buildCommand(options: BuildOptions): Promise<BuildResult> 
     }
 
     if (options.output) {
-      // Write to file
+      // Write to file — ensure parent directories exist for both the primary
+      // output path and any nested additional-file paths (e.g. ops/<name>/...).
       try {
         const outputPath = resolve(options.output);
+        mkdirSync(dirname(outputPath), { recursive: true });
         writeFileSync(outputPath, output);
 
         // Write additional files (e.g. nested stack templates) alongside the primary output
@@ -208,7 +210,9 @@ export async function buildCommand(options: BuildOptions): Promise<BuildResult> 
             } catch {
               // If not JSON, write as-is
             }
-            writeFileSync(join(outputDir, filename), fileContent);
+            const targetPath = join(outputDir, filename);
+            mkdirSync(dirname(targetPath), { recursive: true });
+            writeFileSync(targetPath, fileContent);
           }
         }
       } catch (err) {


### PR DESCRIPTION
## Summary

Closes #38. `chant build` was dying with `ENOENT: no such file or directory` whenever the user passed `-o /some/dir/out.json` without pre-creating `/some/dir`, or when a multi-file serializer (Op codegen) emitted nested files like `ops/<name>/workflow.ts`.

Fix: wrap both `writeFileSync` call sites in `cli/commands/build.ts` (primary output + the additional-files loop) with `mkdirSync(dirname(target), { recursive: true })`.

## Why this was visible

Hit during the manual smoke for #28 — building `examples/gitlab-aws-alb-op/ops` against `/tmp/alb-out` failed until I manually `mkdir -p /tmp/alb-out/ops/alb-deploy/`.

## Tests

Two new cases in `cli/commands/build.test.ts`:
- Primary output path under non-existent parent dirs → succeeds, file written
- Multi-file serializer (matches the Op codegen shape) producing `ops/<name>/{workflow,activities,worker}.ts` into a fresh `dist/` → all four files written

Also replaces an old test that asserted nonexistent output dirs *should* fail — that's the bug this PR fixes.

## Verification

- `just build` clean
- `npx vitest run packages/core/` → 1446/1446 pass