### PR TITLE
feat(gcp): describeResources via Config Connector CRDs (partial #42)

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -68,11 +68,13 @@ Output is grouped into six categories per lexicon:
 
 Drifted entries include attribute-level deltas (`status`, `physicalId`, `lastUpdated`, and each `attributes.*` key).
 
-Lexicons that don't yet implement `describeResources()` are warn-skipped — `--live` doesn't fail the whole command for them. Today, **AWS**, **Temporal**, and **K8s** are covered.
+Lexicons that don't yet implement `describeResources()` are warn-skipped — `--live` doesn't fail the whole command for them. Today, **AWS**, **Temporal**, **K8s**, and **GCP** (via Config Connector) are covered.
 
 The Temporal lexicon resolves its connection via the chant config: `state snapshot <env>` (or `--live` against `<env>`) looks up `temporal.profiles.<env>` in your `chant.config.ts` and falls back to `temporal.defaultProfile`. The same profile model is used by `chant run`. With #39's entity-prop pass-through, namespaces/schedules/search-attributes are mapped back to chant entity names when the declared `props.name` (etc.) match the server-side identifier.
 
 The K8s lexicon shells out to `kubectl get <kind> <name> [-n <namespace>] -o json` per declared entity. The cluster context comes from the user's `kubeconfig` — there's no separate profile model. Twenty common resource types (Deployment, Service, ConfigMap, Secret, Namespace, Pod, PVC, ServiceAccount, Job, CronJob, Ingress, NetworkPolicy, RBAC roles + bindings, ReplicaSet, StatefulSet, DaemonSet) are covered out of the box; CRDs and uncommon types are warn-skipped.
+
+The GCP lexicon uses the same `kubectl` shell-out path against [Config Connector](https://cloud.google.com/config-connector) CRDs. The entity type's GVK derivation matches the serializer (`GCP::Storage::Bucket` → `storagebucket.storage.cnrm.cloud.google.com`), so any of the ~300 chant-supported GCP resources work without per-type configuration. `Ready=True` on the resource's status is mapped to `READY`; otherwise the condition's reason is surfaced.
 
 ### Concurrent snapshots
 

--- a/lexicons/gcp/src/describe-resources.test.ts
+++ b/lexicons/gcp/src/describe-resources.test.ts
@@ -1,0 +1,147 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, exec: (cmd: string, cb: (err: Error | null, out: { stdout: string; stderr: string }) => void) => {
+    Promise.resolve(execMock(cmd)).then(
+      (out) => cb(null, out),
+      (err) => cb(err as Error, { stdout: "", stderr: "" }),
+    );
+  } };
+});
+
+const { describeResources } = await import("./describe-resources");
+
+function makeEntities(records: Array<{ name: string; entityType: string; props: Record<string, unknown> }>) {
+  return new Map(records.map((r) => [r.name, { entityType: r.entityType, props: r.props }]));
+}
+
+describe("gcp describeResources (Config Connector)", () => {
+  beforeEach(() => {
+    execMock.mockReset();
+  });
+
+  test("queries kubectl with the derived CC GVK and maps the response", async () => {
+    let receivedCmd = "";
+    execMock.mockImplementation((cmd: string) => {
+      receivedCmd = cmd;
+      return {
+        stdout: JSON.stringify({
+          metadata: { name: "data-bucket", namespace: "config-control", uid: "uid-1", creationTimestamp: "2026-05-01T00:00:00Z" },
+          status: { conditions: [{ type: "Ready", status: "True" }] },
+        }),
+        stderr: "",
+      };
+    });
+
+    const entities = makeEntities([
+      { name: "dataBucket", entityType: "GCP::Storage::Bucket", props: { metadata: { name: "data-bucket", namespace: "config-control" } } },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["dataBucket"], entities });
+
+    // Resource name follows: <lowerKind>.<service>.cnrm.cloud.google.com
+    expect(receivedCmd).toContain("storagebucket.storage.cnrm.cloud.google.com");
+    expect(receivedCmd).toContain("data-bucket");
+    expect(receivedCmd).toContain("-n config-control");
+
+    expect(result["dataBucket"]).toMatchObject({
+      type: "GCP::Storage::Bucket",
+      physicalId: "uid-1",
+      status: "READY",
+    });
+  });
+
+  test("Compute resource derives correct GVK with service prefix", async () => {
+    let receivedCmd = "";
+    execMock.mockImplementation((cmd: string) => {
+      receivedCmd = cmd;
+      return {
+        stdout: JSON.stringify({
+          metadata: { name: "subnet-1", uid: "uid", creationTimestamp: "t" },
+          status: { conditions: [{ type: "Ready", status: "True" }] },
+        }),
+        stderr: "",
+      };
+    });
+
+    const entities = makeEntities([
+      { name: "sub", entityType: "GCP::Compute::Subnetwork", props: { metadata: { name: "subnet-1" } } },
+    ]);
+
+    await describeResources({ environment: "prod", buildOutput: "", entityNames: ["sub"], entities });
+
+    expect(receivedCmd).toContain("computesubnetwork.compute.cnrm.cloud.google.com");
+  });
+
+  test("Ready=False maps to the condition's reason", async () => {
+    execMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        metadata: { name: "x", uid: "uid", creationTimestamp: "t" },
+        status: { conditions: [{ type: "Ready", status: "False", reason: "DependencyNotFound", message: "..." }] },
+      }),
+      stderr: "",
+    });
+
+    const entities = makeEntities([
+      { name: "x", entityType: "GCP::Storage::Bucket", props: { metadata: { name: "x" } } },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["x"], entities });
+
+    expect(result["x"].status).toBe("DependencyNotFound");
+  });
+
+  test("missing Ready condition falls back to PRESENT", async () => {
+    execMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        metadata: { name: "x", uid: "uid", creationTimestamp: "t" },
+        status: {},
+      }),
+      stderr: "",
+    });
+
+    const entities = makeEntities([
+      { name: "x", entityType: "GCP::Storage::Bucket", props: { metadata: { name: "x" } } },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["x"], entities });
+
+    expect(result["x"].status).toBe("PRESENT");
+  });
+
+  test("kubectl-not-found leaves entity out of result", async () => {
+    execMock.mockImplementation(() => { throw new Error('Error from server (NotFound): storagebucket "x" not found'); });
+
+    const entities = makeEntities([
+      { name: "x", entityType: "GCP::Storage::Bucket", props: { metadata: { name: "x" } } },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["x"], entities });
+
+    expect(result).toEqual({});
+  });
+
+  test("non-GCP entity types are skipped", async () => {
+    const entities = makeEntities([
+      { name: "x", entityType: "AWS::S3::Bucket", props: { metadata: { name: "x" } } },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["x"], entities });
+
+    expect(result).toEqual({});
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  test("entity without metadata.name is silently skipped", async () => {
+    const entities = makeEntities([
+      { name: "broken", entityType: "GCP::Storage::Bucket", props: {} },
+    ]);
+
+    const result = await describeResources({ environment: "prod", buildOutput: "", entityNames: ["broken"], entities });
+
+    expect(result).toEqual({});
+    expect(execMock).not.toHaveBeenCalled();
+  });
+});

--- a/lexicons/gcp/src/describe-resources.ts
+++ b/lexicons/gcp/src/describe-resources.ts
@@ -1,0 +1,118 @@
+/**
+ * Live introspection of a GCP project via Config Connector CRDs.
+ *
+ * GCP entities in chant are emitted as Config Connector custom resources
+ * (apiVersion <service>.cnrm.cloud.google.com/v1beta1, kind <Service><Kind>).
+ * To observe them at runtime we shell out to kubectl against a Config
+ * Connector-enabled cluster — the same pattern as the K8s lexicon.
+ *
+ *   GCP::Storage::Bucket    → kubectl get storagebucket.storage.cnrm.cloud.google.com
+ *   GCP::Compute::Subnetwork → kubectl get computesubnetwork.compute.cnrm.cloud.google.com
+ *
+ * Resource-not-found is silent — `state diff --live` reports it as missing.
+ */
+
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { ResourceMetadata } from "@intentius/chant/lexicon";
+
+const execAsync = promisify(exec);
+
+interface KubectlResponse {
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    uid?: string;
+    creationTimestamp?: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  status?: {
+    conditions?: Array<{ type?: string; status?: string; reason?: string; message?: string }>;
+    [k: string]: unknown;
+  };
+}
+
+/**
+ * Mirror of `lexicons/gcp/src/serializer.ts:deriveGVKFromType` — keeping the
+ * derivation logic local so describeResources can compute the kubectl resource
+ * name without importing serializer internals.
+ */
+function deriveGVK(entityType: string): { group: string; kind: string } | null {
+  const parts = entityType.split("::");
+  if (parts.length !== 3 || parts[0] !== "GCP") return null;
+  const service = parts[1].toLowerCase();
+  const shortKind = parts[2];
+  return {
+    group: `${service}.cnrm.cloud.google.com`,
+    kind: `${parts[1]}${shortKind}`,
+  };
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Config Connector encodes deployment state as a `Ready` condition on the
+ * resource's status. Fall back to listing all condition types if `Ready`
+ * isn't present.
+ */
+function statusFromCC(obj: KubectlResponse): string {
+  const conditions = obj.status?.conditions ?? [];
+  const ready = conditions.find((c) => c.type === "Ready");
+  if (ready) {
+    if (ready.status === "True") return "READY";
+    return ready.reason ?? "NOT_READY";
+  }
+  if (conditions.length > 0) {
+    return conditions.map((c) => `${c.type}=${c.status}`).join(",");
+  }
+  return "PRESENT";
+}
+
+export async function describeResources(options: {
+  environment: string;
+  buildOutput: string;
+  entityNames: string[];
+  entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
+}): Promise<Record<string, ResourceMetadata>> {
+  const result: Record<string, ResourceMetadata> = {};
+
+  for (const [entityName, { entityType, props }] of options.entities) {
+    const gvk = deriveGVK(entityType);
+    if (!gvk) continue;
+
+    const metadata = props.metadata as { name?: string; namespace?: string } | undefined;
+    const name = metadata?.name;
+    if (!name) continue;
+
+    const kubectlResource = `${gvk.kind.toLowerCase()}.${gvk.group}`;
+    const nsArg = metadata.namespace ? ["-n", metadata.namespace] : [];
+    const cmd = ["kubectl", "get", kubectlResource, name, ...nsArg, "-o", "json"].join(" ");
+
+    try {
+      const { stdout } = await execAsync(cmd);
+      const obj: KubectlResponse = JSON.parse(stdout);
+      result[entityName] = {
+        type: entityType,
+        physicalId: obj.metadata?.uid,
+        status: statusFromCC(obj),
+        lastUpdated: obj.metadata?.creationTimestamp,
+        attributes: pruneUndefined({
+          namespace: obj.metadata?.namespace,
+          labels: obj.metadata?.labels,
+          annotations: obj.metadata?.annotations,
+        }),
+      };
+    } catch {
+      // CRD or instance not found — skip silently
+    }
+  }
+
+  return result;
+}

--- a/lexicons/gcp/src/plugin.ts
+++ b/lexicons/gcp/src/plugin.ts
@@ -499,4 +499,9 @@ export const bucket = new StorageBucket({
     const { generateDocs } = await import("./codegen/docs");
     await generateDocs(options);
   },
+
+  async describeResources(options) {
+    const { describeResources } = await import("./describe-resources");
+    return describeResources(options);
+  },
 };


### PR DESCRIPTION
## Summary

Continues progress on #42. Brings the **GCP** lexicon into the snapshot-supported set (now 4 of 11 lexicons covered: AWS, Temporal, K8s, GCP).

GCP entities in chant are emitted as Config Connector custom resources (`apiVersion: <service>.cnrm.cloud.google.com/v1beta1`), so we shell out to kubectl using the same pattern as #47:

```
GCP::Storage::Bucket     → kubectl get storagebucket.storage.cnrm.cloud.google.com <name>
GCP::Compute::Subnetwork → kubectl get computesubnetwork.compute.cnrm.cloud.google.com <name>
```

GVK derivation mirrors the existing serializer (`deriveGVKFromType` in `serializer.ts`), so any of the ~300 chant-supported GCP resources work **without a per-type lookup table** — the K8s describer used a curated map; GCP can derive automatically because of the consistent `<Service><Kind>` naming scheme of CC.

## Status mapping

Reads Config Connector's standard `Ready` condition on the resource's status:

| Source | Output |
|---|---|
| `Ready: True` | `READY` |
| `Ready: False` | the condition's `reason` (e.g. `DependencyNotFound`) |
| no `Ready` condition, but other conditions | `Type=Status,Type=Status,...` |
| no conditions at all | `PRESENT` |

## Coverage table

| Lexicon | Status |
|---|---|
| aws | ✅ |
| temporal | ✅ |
| k8s | ✅ |
| **gcp** | ✅ **new — this PR** |
| azure | ❌ TODO |
| flyway | ❌ TODO |
| slurm | ❌ TODO (semantics need design) |
| github / gitlab | ❌ may be N/A |
| ~~helm / docker~~ | ⚠️ different model |

## Tests

7 unit cases with mocked `exec`:
- GVK derivation produces the right CRD plural for Storage + Compute
- `Ready=True` → `READY`
- `Ready=False` → reason surfaced
- Missing `Ready` condition → `PRESENT`
- kubectl-not-found → entity left out
- Non-GCP entity types → skipped, no kubectl call
- Missing `metadata.name` → silently skipped

## Verification

- `just build` clean
- `npx vitest run` → all green