### PR TITLE
feat(docker): listArtifacts() — containers / images / networks (#53)

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -93,7 +93,7 @@ A single lexicon may emit both resources (entity-keyed) and artifacts (context-k
 | GCP (via Config Connector) | ✅ |  |
 | Azure | ✅ |  |
 | Helm | | ✅ |
-| Docker | | ⏳ #53 |
+| Docker | | ✅ |
 | Flyway | | ⏳ #54 |
 | Slurm | | ⏳ #55 |
 | GitHub / GitLab | | N/A — see #56 |

--- a/lexicons/docker/src/list-artifacts.test.ts
+++ b/lexicons/docker/src/list-artifacts.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, exec: (cmd: string, cb: (err: Error | null, out: { stdout: string; stderr: string }) => void) => {
+    Promise.resolve(execMock(cmd)).then(
+      (out) => cb(null, out),
+      (err) => cb(err as Error, { stdout: "", stderr: "" }),
+    );
+  } };
+});
+
+const { listArtifacts } = await import("./list-artifacts");
+
+describe("docker listArtifacts", () => {
+  beforeEach(() => {
+    execMock.mockReset();
+  });
+
+  test("happy path: containers + images + networks all reported", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("docker ps")) {
+        return {
+          stdout: [
+            JSON.stringify({ Names: "web", ID: "abc123", Image: "nginx:latest", State: "running", Status: "Up 5 minutes" }),
+            JSON.stringify({ Names: "db",  ID: "def456", Image: "postgres:16", State: "running", Status: "Up 2 hours" }),
+          ].join("\n"),
+          stderr: "",
+        };
+      }
+      if (cmd.startsWith("docker image ls")) {
+        return {
+          stdout: [
+            JSON.stringify({ ID: "img1", Repository: "nginx",    Tag: "latest", Size: "187MB", CreatedAt: "2026-04-01" }),
+            JSON.stringify({ ID: "img2", Repository: "postgres", Tag: "16",     Size: "412MB", CreatedAt: "2026-03-20" }),
+          ].join("\n"),
+          stderr: "",
+        };
+      }
+      if (cmd.startsWith("docker network ls")) {
+        return {
+          stdout: [
+            JSON.stringify({ ID: "net1", Name: "bridge", Driver: "bridge", Scope: "local" }),
+          ].join("\n"),
+          stderr: "",
+        };
+      }
+      throw new Error(`unexpected cmd: ${cmd}`);
+    });
+
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+
+    expect(Object.keys(result).sort()).toEqual([
+      "container/db",
+      "container/web",
+      "image/nginx:latest",
+      "image/postgres:16",
+      "network/bridge",
+    ]);
+    expect(result["container/web"]).toMatchObject({
+      type: "Docker::Container",
+      physicalId: "abc123",
+      status: "running",
+    });
+    expect(result["image/nginx:latest"]).toMatchObject({ type: "Docker::Image", physicalId: "img1" });
+    expect(result["network/bridge"]).toMatchObject({ type: "Docker::Network", physicalId: "net1" });
+  });
+
+  test("daemon unreachable on all queries → returns {}", async () => {
+    execMock.mockImplementation(() => { throw new Error("Cannot connect to the Docker daemon"); });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result).toEqual({});
+  });
+
+  test("per-query failure isolation: containers fail → still get images + networks", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("docker ps")) {
+        throw new Error("ps failed");
+      }
+      if (cmd.startsWith("docker image ls")) {
+        return { stdout: JSON.stringify({ ID: "img1", Repository: "alpine", Tag: "3.20", Size: "8MB" }), stderr: "" };
+      }
+      if (cmd.startsWith("docker network ls")) {
+        return { stdout: JSON.stringify({ ID: "net1", Name: "host", Driver: "host", Scope: "local" }), stderr: "" };
+      }
+      throw new Error(`unexpected cmd: ${cmd}`);
+    });
+
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+
+    expect(Object.keys(result).filter((k) => k.startsWith("container/"))).toEqual([]);
+    expect(result["image/alpine:3.20"]).toBeDefined();
+    expect(result["network/host"]).toBeDefined();
+  });
+
+  test("container Status surfaces in attributes.fullStatus", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("docker ps")) {
+        return { stdout: JSON.stringify({ Names: "web", ID: "x", Image: "i", State: "running", Status: "Up 5 minutes" }), stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result["container/web"].attributes).toMatchObject({ fullStatus: "Up 5 minutes" });
+  });
+
+  test("dangling images (Repository=<none>) are skipped", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("docker image ls")) {
+        return {
+          stdout: [
+            JSON.stringify({ ID: "img1", Repository: "<none>", Tag: "<none>", Size: "8MB" }),
+            JSON.stringify({ ID: "img2", Repository: "nginx", Tag: "latest", Size: "187MB" }),
+          ].join("\n"),
+          stderr: "",
+        };
+      }
+      return { stdout: "", stderr: "" };
+    });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(Object.keys(result).filter((k) => k.startsWith("image/"))).toEqual(["image/nginx:latest"]);
+  });
+
+  test("malformed NDJSON line is skipped, others still parsed", async () => {
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("docker ps")) {
+        return {
+          stdout: [
+            "this is not json",
+            JSON.stringify({ Names: "web", ID: "x", State: "running", Status: "Up", Image: "i" }),
+          ].join("\n"),
+          stderr: "",
+        };
+      }
+      return { stdout: "", stderr: "" };
+    });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result["container/web"]).toBeDefined();
+  });
+});

--- a/lexicons/docker/src/list-artifacts.ts
+++ b/lexicons/docker/src/list-artifacts.ts
@@ -1,0 +1,164 @@
+/**
+ * Live introspection of a Docker host via three independent CLI queries.
+ *
+ * The Docker lexicon's chant entities describe Compose / Dockerfile
+ * authoring primitives. The runtime concept (running containers, local
+ * images, networks) is created by `docker compose up` / `docker run` /
+ * `docker network create` outside chant's entity model.
+ *
+ *   docker ps         --format '{{json .}}'  → running containers
+ *   docker image ls   --format '{{json .}}'  → local images
+ *   docker network ls --format '{{json .}}'  → networks
+ *
+ * Output is one JSON object per line (NDJSON), not a JSON array. Daemon
+ * unreachable on any query → that query returns nothing; other queries
+ * still proceed.
+ */
+
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { ArtifactMetadata } from "@intentius/chant/lexicon";
+
+const execAsync = promisify(exec);
+
+interface DockerContainer {
+  Names?: string;
+  ID?: string;
+  Image?: string;
+  Command?: string;
+  State?: string;        // "running" | "exited" | "created" | ...
+  Status?: string;       // "Up 5 minutes" | "Exited (0) 1 hour ago" | ...
+  Ports?: string;
+  Mounts?: string;
+}
+
+interface DockerImage {
+  ID?: string;
+  Repository?: string;
+  Tag?: string;
+  CreatedAt?: string;
+  Size?: string;
+}
+
+interface DockerNetwork {
+  ID?: string;
+  Name?: string;
+  Driver?: string;
+  Scope?: string;
+  CreatedAt?: string;
+}
+
+function parseNdjson<T>(stdout: string): T[] {
+  const out: T[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      out.push(JSON.parse(trimmed));
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return out;
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined && v !== "") out[k] = v;
+  }
+  return out;
+}
+
+async function listContainers(): Promise<Record<string, ArtifactMetadata>> {
+  const result: Record<string, ArtifactMetadata> = {};
+  try {
+    const { stdout } = await execAsync("docker ps --format '{{json .}}'");
+    const containers = parseNdjson<DockerContainer>(stdout);
+    for (const c of containers) {
+      const name = c.Names;
+      if (!name) continue;
+      result[`container/${name}`] = {
+        type: "Docker::Container",
+        physicalId: c.ID,
+        status: c.State ?? c.Status ?? "PRESENT",
+        attributes: pruneUndefined({
+          image: c.Image,
+          command: c.Command,
+          ports: c.Ports,
+          mounts: c.Mounts,
+          fullStatus: c.Status,
+        }),
+      };
+    }
+  } catch {
+    // Docker daemon unreachable — return empty, don't fail the lexicon
+  }
+  return result;
+}
+
+async function listImages(): Promise<Record<string, ArtifactMetadata>> {
+  const result: Record<string, ArtifactMetadata> = {};
+  try {
+    const { stdout } = await execAsync("docker image ls --format '{{json .}}'");
+    const images = parseNdjson<DockerImage>(stdout);
+    for (const img of images) {
+      if (!img.Repository || img.Repository === "<none>") continue;
+      const tag = img.Tag && img.Tag !== "<none>" ? img.Tag : "latest";
+      const key = `image/${img.Repository}:${tag}`;
+      result[key] = {
+        type: "Docker::Image",
+        physicalId: img.ID,
+        status: "PRESENT",
+        lastUpdated: img.CreatedAt,
+        attributes: pruneUndefined({
+          repository: img.Repository,
+          tag,
+          size: img.Size,
+        }),
+      };
+    }
+  } catch {
+    // Docker daemon unreachable
+  }
+  return result;
+}
+
+async function listNetworks(): Promise<Record<string, ArtifactMetadata>> {
+  const result: Record<string, ArtifactMetadata> = {};
+  try {
+    const { stdout } = await execAsync("docker network ls --format '{{json .}}'");
+    const networks = parseNdjson<DockerNetwork>(stdout);
+    for (const net of networks) {
+      const name = net.Name;
+      if (!name) continue;
+      result[`network/${name}`] = {
+        type: "Docker::Network",
+        physicalId: net.ID,
+        status: "PRESENT",
+        lastUpdated: net.CreatedAt,
+        attributes: pruneUndefined({
+          driver: net.Driver,
+          scope: net.Scope,
+        }),
+      };
+    }
+  } catch {
+    // Docker daemon unreachable
+  }
+  return result;
+}
+
+export async function listArtifacts(_options: {
+  environment: string;
+  entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
+}): Promise<Record<string, ArtifactMetadata>> {
+  // Three independent queries — failure of one doesn't block the others.
+  const [containers, images, networks] = await Promise.all([
+    listContainers(),
+    listImages(),
+    listNetworks(),
+  ]);
+
+  return { ...containers, ...images, ...networks };
+}

--- a/lexicons/docker/src/plugin.ts
+++ b/lexicons/docker/src/plugin.ts
@@ -245,4 +245,9 @@ export const api = new Service({
       ],
     },
   ]),
+
+  async listArtifacts(options) {
+    const { listArtifacts } = await import("./list-artifacts");
+    return listArtifacts(options);
+  },
 };


### PR DESCRIPTION
## Summary

Closes #53. Brings Docker into the artifact-supported lexicon set. Three independent shell-outs run in parallel; failure of any one doesn't block the others.

```bash
docker ps         --format '{{json .}}'  # → containers
docker image ls   --format '{{json .}}'  # → images
docker network ls --format '{{json .}}'  # → networks
```

| Query | Key prefix | type | physicalId | status |
|---|---|---|---|---|
| `docker ps` | `container/<name>` | `Docker::Container` | container ID | `state` (running / exited / ...) |
| `docker image ls` | `image/<repo>:<tag>` | `Docker::Image` | image ID | `PRESENT` |
| `docker network ls` | `network/<name>` | `Docker::Network` | network ID | `PRESENT` |

## Failure modes

- Daemon unreachable on any query → that query returns `{}`; other queries still proceed
- Dangling images (Repository=`<none>`) are skipped
- Malformed NDJSON lines are skipped per-line — one bad row doesn't poison the query

## Tests (6 new)

- Happy path: containers + images + networks all reported
- Daemon unreachable on all queries → `{}`
- Per-query failure isolation (containers fail → still get images/networks)
- Container `Status` surfaces in attributes.fullStatus
- Dangling images skipped
- Malformed NDJSON line skipped, others parsed

## Verification

- `just build` clean
- `npx vitest run lexicons/docker/` → all green

## Depends on

- #51 (the `listArtifacts()` contract) — already merged.