### PR TITLE
feat(helm): listArtifacts() — helm list -A -o json (#52)

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -92,7 +92,7 @@ A single lexicon may emit both resources (entity-keyed) and artifacts (context-k
 | K8s | ✅ |  |
 | GCP (via Config Connector) | ✅ |  |
 | Azure | ✅ |  |
-| Helm | | ⏳ #52 |
+| Helm | | ✅ |
 | Docker | | ⏳ #53 |
 | Flyway | | ⏳ #54 |
 | Slurm | | ⏳ #55 |

--- a/lexicons/helm/src/list-artifacts.test.ts
+++ b/lexicons/helm/src/list-artifacts.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, exec: (cmd: string, cb: (err: Error | null, out: { stdout: string; stderr: string }) => void) => {
+    Promise.resolve(execMock(cmd)).then(
+      (out) => cb(null, out),
+      (err) => cb(err as Error, { stdout: "", stderr: "" }),
+    );
+  } };
+});
+
+const { listArtifacts } = await import("./list-artifacts");
+
+describe("helm listArtifacts", () => {
+  beforeEach(() => {
+    execMock.mockReset();
+  });
+
+  test("queries `helm list -A -o json` and maps releases to artifacts", async () => {
+    let receivedCmd = "";
+    execMock.mockImplementation((cmd: string) => {
+      receivedCmd = cmd;
+      return {
+        stdout: JSON.stringify([
+          {
+            name: "web", namespace: "default", revision: "1",
+            updated: "2026-05-09 10:00:00.000000 +0000 UTC",
+            status: "deployed", chart: "web-1.0.0", app_version: "1.0",
+          },
+          {
+            name: "redis", namespace: "infra", revision: "3",
+            updated: "2026-05-09 09:00:00.000000 +0000 UTC",
+            status: "deployed", chart: "redis-7.4.0", app_version: "7.4",
+          },
+        ]),
+        stderr: "",
+      };
+    });
+
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+
+    expect(receivedCmd).toBe("helm list -A -o json");
+    expect(Object.keys(result).sort()).toEqual(["release/default/web", "release/infra/redis"]);
+    expect(result["release/default/web"]).toEqual({
+      type: "Helm::Release",
+      physicalId: "default/web",
+      status: "deployed",
+      lastUpdated: "2026-05-09 10:00:00.000000 +0000 UTC",
+      attributes: { chart: "web-1.0.0", revision: "1", appVersion: "1.0", namespace: "default" },
+    });
+  });
+
+  test("helm binary not installed → returns {} cleanly", async () => {
+    execMock.mockImplementation(() => { throw new Error("helm: command not found"); });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result).toEqual({});
+  });
+
+  test("empty cluster (no releases) → returns {}", async () => {
+    execMock.mockResolvedValue({ stdout: "[]", stderr: "" });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result).toEqual({});
+  });
+
+  test("status mapping for non-deployed states surfaces correctly", async () => {
+    execMock.mockResolvedValue({
+      stdout: JSON.stringify([
+        { name: "broken", namespace: "default", revision: "2", status: "failed", chart: "x-1.0", app_version: "1" },
+      ]),
+      stderr: "",
+    });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result["release/default/broken"].status).toBe("failed");
+  });
+
+  test("revision attribute changes between releases (drift signal)", async () => {
+    execMock.mockResolvedValue({
+      stdout: JSON.stringify([
+        { name: "web", namespace: "default", revision: "5", status: "deployed", chart: "web-2.0.0", app_version: "2.0" },
+      ]),
+      stderr: "",
+    });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result["release/default/web"].attributes).toMatchObject({ revision: "5", chart: "web-2.0.0" });
+  });
+
+  test("malformed JSON output → returns {} (don't fail the snapshot)", async () => {
+    execMock.mockResolvedValue({ stdout: "not json", stderr: "" });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result).toEqual({});
+  });
+});

--- a/lexicons/helm/src/list-artifacts.ts
+++ b/lexicons/helm/src/list-artifacts.ts
@@ -1,0 +1,79 @@
+/**
+ * Live introspection of Helm releases via `helm list -A -o json`.
+ *
+ * The Helm lexicon's chant entities describe chart-authoring primitives
+ * (Chart.yaml, templates/, values.yaml). The runtime concept — a Helm
+ * release installed in a kubeconfig context — is created by `helm install`
+ * outside chant's entity model. This implementation reports those releases
+ * as artifacts so `state diff --live` / `WatchOp` can detect manual
+ * installs/upgrades/rollbacks that slip past CI.
+ *
+ * Helm-not-installed (binary missing) → returns `{}` cleanly so other
+ * lexicons' snapshots aren't blocked.
+ */
+
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { ArtifactMetadata } from "@intentius/chant/lexicon";
+
+const execAsync = promisify(exec);
+
+interface HelmListEntry {
+  name?: string;
+  namespace?: string;
+  revision?: string;
+  updated?: string;
+  status?: string;
+  chart?: string;
+  app_version?: string;
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+export async function listArtifacts(_options: {
+  environment: string;
+  entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
+}): Promise<Record<string, ArtifactMetadata>> {
+  const result: Record<string, ArtifactMetadata> = {};
+
+  let stdout: string;
+  try {
+    ({ stdout } = await execAsync("helm list -A -o json"));
+  } catch {
+    // Binary not installed, no kubeconfig, or some other error — return
+    // empty rather than blocking the whole snapshot.
+    return result;
+  }
+
+  let entries: HelmListEntry[];
+  try {
+    entries = JSON.parse(stdout);
+  } catch {
+    return result;
+  }
+
+  for (const entry of entries) {
+    if (!entry.name || !entry.namespace) continue;
+    const key = `release/${entry.namespace}/${entry.name}`;
+    result[key] = {
+      type: "Helm::Release",
+      physicalId: `${entry.namespace}/${entry.name}`,
+      status: entry.status ?? "unknown",
+      lastUpdated: entry.updated,
+      attributes: pruneUndefined({
+        chart: entry.chart,
+        revision: entry.revision,
+        appVersion: entry.app_version,
+        namespace: entry.namespace,
+      }),
+    };
+  }
+
+  return result;
+}

--- a/lexicons/helm/src/plugin.ts
+++ b/lexicons/helm/src/plugin.ts
@@ -374,4 +374,9 @@ export const service = new Service({
 
     console.error(`Packaged ${stats.resources} resources, ${stats.ruleCount} rules, ${stats.skillCount} skills`);
   },
+
+  async listArtifacts(options) {
+    const { listArtifacts } = await import("./list-artifacts");
+    return listArtifacts(options);
+  },
 };


### PR DESCRIPTION
## Summary

Closes #52. Brings the Helm lexicon into the artifact-supported set introduced in #51, closing the most painful gap from the audit: today, a `WatchOp({ env: "prod" })` on a Helm-on-K8s stack reports `Drift = "false"` even when someone manually `helm install`s a chart with different values.

## Approach

```bash
helm list -A -o json
```

Each release maps to an artifact:

```ts
release/<namespace>/<name> = {
  type: "Helm::Release",
  physicalId: "<namespace>/<name>",
  status: <release.status>,           // "deployed" | "failed" | "pending-install" | ...
  lastUpdated: <release.updated>,
  attributes: { chart, revision, appVersion, namespace },
}
```

## Failure modes

- Helm binary not installed → `{}` (snapshot continues for other lexicons)
- Malformed JSON output → `{}`
- Empty cluster (zero releases) → `{}`

## Tests (6 new)

- Happy path: 2 releases across different namespaces, both keyed correctly
- Helm not installed → `{}`, no throw
- Empty cluster → `{}`
- Status mapping for `failed` state
- Revision-attribute drift signal (revision changes on every `helm upgrade`)
- Malformed JSON → `{}`

## Verification

- `just build` clean
- `npx vitest run lexicons/helm/src/list-artifacts.test.ts` → 6/6
- After merge, the canonical drift smoke is: `helm install foo` against a kubeconfig context, then `chant state diff --live` — should report the new release as `ARTIFACTS ADDED` and `WatchOp` should tag the run with `Drift = "true"`.

## Depends on

- #51 (the `listArtifacts()` contract) — already merged.