### PR TITLE
feat(temporal): activity-result search attributes via outcomeAttribute (#41)

### DIFF
--- a/docs/src/content/docs/guide/ops.mdx
+++ b/docs/src/content/docs/guide/ops.mdx
@@ -201,6 +201,31 @@ For an Op with N phases this is **N+1 upsert calls total**. Values are wrapped a
 
 User-provided keys merge over the `OpName` default; if you set `searchAttributes: { OpName: "custom" }` the user value wins.
 
+### Outcome-based search attributes
+
+Activity steps support an optional `outcomeAttribute` field that captures the activity's return value and surfaces it as a workflow search attribute:
+
+```typescript
+phase("Diff", [
+  {
+    kind: "activity",
+    fn: "stateDiff",
+    args: { env: "prod", live: true },
+    // Capture stateDiff's `drifted` field and tag the run Drift=true/false
+    outcomeAttribute: { name: "Drift", from: "drifted" },
+  },
+]),
+```
+
+The serializer turns this into:
+
+```typescript
+const __r0 = await stateDiff({"env":"prod","live":true});
+upsertSearchAttributes({ "Drift": [String(__r0?.drifted)] });
+```
+
+`from` is a dot-path into the return value; when omitted, the whole return value is stringified. Counters are workflow-scoped (`__r0`, `__r1`, ...), and parallel phases destructure `Promise.all` results so each outcome attribute fires after the corresponding activity returns.
+
 ## Continuous observation
 
 Pair an Op with a `TemporalSchedule` to get periodic state observation — a deployment dashboard that catches drift between change windows, not just at the next deploy. The `WatchOp` composite wires the pieces together:
@@ -224,7 +249,7 @@ Generated `workflow.ts` opens with `upsertSearchAttributes({ OpName, Watch: ["tr
 
 Set `live: false` on `WatchOp` to use the digest-only diff (faster, no cloud queries) for environments without `describeResources()` coverage. See [`chant state`](/chant/cli/state/) for the full diff semantics.
 
-> **Drift classification:** `stateDiff` returns the raw diff output rather than a structured `drifted: yes/no` flag — drift filtering today is a "scan workflow event log for the MISSING/ORPHAN/DRIFTED section headers" exercise. A workflow-level `Drift` search attribute would need either an Op codegen extension to feed activity results back into `upsertSearchAttributes` or a small custom workflow; tracked as a follow-up if it becomes important.
+> **Drift classification:** `stateDiff` returns `{ drifted: boolean, output, exitCode }`, and `WatchOp`'s Diff step is declared with `outcomeAttribute: { name: "Drift", from: "drifted" }` so each run is automatically tagged with `Drift = "true"` / `"false"` in the Temporal UI. Filter on `Drift = "true"` to see the runs that detected actual drift.
 
 ## Op dependencies
 

--- a/lexicons/temporal/src/composites/composites.test.ts
+++ b/lexicons/temporal/src/composites/composites.test.ts
@@ -169,6 +169,8 @@ describe("WatchOp: configuration", () => {
     expect(diffStep.fn).toBe("stateDiff");
     expect(snapStep.args).toEqual({ env: "prod" });
     expect(diffStep.args).toEqual({ env: "prod", live: true });
+    // Drift is surfaced as a workflow search attribute via outcomeAttribute (#41)
+    expect(diffStep.outcomeAttribute).toEqual({ name: "Drift", from: "drifted" });
   });
 
   test("auto-emit search attrs include Watch + Env", () => {
@@ -224,6 +226,8 @@ describe("WatchOp: serialization", () => {
     expect(wf).toContain('upsertSearchAttributes({ Phase: ["Snapshot"] });');
     expect(wf).toContain('upsertSearchAttributes({ Phase: ["Diff"] });');
     expect(wf).toContain("stateSnapshot(");
-    expect(wf).toContain("stateDiff(");
+    // Diff result captured + Drift search attribute auto-emitted
+    expect(wf).toContain("const __r0 = await stateDiff(");
+    expect(wf).toContain('upsertSearchAttributes({ "Drift": [String(__r0?.drifted)] });');
   });
 });

--- a/lexicons/temporal/src/composites/watch-op.ts
+++ b/lexicons/temporal/src/composites/watch-op.ts
@@ -74,7 +74,17 @@ export function WatchOp(config: WatchOpConfig): WatchOpResources {
     },
     phases: [
       phase("Snapshot", [activity("stateSnapshot", { env: config.env })]),
-      phase("Diff", [activity("stateDiff", { env: config.env, live })]),
+      phase("Diff", [
+        // outcomeAttribute surfaces stateDiff's `drifted` boolean as a
+        // workflow-level Drift search attribute, making 'show me runs that
+        // detected drift' a one-filter UI query.
+        {
+          kind: "activity",
+          fn: "stateDiff",
+          args: { env: config.env, live },
+          outcomeAttribute: { name: "Drift", from: "drifted" },
+        },
+      ]),
     ],
   });
 

--- a/lexicons/temporal/src/op/activities/state.ts
+++ b/lexicons/temporal/src/op/activities/state.ts
@@ -33,15 +33,33 @@ export interface StateDiffResult {
   output: string;
   /** Process exit code (0 = success). */
   exitCode: number;
+  /**
+   * True when the diff output contains any drift indicators
+   * (MISSING / ORPHAN / DRIFTED / DISAPPEARED section headers from
+   * `chant state diff --live`).
+   */
+  drifted: boolean;
 }
 
 /**
- * Run `chant state diff <env>` and return the output. Read-only; intended
- * for use inside watch/observation workflows. Uses fastIdempotent profile.
+ * Section headers emitted by `chant state diff --live` that indicate a
+ * non-empty drift category. See packages/core/src/cli/handlers/state.ts.
+ */
+const DRIFT_HEADERS = ["MISSING", "ORPHAN", "DISAPPEARED", "DRIFTED"];
+
+function detectDrift(output: string): boolean {
+  return DRIFT_HEADERS.some((h) => output.includes(`${h} (`) || output.includes(`\n${h}`));
+}
+
+/**
+ * Run `chant state diff <env>` and return the output + structured drift
+ * flag. Read-only; intended for use inside watch/observation workflows.
+ * Uses fastIdempotent profile.
  *
- * Does not classify drift itself — callers can scan the output for the
+ * The `drifted` field is computed by scanning the output for any of the
  * MISSING / ORPHAN / DRIFTED / DISAPPEARED section headers documented in
- * cli/state.mdx.
+ * cli/state.mdx. Pair with `outcomeAttribute: { name: "Drift", from: "drifted" }`
+ * on a WatchOp activity step to surface drift as a workflow search attribute.
  */
 export async function stateDiff(args: StateDiffArgs): Promise<StateDiffResult> {
   const liveFlag = args.live ? " --live" : "";
@@ -49,11 +67,11 @@ export async function stateDiff(args: StateDiffArgs): Promise<StateDiffResult> {
     const { stdout, stderr } = await execAsync(`chant state diff ${args.env}${liveFlag}`);
     const output = `${stdout}${stderr}`.trim();
     if (output) console.log(output);
-    return { output, exitCode: 0 };
+    return { output, exitCode: 0, drifted: detectDrift(output) };
   } catch (err) {
     const e = err as { code?: number; stdout?: string; stderr?: string };
     const output = `${e.stdout ?? ""}${e.stderr ?? ""}`.trim();
     if (output) console.error(output);
-    return { output, exitCode: e.code ?? 1 };
+    return { output, exitCode: e.code ?? 1, drifted: detectDrift(output) };
   }
 }

--- a/lexicons/temporal/src/op/op-serializer.test.ts
+++ b/lexicons/temporal/src/op/op-serializer.test.ts
@@ -381,4 +381,128 @@ describe("serializeOps()", () => {
       expect(wf).toContain('upsertSearchAttributes({ Phase: ["Notify"] });');
     });
   });
+
+  // ── outcomeAttribute (#41) ──────────────────────────────────────────────────
+
+  describe("outcomeAttribute auto-emit", () => {
+    it("captures activity result and emits an upsert with from-path", () => {
+      const ops = new Map([
+        makeOp({
+          name: "watch",
+          overview: "watch",
+          phases: [
+            {
+              name: "Diff",
+              steps: [
+                { kind: "activity", fn: "stateDiff", args: { env: "prod" }, outcomeAttribute: { name: "Drift", from: "drifted" } },
+              ],
+            },
+          ],
+        }),
+      ]);
+      const wf = serializeOps(ops)["ops/watch/workflow.ts"];
+      expect(wf).toContain('const __r0 = await stateDiff({"env":"prod"});');
+      expect(wf).toContain('upsertSearchAttributes({ "Drift": [String(__r0?.drifted)] });');
+    });
+
+    it("stringifies whole result when from is omitted", () => {
+      const ops = new Map([
+        makeOp({
+          name: "watch",
+          overview: "watch",
+          phases: [
+            {
+              name: "Check",
+              steps: [
+                { kind: "activity", fn: "checkSomething", outcomeAttribute: { name: "Status" } },
+              ],
+            },
+          ],
+        }),
+      ]);
+      const wf = serializeOps(ops)["ops/watch/workflow.ts"];
+      expect(wf).toContain('upsertSearchAttributes({ "Status": [String(__r0)] });');
+    });
+
+    it("nested from-path uses optional-chain stringify", () => {
+      const ops = new Map([
+        makeOp({
+          name: "watch",
+          overview: "watch",
+          phases: [
+            {
+              name: "Inspect",
+              steps: [
+                { kind: "activity", fn: "deepInspect", outcomeAttribute: { name: "Ok", from: "result.healthy" } },
+              ],
+            },
+          ],
+        }),
+      ]);
+      const wf = serializeOps(ops)["ops/watch/workflow.ts"];
+      expect(wf).toContain('upsertSearchAttributes({ "Ok": [String(__r0?.result?.healthy)] });');
+    });
+
+    it("counter is workflow-scoped: multiple outcome attrs use __r0, __r1, ...", () => {
+      const ops = new Map([
+        makeOp({
+          name: "watch",
+          overview: "watch",
+          phases: [
+            { name: "A", steps: [{ kind: "activity", fn: "first", outcomeAttribute: { name: "FirstResult" } }] },
+            { name: "B", steps: [{ kind: "activity", fn: "second", outcomeAttribute: { name: "SecondResult" } }] },
+          ],
+        }),
+      ]);
+      const wf = serializeOps(ops)["ops/watch/workflow.ts"];
+      expect(wf).toContain("const __r0 = await first(");
+      expect(wf).toContain("const __r1 = await second(");
+      expect(wf).toContain('upsertSearchAttributes({ "FirstResult": [String(__r0)] });');
+      expect(wf).toContain('upsertSearchAttributes({ "SecondResult": [String(__r1)] });');
+    });
+
+    it("activities without outcomeAttribute keep the bare-await form", () => {
+      const ops = new Map([
+        makeOp({
+          name: "mixed",
+          overview: "mixed",
+          phases: [
+            {
+              name: "Mix",
+              steps: [
+                { kind: "activity", fn: "noOutcome" },
+                { kind: "activity", fn: "withOutcome", outcomeAttribute: { name: "Result" } },
+              ],
+            },
+          ],
+        }),
+      ]);
+      const wf = serializeOps(ops)["ops/mixed/workflow.ts"];
+      expect(wf).toContain("await noOutcome({});");
+      expect(wf).toContain("const __r0 = await withOutcome({});");
+    });
+
+    it("parallel phase with outcome attrs destructures Promise.all results", () => {
+      const ops = new Map([
+        makeOp({
+          name: "fan",
+          overview: "fan",
+          phases: [
+            {
+              name: "Parallel",
+              parallel: true,
+              steps: [
+                { kind: "activity", fn: "alpha", outcomeAttribute: { name: "AlphaOk", from: "ok" } },
+                { kind: "activity", fn: "beta", outcomeAttribute: { name: "BetaOk", from: "ok" } },
+              ],
+            },
+          ],
+        }),
+      ]);
+      const wf = serializeOps(ops)["ops/fan/workflow.ts"];
+      expect(wf).toContain("const [__r0, __r1] = await Promise.all([");
+      expect(wf).toContain('upsertSearchAttributes({ "AlphaOk": [String(__r0?.ok)] });');
+      expect(wf).toContain('upsertSearchAttributes({ "BetaOk": [String(__r1?.ok)] });');
+    });
+  });
 });

--- a/lexicons/temporal/src/op/serializer.ts
+++ b/lexicons/temporal/src/op/serializer.ts
@@ -119,6 +119,28 @@ function generateWorkflow(config: OpConfig): string {
   lines.push(`  upsertSearchAttributes(${JSON.stringify(initialAttrs)});`);
   lines.push("");
 
+  // Counter for outcome-attribute capture variables (workflow-scoped).
+  let resultCounter = 0;
+  const nextResultVar = (): string => `__r${resultCounter++}`;
+
+  // Build a `String(<var>?.<from-path>)` fragment from a dot-path.
+  const stringifyFromPath = (varName: string, from?: string): string => {
+    if (!from) return `String(${varName})`;
+    const parts = from.split(".");
+    return `String(${varName}?.${parts.join("?.")})`;
+  };
+
+  // Emit `upsertSearchAttributes({ <name>: [<expr>] })` for an outcome attr.
+  const emitOutcomeUpsert = (
+    step: ActivityStep,
+    varName: string,
+    indent = "  ",
+  ): string | null => {
+    if (!step.outcomeAttribute) return null;
+    const { name, from } = step.outcomeAttribute;
+    return `${indent}upsertSearchAttributes({ ${JSON.stringify(name)}: [${stringifyFromPath(varName, from)}] });`;
+  };
+
   const renderPhases = (phases: PhaseDefinition[]) => {
     for (const phase of phases) {
       const phaseLines: string[] = [];
@@ -129,20 +151,47 @@ function generateWorkflow(config: OpConfig): string {
       const gateSteps = phase.steps.filter(isGateStep);
 
       if (phase.parallel && activitySteps.length > 1) {
-        phaseLines.push("  await Promise.all([");
-        for (const step of activitySteps) {
-          const argsStr = step.args && Object.keys(step.args).length > 0
-            ? JSON.stringify(step.args)
-            : "{}";
-          phaseLines.push(`    ${step.fn}(${argsStr}),`);
+        // Capture results into an array if any step has an outcome attribute,
+        // otherwise just await Promise.all without the destructure.
+        const anyOutcome = activitySteps.some((s) => s.outcomeAttribute);
+        if (anyOutcome) {
+          const vars = activitySteps.map(() => nextResultVar());
+          phaseLines.push(`  const [${vars.join(", ")}] = await Promise.all([`);
+          for (let i = 0; i < activitySteps.length; i++) {
+            const step = activitySteps[i];
+            const argsStr = step.args && Object.keys(step.args).length > 0
+              ? JSON.stringify(step.args)
+              : "{}";
+            phaseLines.push(`    ${step.fn}(${argsStr}),`);
+          }
+          phaseLines.push("  ]);");
+          for (let i = 0; i < activitySteps.length; i++) {
+            const upsert = emitOutcomeUpsert(activitySteps[i], vars[i]);
+            if (upsert) phaseLines.push(upsert);
+          }
+        } else {
+          phaseLines.push("  await Promise.all([");
+          for (const step of activitySteps) {
+            const argsStr = step.args && Object.keys(step.args).length > 0
+              ? JSON.stringify(step.args)
+              : "{}";
+            phaseLines.push(`    ${step.fn}(${argsStr}),`);
+          }
+          phaseLines.push("  ]);");
         }
-        phaseLines.push("  ]);");
       } else {
         for (const step of activitySteps) {
           const argsStr = step.args && Object.keys(step.args).length > 0
             ? JSON.stringify(step.args)
             : "{}";
-          phaseLines.push(`  await ${step.fn}(${argsStr});`);
+          if (step.outcomeAttribute) {
+            const v = nextResultVar();
+            phaseLines.push(`  const ${v} = await ${step.fn}(${argsStr});`);
+            const upsert = emitOutcomeUpsert(step, v);
+            if (upsert) phaseLines.push(upsert);
+          } else {
+            phaseLines.push(`  await ${step.fn}(${argsStr});`);
+          }
         }
       }
 

--- a/packages/core/src/op/types.ts
+++ b/packages/core/src/op/types.ts
@@ -46,6 +46,19 @@ export interface ActivityStep {
    * Default: "fastIdempotent"
    */
   profile?: "fastIdempotent" | "longInfra" | "k8sWait" | "humanGate";
+  /**
+   * Surface this activity's return value as a workflow search attribute.
+   *
+   * The serializer captures the awaited result into a temporary, then emits
+   * `upsertSearchAttributes({ <name>: [String(<from-path>)] })` immediately
+   * after. Useful for filtering runs by outcome (e.g. `Drift: "true"/"false"`
+   * from a stateDiff activity).
+   *
+   * `from` is a dot-path into the return value (e.g. `"drifted"` for
+   * `{ drifted: boolean }`); when omitted, the whole return value is
+   * stringified.
+   */
+  outcomeAttribute?: { name: string; from?: string };
 }
 
 export interface GateStep {


### PR DESCRIPTION
## Summary

Closes #41. Adds `outcomeAttribute?: { name; from? }` to `ActivityStep` so the Op codegen can capture an activity's return value and emit `upsertSearchAttributes` immediately after the awaited call.

```ts
phase("Diff", [
  {
    kind: "activity",
    fn: "stateDiff",
    args: { env: "prod", live: true },
    outcomeAttribute: { name: "Drift", from: "drifted" },
  },
]),
```

Generates:

```ts
const __r0 = await stateDiff({"env":"prod","live":true});
upsertSearchAttributes({ "Drift": [String(__r0?.drifted)] });
```

`from` is a dot-path; omit it to stringify the whole return value. Counter is workflow-scoped (`__r0`, `__r1`, ...). Steps without `outcomeAttribute` keep the bare `await fn(...)` form. Parallel phases destructure `Promise.all` results when any step in the phase has an outcome attribute.

## Closes the deferred follow-up from #37 (`WatchOp`)

`WatchOp`'s Diff step now declares `outcomeAttribute: { name: "Drift", from: "drifted" }`. The `stateDiff` activity gained a `drifted: boolean` field — detected by scanning the diff output for the MISSING / ORPHAN / DISAPPEARED / DRIFTED section headers from `chant state diff --live`. Every scheduled watch run is now filterable in the Temporal UI as `Drift = "true"` / `"false"`.

## Tests

6 new cases in `op-serializer.test.ts`:
- captures activity result and emits upsert with `from` path
- no-`from` stringifies whole result
- nested `from` uses optional-chain
- counter is workflow-scoped (multiple outcome attrs → `__r0`, `__r1`)
- mixed phase (with + without outcome) keeps bare-await for non-outcome
- parallel phase destructures `Promise.all`

WatchOp serialization test updated to assert the captured-result + drift upsert shape.

## Verification

- `just build` clean
- `npx vitest run` → 1645/1645 pass

## Test plan

- [ ] CI green