### PR TITLE
feat(state): listArtifacts() plugin contract + state-pipeline integration (#51)

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -68,7 +68,37 @@ Output is grouped into six categories per lexicon:
 
 Drifted entries include attribute-level deltas (`status`, `physicalId`, `lastUpdated`, and each `attributes.*` key).
 
-Lexicons that don't yet implement `describeResources()` are warn-skipped — `--live` doesn't fail the whole command for them. Today, **AWS**, **Temporal**, **K8s**, **GCP** (via Config Connector), and **Azure** are covered.
+### Resources vs artifacts
+
+Some lexicons describe *authoring primitives* (Helm chart files, Docker compose files, Flyway migration scripts) rather than 1:1 cloud resources. The runtime concept (a Helm release, a running container, an applied migration) is created by tooling outside chant's entity model.
+
+For these, lexicons implement a separate `listArtifacts()` plugin method instead of (or in addition to) `describeResources()`. The artifact diff is **context-keyed**: it reports what's there now vs what was there at the last snapshot, with no `declared` axis (since artifacts aren't declared as chant entities). Categories are:
+
+| Category | Meaning |
+|---|---|
+| **artifacts added** | Observed now, not in last snapshot |
+| **artifacts removed** | In last snapshot, gone now |
+| **artifacts changed** | In both; metadata changed |
+| **artifacts unchanged** | In both; metadata identical |
+
+A single lexicon may emit both resources (entity-keyed) and artifacts (context-keyed) — `chant state diff --live` shows them in separate sections.
+
+### Coverage today
+
+| Lexicon | `describeResources()` | `listArtifacts()` |
+|---|---|---|
+| AWS | ✅ |  |
+| Temporal | ✅ |  |
+| K8s | ✅ |  |
+| GCP (via Config Connector) | ✅ |  |
+| Azure | ✅ |  |
+| Helm | | ⏳ #52 |
+| Docker | | ⏳ #53 |
+| Flyway | | ⏳ #54 |
+| Slurm | | ⏳ #55 |
+| GitHub / GitLab | | N/A — see #56 |
+
+Lexicons that implement neither method are warn-skipped — `--live` doesn't fail the whole command for them.
 
 The Temporal lexicon resolves its connection via the chant config: `state snapshot <env>` (or `--live` against `<env>`) looks up `temporal.profiles.<env>` in your `chant.config.ts` and falls back to `temporal.defaultProfile`. The same profile model is used by `chant run`. With #39's entity-prop pass-through, namespaces/schedules/search-attributes are mapped back to chant entity names when the declared `props.name` (etc.) match the server-side identifier.
 

--- a/lexicons/temporal/src/op/activities/state.ts
+++ b/lexicons/temporal/src/op/activities/state.ts
@@ -45,7 +45,15 @@ export interface StateDiffResult {
  * Section headers emitted by `chant state diff --live` that indicate a
  * non-empty drift category. See packages/core/src/cli/handlers/state.ts.
  */
-const DRIFT_HEADERS = ["MISSING", "ORPHAN", "DISAPPEARED", "DRIFTED"];
+const DRIFT_HEADERS = [
+  "MISSING",
+  "ORPHAN",
+  "DISAPPEARED",
+  "DRIFTED",
+  "ARTIFACTS ADDED",
+  "ARTIFACTS REMOVED",
+  "ARTIFACTS CHANGED",
+];
 
 function detectDrift(output: string): boolean {
   return DRIFT_HEADERS.some((h) => output.includes(`${h} (`) || output.includes(`\n${h}`));

--- a/packages/core/src/cli/handlers/state.test.ts
+++ b/packages/core/src/cli/handlers/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
-import { createMockPlugin, staticDescribeResources } from "@intentius/chant-test-utils";
+import { createMockPlugin, staticDescribeResources, staticListArtifacts } from "@intentius/chant-test-utils";
 import type { LexiconPlugin, ResourceMetadata } from "../../lexicon";
 import type { BuildResult } from "../../build";
 import type { ParsedArgs } from "../registry";
@@ -145,6 +145,42 @@ describe("runStateDiff --live", () => {
     const stderr = stderrBuf.join("\n");
     expect(stderr).toContain("k8s");
     expect(stderr).toContain("does not implement describeResources");
+  });
+
+  test("--live with a listArtifacts-only plugin diffs artifacts (no resources path)", async () => {
+    buildMock.mockResolvedValue(makeBuildResult({ helm: [] }));
+    fetchStateMock.mockResolvedValue(undefined);
+    // Previous snapshot has no artifact entry for the new release → expect ARTIFACTS ADDED
+    readSnapshotMock.mockResolvedValue(JSON.stringify({
+      lexicon: "helm",
+      environment: "prod",
+      commit: "x",
+      timestamp: "t",
+      resources: {},
+      artifacts: {},
+    }));
+
+    const plugins: LexiconPlugin[] = [
+      createMockPlugin({
+        name: "helm",
+        listArtifacts: staticListArtifacts({
+          "release/default/web": { type: "Helm::Release", physicalId: "default/web", status: "deployed" },
+        }),
+      }),
+    ];
+
+    const ctx = {
+      args: makeArgs({ command: "state", path: "diff", extraPositional: "prod", live: true }),
+      plugins,
+      serializers: plugins.map((p) => p.serializer),
+    };
+
+    const exit = await runStateDiff(ctx);
+
+    expect(exit).toBe(0);
+    const output = stdoutBuf.join("\n");
+    expect(output).toContain("ARTIFACTS ADDED");
+    expect(output).toContain("release/default/web");
   });
 
   test("legacy digest mode still works without --live", async () => {

--- a/packages/core/src/cli/handlers/state.ts
+++ b/packages/core/src/cli/handlers/state.ts
@@ -3,13 +3,13 @@ import { build } from "../../build";
 import { takeSnapshot } from "../../state/snapshot";
 import { readSnapshot, readEnvironmentSnapshots, listSnapshots, fetchState, StaleStateBranchError } from "../../state/git";
 import { computeBuildDigest, diffDigests } from "../../state/digest";
-import { diffLive, type LiveDiffResult } from "../../state/live-diff";
+import { diffLive, diffLiveArtifacts, type LiveDiffResult, type LiveArtifactDiffResult } from "../../state/live-diff";
 import { loadChantConfig } from "../../config";
 import { formatError, formatWarning, formatSuccess, formatBold } from "../format";
 import type { CommandContext } from "../registry";
 import type { StateSnapshot } from "../../state/types";
 import type { SerializerResult } from "../../serializer";
-import type { LexiconPlugin, ResourceMetadata } from "../../lexicon";
+import type { LexiconPlugin, ResourceMetadata, ArtifactMetadata } from "../../lexicon";
 import type { BuildResult } from "../../build";
 
 /**
@@ -49,10 +49,10 @@ export async function runStateSnapshot(ctx: CommandContext): Promise<number> {
     return 1;
   }
 
-  const pluginsWithDescribe = targetPlugins.filter((p) => p.describeResources);
-  if (pluginsWithDescribe.length === 0) {
+  const observingPlugins = targetPlugins.filter((p) => p.describeResources || p.listArtifacts);
+  if (observingPlugins.length === 0) {
     console.error(formatError({
-      message: "No plugins implement describeResources",
+      message: "No plugins implement describeResources or listArtifacts",
       hint: lexiconFilter ? `Lexicon "${lexiconFilter}" does not support state snapshots` : undefined,
     }));
     return 1;
@@ -60,7 +60,7 @@ export async function runStateSnapshot(ctx: CommandContext): Promise<number> {
 
   let result;
   try {
-    result = await takeSnapshot(environment, pluginsWithDescribe, buildResult);
+    result = await takeSnapshot(environment, observingPlugins, buildResult);
   } catch (err) {
     if (err instanceof StaleStateBranchError) {
       console.error(formatError({
@@ -225,14 +225,14 @@ async function runStateDiffLive(args: LiveDiffArgs): Promise<number> {
     const plugin = args.plugins.find((p) => p.name === lexiconName);
     if (!plugin) continue;
 
-    if (!plugin.describeResources) {
+    if (!plugin.describeResources && !plugin.listArtifacts) {
       console.error(formatWarning({
-        message: `${lexiconName}: lexicon does not implement describeResources — skipping (use without --live for digest diff)`,
+        message: `${lexiconName}: lexicon does not implement describeResources or listArtifacts — skipping (use without --live for digest diff)`,
       }));
       continue;
     }
 
-    // Resources declared in this lexicon's slice of the build
+    // Build per-lexicon entity index
     const declared = new Set<string>();
     const entities = new Map<string, { entityType: string; props: Record<string, unknown> }>();
     for (const [name, entity] of args.buildResult.entities) {
@@ -255,38 +255,60 @@ async function runStateDiffLive(args: LiveDiffArgs): Promise<number> {
           ? rawOutput
           : (rawOutput as SerializerResult).primary;
 
-    let observedNow: Record<string, ResourceMetadata>;
-    try {
-      observedNow = await plugin.describeResources({
-        environment: args.environment,
-        buildOutput,
-        entityNames: Array.from(declared),
-        entities,
-      });
-    } catch (err) {
-      console.error(formatError({
-        message: `${lexiconName}: describeResources failed — ${err instanceof Error ? err.message : String(err)}`,
-      }));
-      continue;
-    }
-
-    let observedThen: Record<string, ResourceMetadata> | undefined;
+    // Read previous snapshot once; both flows pull what they need.
+    let prevSnapshot: StateSnapshot | undefined;
     const content = await readSnapshot(args.environment, lexiconName);
-    if (content) {
-      const snapshot: StateSnapshot = JSON.parse(content);
-      observedThen = snapshot.resources;
+    if (content) prevSnapshot = JSON.parse(content);
+
+    let lexiconChecked = false;
+
+    // ── Resources path (entity-keyed) ──────────────────────────────────────
+    if (plugin.describeResources) {
+      let observedNow: Record<string, ResourceMetadata>;
+      try {
+        observedNow = await plugin.describeResources({
+          environment: args.environment,
+          buildOutput,
+          entityNames: Array.from(declared),
+          entities,
+        });
+      } catch (err) {
+        console.error(formatError({
+          message: `${lexiconName}: describeResources failed — ${err instanceof Error ? err.message : String(err)}`,
+        }));
+        continue;
+      }
+      const observedThen = prevSnapshot?.resources;
+      const diff = diffLive({ declared, observedNow, observedThen });
+      totalDrift += diff.driftedSinceSnapshot.length + diff.missing.length + diff.orphan.length + diff.disappeared.length;
+      renderLiveDiff(lexiconName, args.environment, diff);
+      lexiconChecked = true;
     }
 
-    const diff = diffLive({ declared, observedNow, observedThen });
-    totalLexiconsChecked++;
-    totalDrift += diff.driftedSinceSnapshot.length + diff.missing.length + diff.orphan.length + diff.disappeared.length;
+    // ── Artifacts path (context-keyed) ─────────────────────────────────────
+    if (plugin.listArtifacts) {
+      let observedNow: Record<string, ArtifactMetadata>;
+      try {
+        observedNow = await plugin.listArtifacts({ environment: args.environment, entities });
+      } catch (err) {
+        console.error(formatError({
+          message: `${lexiconName}: listArtifacts failed — ${err instanceof Error ? err.message : String(err)}`,
+        }));
+        continue;
+      }
+      const observedThen = prevSnapshot?.artifacts;
+      const adiff = diffLiveArtifacts({ observedNow, observedThen });
+      totalDrift += adiff.added.length + adiff.removed.length + adiff.changed.length;
+      renderLiveArtifactDiff(lexiconName, args.environment, adiff);
+      lexiconChecked = true;
+    }
 
-    renderLiveDiff(lexiconName, args.environment, diff);
+    if (lexiconChecked) totalLexiconsChecked++;
   }
 
   if (totalLexiconsChecked === 0) {
     console.error(formatWarning({
-      message: "No lexicons implement describeResources — nothing to diff in --live mode",
+      message: "No lexicons implement describeResources or listArtifacts — nothing to diff in --live mode",
     }));
     return 1;
   }
@@ -342,6 +364,42 @@ function formatValue(v: unknown): string {
   if (typeof v === "string") return v.length > 60 ? v.slice(0, 57) + "..." : v;
   const json = JSON.stringify(v);
   return json.length > 60 ? json.slice(0, 57) + "..." : json;
+}
+
+function renderLiveArtifactDiff(lexiconName: string, environment: string, diff: LiveArtifactDiffResult): void {
+  // Skip emission entirely when there's nothing to show — keeps the output
+  // clean for lexicons that only implement describeResources.
+  if (diff.added.length === 0 && diff.removed.length === 0 && diff.changed.length === 0 && diff.unchanged.length === 0) {
+    return;
+  }
+
+  const counts =
+    `${diff.added.length} added, ${diff.removed.length} removed, ` +
+    `${diff.changed.length} changed, ${diff.unchanged.length} unchanged`;
+
+  console.log(`\n${formatBold(lexiconName)} (artifacts) — environment: ${environment}`);
+  console.log(counts);
+  console.log("-".repeat(80));
+
+  if (diff.added.length > 0) {
+    console.log(formatBold("\nARTIFACTS ADDED (in cloud now, not in last snapshot):"));
+    for (const name of diff.added) console.log(`  - ${name}`);
+  }
+  if (diff.removed.length > 0) {
+    console.log(formatBold("\nARTIFACTS REMOVED (in last snapshot, gone now):"));
+    for (const name of diff.removed) console.log(`  - ${name}`);
+  }
+  if (diff.changed.length > 0) {
+    console.log(formatBold("\nARTIFACTS CHANGED (metadata differs since last snapshot):"));
+    for (const drift of diff.changed) {
+      console.log(`  - ${drift.name} (${drift.type})`);
+      for (const change of drift.changes) {
+        const oldStr = formatValue(change.oldValue);
+        const newStr = formatValue(change.newValue);
+        console.log(`      ${change.path}: ${oldStr} → ${newStr}`);
+      }
+    }
+  }
 }
 
 /**

--- a/packages/core/src/lexicon.ts
+++ b/packages/core/src/lexicon.ts
@@ -198,6 +198,9 @@ export interface LexiconPlugin {
   /**
    * Query deployed resources and return API metadata. Opt-in.
    *
+   * Use this when each chant entity has a 1:1 cloud equivalent — e.g. an
+   * AWS CFN resource, a K8s object, an ARM resource, a Temporal namespace.
+   *
    * `entities` carries the chant-side entity declarations for this lexicon,
    * keyed by chant entity name (e.g. the export name from a `*.ts` file).
    * Implementations that need to map cloud-side names back to chant entity
@@ -214,6 +217,26 @@ export interface LexiconPlugin {
     entityNames: string[];
     entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
   }): Promise<Record<string, ResourceMetadata>>;
+
+  /**
+   * List runtime artifacts in the given environment. Opt-in.
+   *
+   * Use this for lexicons whose chant entities describe *authoring*
+   * primitives rather than 1:1 cloud resources — e.g. Helm (charts vs
+   * releases), Docker (Compose vs running containers), Flyway (migration
+   * scripts vs applied migrations). The contract is context-keyed: given an
+   * environment, list all artifacts visible there. There is no `declared`
+   * comparison axis — `state diff --live` reports added/removed/changed
+   * between snapshots, not vs. declared.
+   *
+   * `entities` is passed for cases where the lexicon needs to know what
+   * was declared in order to enumerate (e.g. Flyway needs the declared
+   * `Flyway::Environment` entities to know which DBs to query).
+   */
+  listArtifacts?(options: {
+    environment: string;
+    entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
+  }): Promise<Record<string, ArtifactMetadata>>;
 }
 
 /**
@@ -229,6 +252,26 @@ export interface ResourceMetadata {
   /** ISO timestamp of last update */
   lastUpdated?: string;
   /** Cloud-assigned output properties */
+  attributes?: Record<string, unknown>;
+}
+
+/**
+ * Metadata about a runtime artifact, returned by listArtifacts. Same shape
+ * as ResourceMetadata; the conceptual distinction is whether the lexicon's
+ * chant entities have 1:1 runtime equivalents (resources) or whether the
+ * runtime artifacts are created by tooling outside chant's entity model
+ * (artifacts — e.g. Helm releases, Docker containers, Flyway migrations).
+ */
+export interface ArtifactMetadata {
+  /** Artifact type (e.g. Helm::Release, Docker::Container) */
+  type: string;
+  /** Server-side identifier */
+  physicalId?: string;
+  /** Provider-specific status string */
+  status: string;
+  /** ISO timestamp of last update */
+  lastUpdated?: string;
+  /** Provider-specific properties */
   attributes?: Record<string, unknown>;
 }
 

--- a/packages/core/src/state/live-diff.test.ts
+++ b/packages/core/src/state/live-diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest";
-import { diffLive } from "./live-diff";
-import type { ResourceMetadata } from "../lexicon";
+import { diffLive, diffLiveArtifacts } from "./live-diff";
+import type { ResourceMetadata, ArtifactMetadata } from "../lexicon";
 
 const meta = (overrides: Partial<ResourceMetadata> = {}): ResourceMetadata => ({
   type: "AWS::S3::Bucket",
@@ -111,5 +111,74 @@ describe("diffLive", () => {
     expect(result.newlyObserved).toEqual(["d"]);
     expect(result.driftedSinceSnapshot.map((d) => d.name)).toEqual(["c"]);
     expect(result.unchanged).toEqual(["b"]);
+  });
+});
+
+describe("diffLiveArtifacts", () => {
+  const a = (overrides: Partial<ArtifactMetadata> = {}): ArtifactMetadata => ({
+    type: "Helm::Release",
+    physicalId: "default/foo",
+    status: "deployed",
+    ...overrides,
+  });
+
+  test("empty inputs produce empty result", () => {
+    expect(diffLiveArtifacts({ observedNow: {}, observedThen: undefined })).toEqual({
+      added: [], removed: [], changed: [], unchanged: [],
+    });
+  });
+
+  test("observed now, no previous snapshot → added", () => {
+    const result = diffLiveArtifacts({
+      observedNow: { "release/default/foo": a() },
+      observedThen: undefined,
+    });
+    expect(result.added).toEqual(["release/default/foo"]);
+  });
+
+  test("in previous snapshot, gone now → removed", () => {
+    const result = diffLiveArtifacts({
+      observedNow: {},
+      observedThen: { "release/default/foo": a() },
+    });
+    expect(result.removed).toEqual(["release/default/foo"]);
+  });
+
+  test("metadata differs between snapshots → changed", () => {
+    const result = diffLiveArtifacts({
+      observedNow:  { "release/default/foo": a({ status: "failed" }) },
+      observedThen: { "release/default/foo": a({ status: "deployed" }) },
+    });
+    expect(result.changed).toHaveLength(1);
+    expect(result.changed[0].name).toBe("release/default/foo");
+    expect(result.changed[0].changes.map((c) => c.path)).toContain("status");
+  });
+
+  test("identical metadata → unchanged", () => {
+    const same = a();
+    const result = diffLiveArtifacts({
+      observedNow:  { "release/default/foo": same },
+      observedThen: { "release/default/foo": same },
+    });
+    expect(result.unchanged).toEqual(["release/default/foo"]);
+  });
+
+  test("mixed: counts add up across all four categories", () => {
+    const result = diffLiveArtifacts({
+      observedNow: {
+        "release/default/b": a(),                          // unchanged
+        "release/default/c": a({ status: "failed" }),      // changed
+        "release/default/d": a(),                          // added
+      },
+      observedThen: {
+        "release/default/a": a(),                          // removed
+        "release/default/b": a(),                          // unchanged
+        "release/default/c": a(),                          // changed
+      },
+    });
+    expect(result.added).toEqual(["release/default/d"]);
+    expect(result.removed).toEqual(["release/default/a"]);
+    expect(result.changed.map((c) => c.name)).toEqual(["release/default/c"]);
+    expect(result.unchanged).toEqual(["release/default/b"]);
   });
 });

--- a/packages/core/src/state/live-diff.ts
+++ b/packages/core/src/state/live-diff.ts
@@ -4,8 +4,15 @@
  * Produces structured drift signal — *what is in the cloud right now* against
  * both *what was declared in source* and *what was observed at the last
  * snapshot*. Pure function; all I/O happens in the caller.
+ *
+ * Two diff flavors:
+ *   - diffLive       — entity-keyed (declared ↔ observedNow ↔ observedThen)
+ *   - diffLiveArtifacts — context-keyed (observedNow ↔ observedThen only;
+ *                        no `declared` axis since artifacts aren't declared
+ *                        as chant entities — they're created by tooling
+ *                        outside chant's entity model)
  */
-import type { ResourceMetadata } from "../lexicon";
+import type { ResourceMetadata, ArtifactMetadata } from "../lexicon";
 
 export interface AttributeChange {
   /** Attribute path (e.g. "status", "physicalId", "attributes.tags.env"). */
@@ -146,6 +153,63 @@ export function diffLive(input: DiffLiveInput): LiveDiffResult {
     disappeared: disappeared.sort(),
     newlyObserved: newlyObserved.sort(),
     driftedSinceSnapshot: driftedSinceSnapshot.sort((a, b) => a.name.localeCompare(b.name)),
+    unchanged: unchanged.sort(),
+  };
+}
+
+// ── Artifact diff (no `declared` axis) ──────────────────────────────────────
+
+export interface LiveArtifactDiffResult {
+  /** Observed now, not in previous snapshot. */
+  added: string[];
+  /** In previous snapshot, not observed now. */
+  removed: string[];
+  /** In both; metadata changed. */
+  changed: ResourceDrift[];
+  /** In both; metadata identical. */
+  unchanged: string[];
+}
+
+export interface DiffLiveArtifactsInput {
+  /** Artifacts returned by `plugin.listArtifacts()` right now. */
+  observedNow: Record<string, ArtifactMetadata>;
+  /** Artifacts captured by the previous snapshot, if any. */
+  observedThen: Record<string, ArtifactMetadata> | undefined;
+}
+
+export function diffLiveArtifacts(input: DiffLiveArtifactsInput): LiveArtifactDiffResult {
+  const observedThenMap = input.observedThen ?? {};
+  const nowNames = new Set(Object.keys(input.observedNow));
+  const thenNames = new Set(Object.keys(observedThenMap));
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: ResourceDrift[] = [];
+  const unchanged: string[] = [];
+
+  for (const name of nowNames) {
+    if (!thenNames.has(name)) {
+      added.push(name);
+      continue;
+    }
+    const now = input.observedNow[name];
+    const then = observedThenMap[name];
+    const diffs = compareMetadata(then, now);
+    if (diffs.length === 0) {
+      unchanged.push(name);
+    } else {
+      changed.push({ name, type: now.type, changes: diffs });
+    }
+  }
+
+  for (const name of thenNames) {
+    if (!nowNames.has(name)) removed.push(name);
+  }
+
+  return {
+    added: added.sort(),
+    removed: removed.sort(),
+    changed: changed.sort((a, b) => a.name.localeCompare(b.name)),
     unchanged: unchanged.sort(),
   };
 }

--- a/packages/core/src/state/snapshot.test.ts
+++ b/packages/core/src/state/snapshot.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
-import { createMockPlugin, staticDescribeResources } from "@intentius/chant-test-utils";
+import { createMockPlugin, staticDescribeResources, staticListArtifacts } from "@intentius/chant-test-utils";
 import type { BuildResult } from "../build";
 
 const writeSnapshotMock = vi.fn();
@@ -116,5 +116,56 @@ describe("takeSnapshot", () => {
     });
     const result = await takeSnapshot("prod", [plugin], makeBuildResult({ aws: ["cred"] }));
     expect(result.warnings.some((w) => w.toLowerCase().includes("sensitive"))).toBe(true);
+  });
+
+  // ── listArtifacts() integration (#51) ─────────────────────────────────────
+
+  test("calls listArtifacts when implemented and stores artifacts in snapshot", async () => {
+    const plugin = createMockPlugin({
+      name: "helm",
+      listArtifacts: staticListArtifacts({
+        "release/default/web": { type: "Helm::Release", physicalId: "default/web", status: "deployed" },
+      }),
+    });
+    const result = await takeSnapshot("prod", [plugin], makeBuildResult({ helm: [] }));
+    expect(result.snapshots).toHaveLength(1);
+    expect(result.snapshots[0].artifacts).toEqual({
+      "release/default/web": { type: "Helm::Release", physicalId: "default/web", status: "deployed" },
+    });
+    expect(result.snapshots[0].resources).toEqual({});
+  });
+
+  test("plugin can implement both describeResources and listArtifacts", async () => {
+    const plugin = createMockPlugin({
+      name: "k8s",
+      describeResources: staticDescribeResources({
+        web: { type: "K8s::Apps::Deployment", status: "READY" },
+      }),
+      listArtifacts: staticListArtifacts({
+        "release/default/proxy": { type: "Helm::Release", status: "deployed" },
+      }),
+    });
+    const result = await takeSnapshot("prod", [plugin], makeBuildResult({ k8s: ["web"] }));
+    expect(result.snapshots[0].resources).toEqual({
+      web: { type: "K8s::Apps::Deployment", status: "READY" },
+    });
+    expect(result.snapshots[0].artifacts).toBeDefined();
+    expect(result.snapshots[0].artifacts!["release/default/proxy"]).toBeDefined();
+  });
+
+  test("plugin with neither method is skipped (existing behavior preserved)", async () => {
+    const plugin = createMockPlugin({ name: "noop" });
+    const result = await takeSnapshot("prod", [plugin], makeBuildResult({ noop: ["x"] }));
+    expect(result.snapshots).toEqual([]);
+  });
+
+  test("listArtifacts only, empty result → error 'no valid resources or artifacts returned'", async () => {
+    const plugin = createMockPlugin({
+      name: "helm",
+      listArtifacts: async () => ({}),
+    });
+    const result = await takeSnapshot("prod", [plugin], makeBuildResult({ helm: [] }));
+    expect(result.errors.some((e) => e.includes("helm") && e.includes("no valid"))).toBe(true);
+    expect(result.snapshots).toEqual([]);
   });
 });

--- a/packages/core/src/state/snapshot.ts
+++ b/packages/core/src/state/snapshot.ts
@@ -2,7 +2,7 @@
  * Snapshot orchestration: queries plugins for deployed resource metadata,
  * assembles StateSnapshots, computes build digests, and writes to git.
  */
-import type { LexiconPlugin, ResourceMetadata } from "../lexicon";
+import type { LexiconPlugin, ResourceMetadata, ArtifactMetadata } from "../lexicon";
 import type { BuildResult } from "../build";
 import type { SerializerResult } from "../serializer";
 import type { StateSnapshot } from "./types";
@@ -95,7 +95,7 @@ export async function takeSnapshot(
   const digest = computeBuildDigest(buildResult);
 
   for (const plugin of plugins) {
-    if (!plugin.describeResources) continue;
+    if (!plugin.describeResources && !plugin.listArtifacts) continue;
 
     // Get serialized build output for this lexicon
     const rawOutput = buildResult.outputs.get(plugin.name);
@@ -121,26 +121,37 @@ export async function takeSnapshot(
       }
     }
 
+    let resources: Record<string, ResourceMetadata> = {};
+    let artifacts: Record<string, ArtifactMetadata> = {};
+
     try {
-      const resources = await plugin.describeResources({
-        environment,
-        buildOutput,
-        entityNames,
-        entities,
-      });
-
-      const { valid, dropped, warnings: validationWarnings } =
-        validateResources(resources);
-      warnings.push(...validationWarnings);
-
-      if (dropped.length > 0) {
-        warnings.push(
-          `${plugin.name}: dropped ${dropped.length} invalid resource(s)`,
-        );
+      if (plugin.describeResources) {
+        const raw = await plugin.describeResources({
+          environment,
+          buildOutput,
+          entityNames,
+          entities,
+        });
+        const { valid, dropped, warnings: validationWarnings } = validateResources(raw);
+        warnings.push(...validationWarnings);
+        if (dropped.length > 0) {
+          warnings.push(`${plugin.name}: dropped ${dropped.length} invalid resource(s)`);
+        }
+        resources = valid;
       }
 
-      if (Object.keys(valid).length === 0) {
-        errors.push(`${plugin.name}: no valid resources returned`);
+      if (plugin.listArtifacts) {
+        const raw = await plugin.listArtifacts({ environment, entities });
+        const { valid, dropped, warnings: validationWarnings } = validateResources(raw);
+        warnings.push(...validationWarnings);
+        if (dropped.length > 0) {
+          warnings.push(`${plugin.name}: dropped ${dropped.length} invalid artifact(s)`);
+        }
+        artifacts = valid;
+      }
+
+      if (Object.keys(resources).length === 0 && Object.keys(artifacts).length === 0) {
+        errors.push(`${plugin.name}: no valid resources or artifacts returned`);
         continue;
       }
 
@@ -149,7 +160,8 @@ export async function takeSnapshot(
         environment,
         commit: headCommit,
         timestamp,
-        resources: valid,
+        resources,
+        ...(Object.keys(artifacts).length > 0 && { artifacts }),
         digest,
       };
 

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -1,6 +1,6 @@
-import type { ResourceMetadata } from "../lexicon";
+import type { ResourceMetadata, ArtifactMetadata } from "../lexicon";
 
-export type { ResourceMetadata } from "../lexicon";
+export type { ResourceMetadata, ArtifactMetadata } from "../lexicon";
 
 /**
  * State snapshot for a single lexicon in an environment.
@@ -14,6 +14,8 @@ export interface StateSnapshot {
   timestamp: string;
   /** Resource metadata keyed by logical name */
   resources: Record<string, ResourceMetadata>;
+  /** Artifact metadata keyed by server-side identifier (lexicon-specific). */
+  artifacts?: Record<string, ArtifactMetadata>;
   /** Build digest at snapshot time — what was declared when this snapshot was taken */
   digest?: BuildDigest;
 }

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -18,7 +18,7 @@ export {
   expectNoDiagnostics,
   expectDiagnostic,
 } from "./post-synth-harness";
-export { createMockPlugin, staticDescribeResources } from "./mock-plugin";
+export { createMockPlugin, staticDescribeResources, staticListArtifacts } from "./mock-plugin";
 export type { MockPluginOptions } from "./mock-plugin";
 export { createMockTemporalClient } from "./mock-temporal-client";
 export type {

--- a/packages/test-utils/src/mock-plugin.ts
+++ b/packages/test-utils/src/mock-plugin.ts
@@ -1,4 +1,4 @@
-import type { LexiconPlugin, ResourceMetadata } from "../../core/src/lexicon";
+import type { LexiconPlugin, ResourceMetadata, ArtifactMetadata } from "../../core/src/lexicon";
 import type { Serializer } from "../../core/src/serializer";
 import { createMockSerializer } from "./fixtures";
 
@@ -6,6 +6,7 @@ export interface MockPluginOptions {
   name?: string;
   serializer?: Serializer;
   describeResources?: LexiconPlugin["describeResources"];
+  listArtifacts?: LexiconPlugin["listArtifacts"];
 }
 
 export function createMockPlugin(options: MockPluginOptions = {}): LexiconPlugin {
@@ -19,6 +20,7 @@ export function createMockPlugin(options: MockPluginOptions = {}): LexiconPlugin
     coverage: noop,
     package: noop,
     ...(options.describeResources && { describeResources: options.describeResources }),
+    ...(options.listArtifacts && { listArtifacts: options.listArtifacts }),
   };
 }
 
@@ -26,4 +28,10 @@ export function staticDescribeResources(
   resources: Record<string, ResourceMetadata>,
 ): LexiconPlugin["describeResources"] {
   return async () => resources;
+}
+
+export function staticListArtifacts(
+  artifacts: Record<string, ArtifactMetadata>,
+): LexiconPlugin["listArtifacts"] {
+  return async () => artifacts;
 }


### PR DESCRIPTION
## Summary

Closes #51. Foundation for the artifact-shaped lexicons (Helm, Docker, Flyway, Slurm — #52–#55). Adds a second observation contract alongside `describeResources()`:

```ts
listArtifacts?(options: {
  environment: string;
  entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
}): Promise<Record<string, ArtifactMetadata>>;
```

Use this for lexicons whose chant entities describe *authoring* primitives (chart files, Compose files, migration scripts) rather than 1:1 cloud resources. Context-keyed (no `declared` axis); `state diff --live` reports added/removed/changed between snapshots.

## Pipeline integration

| Surface | Change |
|---|---|
| `StateSnapshot` | Optional `artifacts?: Record<string, ArtifactMetadata>` field alongside `resources` |
| `takeSnapshot()` | Calls both methods per plugin, merges results into snapshot. Empty resources + empty artifacts → "no valid resources or artifacts returned" error (was previously resources-only) |
| `diffLiveArtifacts()` | New pure function — observed-then vs observed-now (no declared axis). Categories: added / removed / changed / unchanged |
| `runStateDiffLive` | Renders separate `ARTIFACTS` section per lexicon when artifacts are present |
| `cli/handlers/state.ts` (snapshot) | Filter widened from `p.describeResources` to `p.describeResources \|\| p.listArtifacts` |
| `lexicons/temporal/src/op/activities/state.ts` | `DRIFT_HEADERS` extended with `ARTIFACTS ADDED/REMOVED/CHANGED` so `WatchOp` catches artifact-only drift |

## Test infrastructure

- `mockPlugin` gains a `listArtifacts?` option
- New `staticListArtifacts(...)` helper alongside `staticDescribeResources`

## Tests added

- **`diffLiveArtifacts`** (6 new): empty inputs, added, removed, changed (metadata diff surfaces `path`), unchanged, mixed-category counts
- **`takeSnapshot`** (4 new): listArtifacts-only path stores `artifacts`, both methods on one plugin populate both fields, plugin with neither is skipped, empty result errors with new message
- **`runStateDiffLive`** (1 new): listArtifacts-only plugin produces `ARTIFACTS ADDED` section in output

## Verification

- `just build` clean
- `npx vitest run packages/core/ packages/test-utils/ lexicons/` → 5691/5691 (5 skipped, unrelated). +11 new tests vs main.

## Dependencies / unblocks

This issue is foundational for #52, #53, #54, #55 — all of which add per-lexicon `listArtifacts()` implementations against this contract. #56 is independent.

## Test plan

- [ ] CI green
- [ ] After merge, #52 (Helm) is the next-most-valuable PR — validates the contract on the highest-pain gap (Helm-on-K8s drift today is invisible)