### PR TITLE
feat(state): pass entity props through describeResources() (#39)

### DIFF
--- a/lexicons/temporal/src/describe-resources.test.ts
+++ b/lexicons/temporal/src/describe-resources.test.ts
@@ -130,7 +130,7 @@ describe("describeResources", () => {
     });
     setupClientMock(connection, client);
 
-    const result = await describeResources({ environment: "dev", buildOutput: "", entityNames: [] });
+    const result = await describeResources({ environment: "dev", buildOutput: "", entityNames: [], entities: new Map() });
 
     expect(Object.keys(result).sort()).toEqual([
       "namespace/default",
@@ -155,7 +155,7 @@ describe("describeResources", () => {
     });
     setupClientMock(connection, client);
 
-    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: [] });
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: [], entities: new Map() });
 
     expect(result["namespace/prod"]).toEqual({
       type: "Temporal::Namespace",
@@ -191,7 +191,7 @@ describe("describeResources", () => {
       Client: vi.fn() as unknown as new () => unknown,
     });
 
-    await expect(describeResources({ environment: "dev", buildOutput: "", entityNames: [] }))
+    await expect(describeResources({ environment: "dev", buildOutput: "", entityNames: [], entities: new Map() }))
       .rejects.toThrow(/UNAVAILABLE/);
   });
 
@@ -200,7 +200,7 @@ describe("describeResources", () => {
     const client = fakeClient({});
     setupClientMock(connection, client);
 
-    const result = await describeResources({ environment: "dev", buildOutput: "", entityNames: [] });
+    const result = await describeResources({ environment: "dev", buildOutput: "", entityNames: [], entities: new Map() });
 
     expect(result).toEqual({});
   });
@@ -220,7 +220,7 @@ describe("describeResources", () => {
     });
     setupClientMock(connection, client);
 
-    const result = await describeResources({ environment: "dev", buildOutput: "", entityNames: [] });
+    const result = await describeResources({ environment: "dev", buildOutput: "", entityNames: [], entities: new Map() });
 
     // Both namespaces present
     expect(result["namespace/broken"]).toBeDefined();
@@ -233,5 +233,96 @@ describe("describeResources", () => {
     // Warnings emitted
     expect(warnSpy).toHaveBeenCalledTimes(2);
     warnSpy.mockRestore();
+  });
+
+  // ── Round-trip mapping via entity props (#39) ───────────────────────────────
+
+  test("maps server-side namespace back to chant entity name when props.name matches", async () => {
+    const connection = fakeConnection({
+      namespaces: [{ name: "prod" }],
+      searchAttributesByNs: {},
+      schedulesByNs: {},
+    });
+    const client = fakeClient({});
+    setupClientMock(connection, client);
+
+    const entities = new Map<string, { entityType: string; props: Record<string, unknown> }>([
+      ["prodNs", { entityType: "Temporal::Namespace", props: { name: "prod", retention: "30d" } }],
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["prodNs"], entities });
+
+    expect(result["prodNs"]).toBeDefined();
+    expect(result["namespace/prod"]).toBeUndefined();
+    expect(result["prodNs"].physicalId).toBe("prod");
+  });
+
+  test("maps SearchAttribute back to chant entity name via props.name + props.namespace", async () => {
+    const connection = fakeConnection({
+      namespaces: [{ name: "prod" }],
+      searchAttributesByNs: { prod: { Project: 2, OtherAttr: 1 } },
+      schedulesByNs: {},
+    });
+    const client = fakeClient({});
+    setupClientMock(connection, client);
+
+    const entities = new Map<string, { entityType: string; props: Record<string, unknown> }>([
+      ["projectAttr", { entityType: "Temporal::SearchAttribute", props: { name: "Project", type: "Keyword", namespace: "prod" } }],
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["projectAttr"], entities });
+
+    expect(result["projectAttr"]).toBeDefined();
+    expect(result["searchAttribute/prod/Project"]).toBeUndefined();
+    // Undeclared attr → orphan key (server-side prefix)
+    expect(result["searchAttribute/prod/OtherAttr"]).toBeDefined();
+  });
+
+  test("maps Schedule back to chant entity name via props.scheduleId", async () => {
+    const connection = fakeConnection({
+      namespaces: [{ name: "prod" }],
+      searchAttributesByNs: {},
+      schedulesByNs: {},
+    });
+    const client = fakeClient({
+      schedulesByNs: {
+        prod: [
+          { scheduleId: "daily-report", workflowType: "reportWf" },
+          { scheduleId: "weekly-cleanup", workflowType: "cleanupWf" },
+        ],
+      },
+    });
+    setupClientMock(connection, client);
+
+    const entities = new Map<string, { entityType: string; props: Record<string, unknown> }>([
+      ["dailyReport", { entityType: "Temporal::Schedule", props: { scheduleId: "daily-report", namespace: "prod" } }],
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["dailyReport"], entities });
+
+    expect(result["dailyReport"]).toBeDefined();
+    expect(result["schedule/prod/daily-report"]).toBeUndefined();
+    expect(result["schedule/prod/weekly-cleanup"]).toBeDefined();
+  });
+
+  test("SearchAttribute without explicit namespace falls back to first declared namespace's name", async () => {
+    const connection = fakeConnection({
+      namespaces: [{ name: "prod" }],
+      searchAttributesByNs: { prod: { Project: 2 } },
+      schedulesByNs: {},
+    });
+    const client = fakeClient({});
+    setupClientMock(connection, client);
+
+    const entities = new Map<string, { entityType: string; props: Record<string, unknown> }>([
+      ["prodNs", { entityType: "Temporal::Namespace", props: { name: "prod" } }],
+      // No namespace prop on the attribute — should default to "prod"
+      ["projectAttr", { entityType: "Temporal::SearchAttribute", props: { name: "Project", type: "Keyword" } }],
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["prodNs", "projectAttr"], entities });
+
+    expect(result["projectAttr"]).toBeDefined();
+    expect(result["searchAttribute/prod/Project"]).toBeUndefined();
   });
 });

--- a/lexicons/temporal/src/describe-resources.ts
+++ b/lexicons/temporal/src/describe-resources.ts
@@ -139,19 +139,81 @@ async function paginateNamespaces(connection: RichConnection): Promise<NonNullab
   return all;
 }
 
-export async function describeResources(_options: {
+/**
+ * Build reverse-lookup maps from server-side identifiers back to chant
+ * entity names, using the `entities` map passed via the plugin contract.
+ *
+ * Mapping rules:
+ *   - Namespace:       props.name              -> entity name
+ *   - SearchAttribute: <ns>/<props.name>       -> entity name
+ *   - Schedule:        <ns>/<props.scheduleId> -> entity name
+ *
+ * For SearchAttribute, the namespace defaults to the *first declared
+ * Temporal::Namespace's name* if the entity itself doesn't pin one — this
+ * matches the serializer's behavior when emitting registration commands.
+ */
+function buildEntityIndex(
+  entities: Map<string, { entityType: string; props: Record<string, unknown> }>,
+): {
+  namespaceByName: Map<string, string>;
+  searchAttrByKey: Map<string, string>;
+  scheduleByKey: Map<string, string>;
+  defaultNamespace?: string;
+} {
+  const namespaceByName = new Map<string, string>();
+  const searchAttrByKey = new Map<string, string>();
+  const scheduleByKey = new Map<string, string>();
+  let defaultNamespace: string | undefined;
+
+  for (const [entityName, { entityType, props }] of entities) {
+    if (entityType === "Temporal::Namespace") {
+      const nsName = (props.name as string) || "";
+      if (nsName) {
+        namespaceByName.set(nsName, entityName);
+        if (!defaultNamespace) defaultNamespace = nsName;
+      }
+    }
+  }
+
+  for (const [entityName, { entityType, props }] of entities) {
+    if (entityType === "Temporal::SearchAttribute") {
+      const attrName = (props.name as string) || "";
+      const ns = (props.namespace as string) || defaultNamespace || "";
+      if (attrName && ns) searchAttrByKey.set(`${ns}/${attrName}`, entityName);
+    } else if (entityType === "Temporal::Schedule") {
+      const scheduleId = (props.scheduleId as string) || "";
+      const ns = (props.namespace as string) || defaultNamespace || "";
+      if (scheduleId && ns) scheduleByKey.set(`${ns}/${scheduleId}`, entityName);
+    }
+  }
+
+  return { namespaceByName, searchAttrByKey, scheduleByKey, defaultNamespace };
+}
+
+export async function describeResources(options: {
   environment: string;
   buildOutput: string;
   entityNames: string[];
+  entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
 }): Promise<Record<string, ResourceMetadata>> {
   const { config } = await loadChantConfig(process.cwd());
-  const profile = resolveProfileForEnv(config as Record<string, unknown>, _options.environment);
+  const profile = resolveProfileForEnv(config as Record<string, unknown>, options.environment);
 
   const mod = (await loadTemporalClient()) as unknown as RichClientModule;
   const connection = await mod.Connection.connect(connectionOptions(profile));
   const client = new mod.Client({ connection });
 
+  const idx = buildEntityIndex(options.entities);
   const result: Record<string, ResourceMetadata> = {};
+
+  // Map a server-side identifier to a chant entity name when possible;
+  // otherwise fall back to the server-side prefixed key (orphan).
+  const keyForNamespace = (name: string): string =>
+    idx.namespaceByName.get(name) ?? `namespace/${name}`;
+  const keyForSearchAttr = (ns: string, attr: string): string =>
+    idx.searchAttrByKey.get(`${ns}/${attr}`) ?? `searchAttribute/${ns}/${attr}`;
+  const keyForSchedule = (ns: string, scheduleId: string): string =>
+    idx.scheduleByKey.get(`${ns}/${scheduleId}`) ?? `schedule/${ns}/${scheduleId}`;
 
   try {
     const namespaces = await paginateNamespaces(connection);
@@ -160,7 +222,7 @@ export async function describeResources(_options: {
       const name = ns.namespaceInfo?.name;
       if (!name) continue;
 
-      result[`namespace/${name}`] = {
+      result[keyForNamespace(name)] = {
         type: "Temporal::Namespace",
         physicalId: name,
         status: namespaceStateToString(ns.namespaceInfo?.state),
@@ -176,7 +238,7 @@ export async function describeResources(_options: {
       try {
         const sa = await connection.operatorService.listSearchAttributes({ namespace: name });
         for (const [attrName, valueType] of Object.entries(sa.customAttributes ?? {})) {
-          result[`searchAttribute/${name}/${attrName}`] = {
+          result[keyForSearchAttr(name, attrName)] = {
             type: "Temporal::SearchAttribute",
             physicalId: `${name}/${attrName}`,
             status: "REGISTERED",
@@ -199,7 +261,7 @@ export async function describeResources(_options: {
       try {
         for await (const s of client.scheduleClient.list({ namespace: name })) {
           if (!s.scheduleId) continue;
-          result[`schedule/${name}/${s.scheduleId}`] = {
+          result[keyForSchedule(name, s.scheduleId)] = {
             type: "Temporal::Schedule",
             physicalId: `${name}/${s.scheduleId}`,
             status: s.state?.paused ? "PAUSED" : "ACTIVE",

--- a/packages/core/src/cli/handlers/state.ts
+++ b/packages/core/src/cli/handlers/state.ts
@@ -234,9 +234,16 @@ async function runStateDiffLive(args: LiveDiffArgs): Promise<number> {
 
     // Resources declared in this lexicon's slice of the build
     const declared = new Set<string>();
+    const entities = new Map<string, { entityType: string; props: Record<string, unknown> }>();
     for (const [name, entity] of args.buildResult.entities) {
       if (entity.lexicon === lexiconName) {
         declared.add(name);
+        entities.set(name, {
+          entityType: entity.entityType,
+          props: ("props" in entity && entity.props != null
+            ? entity.props
+            : {}) as Record<string, unknown>,
+        });
       }
     }
 
@@ -254,6 +261,7 @@ async function runStateDiffLive(args: LiveDiffArgs): Promise<number> {
         environment: args.environment,
         buildOutput,
         entityNames: Array.from(declared),
+        entities,
       });
     } catch (err) {
       console.error(formatError({

--- a/packages/core/src/lexicon.ts
+++ b/packages/core/src/lexicon.ts
@@ -195,11 +195,24 @@ export interface LexiconPlugin {
   mcpResources?(): McpResourceContribution[];
 
   // State
-  /** Query deployed resources and return API metadata. Opt-in. */
+  /**
+   * Query deployed resources and return API metadata. Opt-in.
+   *
+   * `entities` carries the chant-side entity declarations for this lexicon,
+   * keyed by chant entity name (e.g. the export name from a `*.ts` file).
+   * Implementations that need to map cloud-side names back to chant entity
+   * names (e.g. Temporal — server-side namespace `prod` ↔ chant entity `ns`
+   * declared with `name: "prod"`) read this; implementations that already
+   * have name parity (e.g. AWS CloudFormation logical IDs == chant entity
+   * names) can ignore it.
+   *
+   * `entityNames` is preserved as a convenience for the simple case.
+   */
   describeResources?(options: {
     environment: string;
     buildOutput: string;
     entityNames: string[];
+    entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
   }): Promise<Record<string, ResourceMetadata>>;
 }
 

--- a/packages/core/src/state/snapshot.ts
+++ b/packages/core/src/state/snapshot.ts
@@ -106,11 +106,18 @@ export async function takeSnapshot(
           ? rawOutput
           : (rawOutput as SerializerResult).primary;
 
-    // Get entity names for this lexicon
+    // Get entity names + entity props for this lexicon
     const entityNames: string[] = [];
+    const entities = new Map<string, { entityType: string; props: Record<string, unknown> }>();
     for (const [name, entity] of buildResult.entities) {
       if (entity.lexicon === plugin.name) {
         entityNames.push(name);
+        entities.set(name, {
+          entityType: entity.entityType,
+          props: ("props" in entity && entity.props != null
+            ? entity.props
+            : {}) as Record<string, unknown>,
+        });
       }
     }
 
@@ -119,6 +126,7 @@ export async function takeSnapshot(
         environment,
         buildOutput,
         entityNames,
+        entities,
       });
 
       const { valid, dropped, warnings: validationWarnings } =


### PR DESCRIPTION
## Summary

Closes #39. Extends `LexiconPlugin.describeResources()` with `entities: Map<string, { entityType, props }>` so plugins can map cloud-side identifiers back to chant entity names. Solves the round-trip problem identified during #27 where the Temporal lexicon was forced to use server-side keys (`namespace/prod`) instead of chant entity names.

```ts
describeResources?(options: {
  environment: string;
  buildOutput: string;
  entityNames: string[];
  entities: Map<string, { entityType: string; props: Record<string, unknown> }>;  // ← new
}): Promise<Record<string, ResourceMetadata>>
```

`entityNames` preserved for the simple case. AWS lexicon (CloudFormation logical IDs == chant entity names) continues unchanged.

## Temporal mapping

| Server-side identifier | Chant entity match |
|---|---|
| Namespace `prod` | Entity with `entityType: "Temporal::Namespace"` and `props.name === "prod"` |
| SearchAttribute `prod/Project` | Entity with `entityType: "Temporal::SearchAttribute"` and `props.name === "Project"` + `props.namespace === "prod"` (or default-fallback to first declared namespace) |
| Schedule `prod/daily-report` | Entity with `entityType: "Temporal::Schedule"` and `props.scheduleId === "daily-report"` |

Server-side resources without a matching declaration still surface as orphan keys (`namespace/<name>`, etc.) so `chant state diff --live` correctly reports them as **orphan** (in cloud, not declared) rather than forcing a synthetic mapping.

## Tests

4 new cases in `describe-resources.test.ts`:
- Namespace mapping by `props.name`
- SearchAttribute mapping by `props.name + props.namespace`
- Schedule mapping by `props.scheduleId`
- SearchAttribute namespace fallback to first declared

Plus the 5 existing cases updated to pass `entities: new Map()` (no behavior change since they don't declare entities).

## Verification

- `just build` clean
- `npx vitest run` → 1639/1639 pass

## Test plan

- [ ] CI green
- [ ] After merge, lays the foundation for #42 (per-lexicon `describeResources` rollout)