### PR TITLE
feat(k8s): describeResources via kubectl get (partial #42)

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -68,9 +68,11 @@ Output is grouped into six categories per lexicon:
 
 Drifted entries include attribute-level deltas (`status`, `physicalId`, `lastUpdated`, and each `attributes.*` key).
 
-Lexicons that don't yet implement `describeResources()` are warn-skipped — `--live` doesn't fail the whole command for them. Today, **AWS** and **Temporal** are covered.
+Lexicons that don't yet implement `describeResources()` are warn-skipped — `--live` doesn't fail the whole command for them. Today, **AWS**, **Temporal**, and **K8s** are covered.
 
-The Temporal lexicon resolves its connection via the chant config: `state snapshot <env>` (or `--live` against `<env>`) looks up `temporal.profiles.<env>` in your `chant.config.ts` and falls back to `temporal.defaultProfile`. The same profile model is used by `chant run`. Server-side identifiers are used as the resource keys (e.g. `namespace/prod`, `searchAttribute/prod/Project`, `schedule/prod/daily-report`).
+The Temporal lexicon resolves its connection via the chant config: `state snapshot <env>` (or `--live` against `<env>`) looks up `temporal.profiles.<env>` in your `chant.config.ts` and falls back to `temporal.defaultProfile`. The same profile model is used by `chant run`. With #39's entity-prop pass-through, namespaces/schedules/search-attributes are mapped back to chant entity names when the declared `props.name` (etc.) match the server-side identifier.
+
+The K8s lexicon shells out to `kubectl get <kind> <name> [-n <namespace>] -o json` per declared entity. The cluster context comes from the user's `kubeconfig` — there's no separate profile model. Twenty common resource types (Deployment, Service, ConfigMap, Secret, Namespace, Pod, PVC, ServiceAccount, Job, CronJob, Ingress, NetworkPolicy, RBAC roles + bindings, ReplicaSet, StatefulSet, DaemonSet) are covered out of the box; CRDs and uncommon types are warn-skipped.
 
 ### Concurrent snapshots
 

--- a/lexicons/k8s/src/describe-resources.test.ts
+++ b/lexicons/k8s/src/describe-resources.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, exec: (cmd: string, cb: (err: Error | null, out: { stdout: string; stderr: string }) => void) => {
+    Promise.resolve(execMock(cmd)).then(
+      (out) => cb(null, out),
+      (err) => cb(err as Error, { stdout: "", stderr: "" }),
+    );
+  } };
+});
+
+const { describeResources } = await import("./describe-resources");
+
+function makeEntities(records: Array<{ name: string; entityType: string; props: Record<string, unknown> }>) {
+  return new Map(records.map((r) => [r.name, { entityType: r.entityType, props: r.props }]));
+}
+
+describe("k8s describeResources", () => {
+  beforeEach(() => {
+    execMock.mockReset();
+  });
+
+  test("queries kubectl for each declared K8s entity and maps response to ResourceMetadata", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.includes("deployment.apps web")) {
+        return {
+          stdout: JSON.stringify({
+            metadata: { name: "web", namespace: "prod", uid: "uid-1", creationTimestamp: "2026-05-01T00:00:00Z", labels: { app: "web" } },
+            status: { readyReplicas: 3, replicas: 3 },
+          }),
+          stderr: "",
+        };
+      }
+      if (cmd.includes("service web-svc")) {
+        return {
+          stdout: JSON.stringify({
+            metadata: { name: "web-svc", namespace: "prod", uid: "uid-2", creationTimestamp: "2026-05-01T00:00:00Z" },
+          }),
+          stderr: "",
+        };
+      }
+      throw new Error(`unexpected cmd: ${cmd}`);
+    });
+
+    const entities = makeEntities([
+      { name: "web", entityType: "K8s::Apps::Deployment", props: { metadata: { name: "web", namespace: "prod" } } },
+      { name: "webSvc", entityType: "K8s::Core::Service", props: { metadata: { name: "web-svc", namespace: "prod" } } },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["web", "webSvc"], entities });
+
+    expect(result["web"]).toMatchObject({
+      type: "K8s::Apps::Deployment",
+      physicalId: "uid-1",
+      status: "READY",
+      attributes: expect.objectContaining({ namespace: "prod", labels: { app: "web" } }),
+    });
+    expect(result["webSvc"]).toMatchObject({
+      type: "K8s::Core::Service",
+      physicalId: "uid-2",
+      status: "PRESENT",
+    });
+  });
+
+  test("kubectl-not-found leaves entity out of the result (so state diff reports as missing)", async () => {
+    execMock.mockImplementation(() => { throw new Error('Error from server (NotFound): deployments.apps "missing" not found'); });
+
+    const entities = makeEntities([
+      { name: "missing", entityType: "K8s::Apps::Deployment", props: { metadata: { name: "missing", namespace: "prod" } } },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["missing"], entities });
+
+    expect(result).toEqual({});
+  });
+
+  test("entity types without kubectl mapping are warn-skipped", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const entities = makeEntities([
+      { name: "exotic", entityType: "K8s::Custom::CRD::SomeOperator", props: { metadata: { name: "x" } } },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["exotic"], entities });
+
+    expect(result).toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("kubectl mapping"));
+    expect(warnSpy.mock.calls[0][0]).toContain("K8s::Custom::CRD::SomeOperator");
+    warnSpy.mockRestore();
+  });
+
+  test("Deployment with replicas != readyReplicas reports PROGRESSING", async () => {
+    execMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        metadata: { name: "web", namespace: "prod", uid: "uid", creationTimestamp: "t" },
+        status: { readyReplicas: 1, replicas: 3 },
+      }),
+      stderr: "",
+    });
+
+    const entities = makeEntities([
+      { name: "web", entityType: "K8s::Apps::Deployment", props: { metadata: { name: "web", namespace: "prod" } } },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["web"], entities });
+
+    expect(result["web"].status).toBe("PROGRESSING(1/3)");
+  });
+
+  test("Pod uses status.phase as the status", async () => {
+    execMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        metadata: { name: "p", namespace: "prod", uid: "uid", creationTimestamp: "t" },
+        status: { phase: "Running" },
+      }),
+      stderr: "",
+    });
+
+    const entities = makeEntities([
+      { name: "p", entityType: "K8s::Core::Pod", props: { metadata: { name: "p", namespace: "prod" } } },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["p"], entities });
+
+    expect(result["p"].status).toBe("Running");
+  });
+
+  test("namespace-less resource omits the -n flag", async () => {
+    let receivedCmd = "";
+    execMock.mockImplementation((cmd: string) => {
+      receivedCmd = cmd;
+      return {
+        stdout: JSON.stringify({
+          metadata: { name: "mynamespace", uid: "uid", creationTimestamp: "t" },
+          status: { phase: "Active" },
+        }),
+        stderr: "",
+      };
+    });
+
+    const entities = makeEntities([
+      { name: "ns", entityType: "K8s::Core::Namespace", props: { metadata: { name: "mynamespace" } } },
+    ]);
+
+    await describeResources({ environment: "prod", buildOutput: "", entityNames: ["ns"], entities });
+
+    expect(receivedCmd).not.toContain("-n");
+    expect(receivedCmd).toContain("namespace mynamespace");
+  });
+
+  test("entity without metadata.name is silently skipped", async () => {
+    const entities = makeEntities([
+      { name: "broken", entityType: "K8s::Apps::Deployment", props: {} },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["broken"], entities });
+
+    expect(result).toEqual({});
+    expect(execMock).not.toHaveBeenCalled();
+  });
+});

--- a/lexicons/k8s/src/describe-resources.ts
+++ b/lexicons/k8s/src/describe-resources.ts
@@ -1,0 +1,134 @@
+/**
+ * Live introspection of a Kubernetes cluster — implements the
+ * LexiconPlugin.describeResources() contract for the k8s lexicon.
+ *
+ * For each declared K8s entity, runs `kubectl get <kind> <name> [-n <ns>] -o json`
+ * and maps the response to a ResourceMetadata entry keyed by the chant entity
+ * name (using the props.metadata.name + props.metadata.namespace from #39's
+ * entity-prop pass-through).
+ *
+ * Resource-not-found is silent — `state diff --live` then reports it as
+ * missing (declared, not in cloud). Unknown entity types are warn-skipped;
+ * extending the KUBECTL_RESOURCE map covers more.
+ */
+
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { ResourceMetadata } from "@intentius/chant/lexicon";
+
+const execAsync = promisify(exec);
+
+/**
+ * Map chant entity types to `kubectl get` resource names. Add entries here
+ * as new types are needed.
+ */
+const KUBECTL_RESOURCE: Record<string, string> = {
+  "K8s::Apps::Deployment": "deployment.apps",
+  "K8s::Apps::StatefulSet": "statefulset.apps",
+  "K8s::Apps::DaemonSet": "daemonset.apps",
+  "K8s::Apps::ReplicaSet": "replicaset.apps",
+  "K8s::Core::Service": "service",
+  "K8s::Core::ConfigMap": "configmap",
+  "K8s::Core::Secret": "secret",
+  "K8s::Core::Namespace": "namespace",
+  "K8s::Core::Pod": "pod",
+  "K8s::Core::PersistentVolumeClaim": "persistentvolumeclaim",
+  "K8s::Core::ServiceAccount": "serviceaccount",
+  "K8s::Batch::Job": "job.batch",
+  "K8s::Batch::CronJob": "cronjob.batch",
+  "K8s::Networking::Ingress": "ingress.networking.k8s.io",
+  "K8s::Networking::NetworkPolicy": "networkpolicy.networking.k8s.io",
+  "K8s::Rbac::Role": "role.rbac.authorization.k8s.io",
+  "K8s::Rbac::RoleBinding": "rolebinding.rbac.authorization.k8s.io",
+  "K8s::Rbac::ClusterRole": "clusterrole.rbac.authorization.k8s.io",
+  "K8s::Rbac::ClusterRoleBinding": "clusterrolebinding.rbac.authorization.k8s.io",
+};
+
+interface KubectlResponse {
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    uid?: string;
+    creationTimestamp?: string;
+    labels?: Record<string, string>;
+    resourceVersion?: string;
+  };
+  status?: {
+    phase?: string;
+    [k: string]: unknown;
+  };
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+function statusFromKubectl(obj: KubectlResponse): string {
+  // Different K8s resource types report status differently. Fall back to
+  // "PRESENT" if we can't extract a meaningful field.
+  const phase = obj.status?.phase;
+  if (typeof phase === "string") return phase;
+  // Deployment/StatefulSet — readyReplicas == replicas → READY
+  const status = obj.status as Record<string, unknown> | undefined;
+  if (status && typeof status.readyReplicas === "number" && typeof status.replicas === "number") {
+    return status.readyReplicas === status.replicas ? "READY" : `PROGRESSING(${status.readyReplicas}/${status.replicas})`;
+  }
+  return "PRESENT";
+}
+
+export async function describeResources(options: {
+  environment: string;
+  buildOutput: string;
+  entityNames: string[];
+  entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
+}): Promise<Record<string, ResourceMetadata>> {
+  const result: Record<string, ResourceMetadata> = {};
+  const skippedTypes = new Set<string>();
+
+  for (const [entityName, { entityType, props }] of options.entities) {
+    const kubectlResource = KUBECTL_RESOURCE[entityType];
+    if (!kubectlResource) {
+      skippedTypes.add(entityType);
+      continue;
+    }
+
+    const metadata = props.metadata as { name?: string; namespace?: string } | undefined;
+    const name = metadata?.name;
+    if (!name) continue;
+
+    const nsArg = metadata.namespace ? ["-n", metadata.namespace] : [];
+    const cmd = ["kubectl", "get", kubectlResource, name, ...nsArg, "-o", "json"].join(" ");
+
+    try {
+      const { stdout } = await execAsync(cmd);
+      const obj: KubectlResponse = JSON.parse(stdout);
+      result[entityName] = {
+        type: entityType,
+        physicalId: obj.metadata?.uid,
+        status: statusFromKubectl(obj),
+        lastUpdated: obj.metadata?.creationTimestamp,
+        attributes: pruneUndefined({
+          namespace: obj.metadata?.namespace,
+          labels: obj.metadata?.labels,
+          resourceVersion: obj.metadata?.resourceVersion,
+        }),
+      };
+    } catch {
+      // Resource not found / kubectl error — leave it out so state diff
+      // can report it as missing. Don't fail the whole snapshot.
+    }
+  }
+
+  if (skippedTypes.size > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[k8s] skipped ${skippedTypes.size} entity type(s) without kubectl mapping: ${[...skippedTypes].join(", ")}`,
+    );
+  }
+
+  return result;
+}

--- a/lexicons/k8s/src/plugin.ts
+++ b/lexicons/k8s/src/plugin.ts
@@ -657,4 +657,9 @@ const { deployment, service, serviceMonitor, prometheusRule } = MonitoredService
         ],
       },
     ]),
+
+  async describeResources(options) {
+    const { describeResources } = await import("./describe-resources");
+    return describeResources(options);
+  },
 };


### PR DESCRIPTION
## Summary

Partial progress on #42. Brings the **k8s** lexicon into the snapshot-supported set (previously only AWS + Temporal). Per declared K8s entity, shells out to `kubectl get <kind> <name> [-n <namespace>] -o json` and maps the response to `ResourceMetadata` keyed by chant entity name — possible thanks to #39's entity-prop pass-through.

## Coverage table — updated

| Lexicon | Status this PR |
|---|---|
| aws | ✅ already covered |
| temporal | ✅ already covered |
| **k8s** | **✅ new — this PR** |
| gcp | ❌ TODO |
| azure | ❌ TODO |
| flyway | ❌ TODO |
| slurm | ❌ TODO |
| github | ❌ TODO |
| gitlab | ❌ TODO |
| ~~helm~~ | ⚠️ doesn't fit the contract (chart authoring, not deployed releases) — needs separate model |
| ~~docker~~ | ⚠️ same — Compose/Dockerfile authoring, not running containers |

The **helm** and **docker** lexicons emit *authoring* primitives (chart files, compose files) rather than deployed runtime resources, so they don't fit the `describeResources()` contract the same way other lexicons do. Flagged as a separate model rather than forced to fit.

## What's covered (out of the box, K8s)

20 common resource types:

| Group | Types |
|---|---|
| Apps | Deployment, StatefulSet, DaemonSet, ReplicaSet |
| Core | Service, ConfigMap, Secret, Namespace, Pod, PVC, ServiceAccount |
| Batch | Job, CronJob |
| Networking | Ingress, NetworkPolicy |
| RBAC | Role, RoleBinding, ClusterRole, ClusterRoleBinding |

Other / CRD types are warn-skipped (the lookup map is intentionally extensible — adding a new chant `entityType` → `kubectl` resource name pair is one line).

## Status mapping

| Source | Output |
|---|---|
| `status.phase` (Pods, Namespaces) | the phase string verbatim |
| `readyReplicas == replicas` | `READY` |
| `readyReplicas < replicas` | `PROGRESSING(<ready>/<total>)` |
| anything else | `PRESENT` |

Resource-not-found in the cluster is silent — `state diff --live` then correctly reports it as **missing** (declared, not in cloud).

## Tests

7 unit tests in `lexicons/k8s/src/describe-resources.test.ts` with mocked `exec`:
- Queries kubectl per declared entity, maps response correctly
- Resource not found → entity left out of result
- Unknown entity types → warn-skipped
- Deployment progressing vs ready status
- Pod status from `phase`
- Namespace-less resources omit `-n`
- Missing `metadata.name` silently skipped

## Verification

- `just build` clean
- `npx vitest run` → 2364/2365 pass (1 skipped, unrelated)

## Test plan

- [ ] CI green
- [ ] After merge, `chant state snapshot <env>` against a kubeconfig context will write `<env>/k8s.json` to the orphan branch with one row per declared resource that exists in cluster