### PR TITLE
feat(flyway): listArtifacts() — per-env migration history (#54)

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -94,7 +94,7 @@ A single lexicon may emit both resources (entity-keyed) and artifacts (context-k
 | Azure | ✅ |  |
 | Helm | | ✅ |
 | Docker | | ✅ |
-| Flyway | | ⏳ #54 |
+| Flyway | | ✅ |
 | Slurm | | ⏳ #55 |
 | GitHub / GitLab | | N/A — see #56 |
 

--- a/lexicons/flyway/src/list-artifacts.test.ts
+++ b/lexicons/flyway/src/list-artifacts.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, exec: (cmd: string, cb: (err: Error | null, out: { stdout: string; stderr: string }) => void) => {
+    Promise.resolve(execMock(cmd)).then(
+      (out) => cb(null, out),
+      (err) => cb(err as Error, { stdout: "", stderr: "" }),
+    );
+  } };
+});
+
+const { listArtifacts } = await import("./list-artifacts");
+
+function makeEntities(records: Array<{ name: string; entityType: string; props: Record<string, unknown> }>) {
+  return new Map(records.map((r) => [r.name, { entityType: r.entityType, props: r.props }]));
+}
+
+describe("flyway listArtifacts", () => {
+  beforeEach(() => {
+    execMock.mockReset();
+  });
+
+  test("queries flyway info per declared environment and maps migrations", async () => {
+    let cmdsRun: string[] = [];
+    execMock.mockImplementation((cmd: string) => {
+      cmdsRun.push(cmd);
+      return {
+        stdout: JSON.stringify({
+          schemaName: "public",
+          migrations: [
+            { version: "1", description: "init", type: "SQL", state: "Success", installedRank: 1, installedOn: "2026-04-01T00:00:00Z" },
+            { version: "2", description: "add users",  type: "SQL", state: "Success", installedRank: 2, installedOn: "2026-04-15T00:00:00Z" },
+            { version: "3", description: "add orders", type: "SQL", state: "Pending" },
+          ],
+        }),
+        stderr: "",
+      };
+    });
+
+    const entities = makeEntities([
+      { name: "prod", entityType: "Flyway::Environment", props: { name: "production" } },
+    ]);
+
+    const result = await listArtifacts({ environment: "prod", entities });
+
+    expect(cmdsRun).toEqual(["flyway info -environments=production -outputType=json"]);
+    expect(Object.keys(result).sort()).toEqual([
+      "migration/production/1",
+      "migration/production/2",
+      "migration/production/3",
+    ]);
+    expect(result["migration/production/2"]).toEqual({
+      type: "Flyway::Migration",
+      physicalId: "production/2",
+      status: "Success",
+      lastUpdated: "2026-04-15T00:00:00Z",
+      attributes: {
+        environment: "production",
+        description: "add users",
+        migrationType: "SQL",
+        installedRank: 2,
+      },
+    });
+    expect(result["migration/production/3"].status).toBe("Pending");
+  });
+
+  test("multiple declared envs each get their own flyway info call", async () => {
+    let cmdsRun: string[] = [];
+    execMock.mockImplementation((cmd: string) => {
+      cmdsRun.push(cmd);
+      return { stdout: JSON.stringify({ migrations: [{ version: "1", state: "Success" }] }), stderr: "" };
+    });
+
+    const entities = makeEntities([
+      { name: "prod",    entityType: "Flyway::Environment", props: { name: "production" } },
+      { name: "staging", entityType: "Flyway::Environment", props: { name: "staging" } },
+    ]);
+
+    const result = await listArtifacts({ environment: "prod", entities });
+
+    expect(cmdsRun.sort()).toEqual([
+      "flyway info -environments=production -outputType=json",
+      "flyway info -environments=staging -outputType=json",
+    ]);
+    expect(result["migration/production/1"]).toBeDefined();
+    expect(result["migration/staging/1"]).toBeDefined();
+  });
+
+  test("missing flyway binary on one env warns and continues with others", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    execMock.mockImplementation((cmd: string) => {
+      if (cmd.includes("environments=broken")) {
+        throw new Error("flyway: command not found");
+      }
+      return { stdout: JSON.stringify({ migrations: [{ version: "1", state: "Success" }] }), stderr: "" };
+    });
+
+    const entities = makeEntities([
+      { name: "broken", entityType: "Flyway::Environment", props: { name: "broken" } },
+      { name: "ok",     entityType: "Flyway::Environment", props: { name: "ok" } },
+    ]);
+
+    const result = await listArtifacts({ environment: "prod", entities });
+
+    expect(Object.keys(result).filter((k) => k.includes("/broken/"))).toEqual([]);
+    expect(result["migration/ok/1"]).toBeDefined();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test("Failed migration state surfaces correctly", async () => {
+    execMock.mockResolvedValue({
+      stdout: JSON.stringify({ migrations: [{ version: "5", description: "broken", state: "Failed" }] }),
+      stderr: "",
+    });
+    const entities = makeEntities([
+      { name: "prod", entityType: "Flyway::Environment", props: { name: "production" } },
+    ]);
+    const result = await listArtifacts({ environment: "prod", entities });
+    expect(result["migration/production/5"].status).toBe("Failed");
+  });
+
+  test("no declared envs → returns {} without spawning flyway", async () => {
+    const result = await listArtifacts({ environment: "prod", entities: makeEntities([]) });
+    expect(result).toEqual({});
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  test("non-Flyway entity types are ignored", async () => {
+    execMock.mockResolvedValue({ stdout: JSON.stringify({ migrations: [] }), stderr: "" });
+    const entities = makeEntities([
+      { name: "x", entityType: "AWS::S3::Bucket", props: { name: "x" } },
+    ]);
+    const result = await listArtifacts({ environment: "prod", entities });
+    expect(result).toEqual({});
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  test("malformed JSON output → warn-skipped", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    execMock.mockResolvedValue({ stdout: "not valid json", stderr: "" });
+    const entities = makeEntities([
+      { name: "prod", entityType: "Flyway::Environment", props: { name: "production" } },
+    ]);
+    const result = await listArtifacts({ environment: "prod", entities });
+    expect(result).toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("malformed JSON"));
+    warnSpy.mockRestore();
+  });
+});

--- a/lexicons/flyway/src/list-artifacts.ts
+++ b/lexicons/flyway/src/list-artifacts.ts
@@ -1,0 +1,110 @@
+/**
+ * Live introspection of applied Flyway migrations via `flyway info -outputType=json`.
+ *
+ * The Flyway lexicon's chant entities describe migration *configuration*
+ * (`Flyway::Project`, `Flyway::Config`, `Flyway::Environment`). The runtime
+ * concept — the migration history applied to a target DB — is created by
+ * `flyway migrate` outside chant's entity model. This implementation reports
+ * the migration history per declared `Flyway::Environment` so `state diff
+ * --live` / `WatchOp` can detect manual migrations run outside CI.
+ *
+ * Per-env query pattern: discovers envs via the `entities` map (see #39's
+ * entity-prop pass-through). Failure on one env (DB unreachable, flyway
+ * binary missing) is warn-soft; other envs still proceed.
+ */
+
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { ArtifactMetadata } from "@intentius/chant/lexicon";
+
+const execAsync = promisify(exec);
+
+interface FlywayMigration {
+  version?: string | null;
+  description?: string;
+  type?: string;          // "SQL" | "JDBC" | "BASELINE" | ...
+  state?: string;         // "Success" | "Failed" | "Pending" | "Baseline" | ...
+  installedRank?: number;
+  installedOn?: string;
+  installedBy?: string;
+  executionTime?: number;
+  checksum?: number | string;
+}
+
+interface FlywayInfoResponse {
+  migrations?: FlywayMigration[];
+  schemaName?: string;
+  database?: string;
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined && v !== null) out[k] = v;
+  }
+  return out;
+}
+
+export async function listArtifacts(options: {
+  environment: string;
+  entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
+}): Promise<Record<string, ArtifactMetadata>> {
+  const result: Record<string, ArtifactMetadata> = {};
+
+  // Discover declared Flyway::Environment names from the entities map.
+  const declaredEnvs: string[] = [];
+  for (const [, { entityType, props }] of options.entities) {
+    if (entityType !== "Flyway::Environment") continue;
+    const name = props.name as string | undefined;
+    if (name) declaredEnvs.push(name);
+  }
+
+  if (declaredEnvs.length === 0) return result;
+
+  for (const envName of declaredEnvs) {
+    const cmd = `flyway info -environments=${envName} -outputType=json`;
+    let stdout: string;
+    try {
+      ({ stdout } = await execAsync(cmd));
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[flyway] failed to query info for environment "${envName}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      continue;
+    }
+
+    let parsed: FlywayInfoResponse;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      // eslint-disable-next-line no-console
+      console.warn(`[flyway] malformed JSON output for environment "${envName}"`);
+      continue;
+    }
+
+    for (const migration of parsed.migrations ?? []) {
+      const version = migration.version ?? "<unversioned>";
+      const key = `migration/${envName}/${version}`;
+      result[key] = {
+        type: "Flyway::Migration",
+        physicalId: `${envName}/${version}`,
+        status: migration.state ?? "unknown",
+        lastUpdated: migration.installedOn,
+        attributes: pruneUndefined({
+          environment: envName,
+          description: migration.description,
+          migrationType: migration.type,
+          installedRank: migration.installedRank,
+          installedBy: migration.installedBy,
+          executionTimeMs: migration.executionTime,
+          checksum: migration.checksum,
+        }),
+      };
+    }
+  }
+
+  return result;
+}

--- a/lexicons/flyway/src/plugin.ts
+++ b/lexicons/flyway/src/plugin.ts
@@ -561,4 +561,9 @@ const result = VaultSecuredProject({
       ],
     },
   ]),
+
+  async listArtifacts(options) {
+    const { listArtifacts } = await import("./list-artifacts");
+    return listArtifacts(options);
+  },
 };


### PR DESCRIPTION
## Summary

Closes #54. Brings Flyway into the artifact-supported lexicon set. Different shape from Helm/Docker — Flyway uses a **per-environment query pattern**: it discovers declared `Flyway::Environment` entities via #39's entity-prop pass-through, then runs `flyway info -environments=<name> -outputType=json` per env.

Each migration in the response → an artifact:

```ts
migration/<env-name>/<version> = {
  type: "Flyway::Migration",
  physicalId: "<env>/<version>",
  status: <migration.state>,    // "Success" | "Failed" | "Pending" | ...
  lastUpdated: <migration.installedOn>,
  attributes: { environment, description, migrationType, installedRank, ... },
}
```

## Why this matters

Catches the canonical drift case: **"did someone run a manual migration on prod outside CI?"** A manual `flyway migrate` appears in the next snapshot's artifacts; `state diff --live` reports it as `ARTIFACTS ADDED`; `WatchOp` flips `Drift = "true"`.

## Failure modes

- Per-env: one env's failure (DB unreachable, binary missing) → warn-soft, other envs proceed
- No declared `Flyway::Environment` entities → returns `{}` without spawning anything
- Malformed JSON output → warn-skipped per env

## Tests (7 new)

- Happy path: 3 migrations in 3 different states (Success / Pending) keyed correctly
- Multiple declared envs each get their own `flyway info` call
- Per-env failure isolation with warning emitted
- `Failed` state surfaces correctly
- No declared envs → `{}`, no exec
- Non-Flyway entity types ignored
- Malformed JSON → warn, `{}`

## Verification

- `just build` clean
- `npx vitest run lexicons/flyway/` → all green

## Depends on

- #51 (the `listArtifacts()` contract) — already merged
- Reuses #39 entity-prop pass-through to discover declared envs