### PR TITLE
feat(slurm): listArtifacts() — partition state via sinfo (#55)

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -95,7 +95,7 @@ A single lexicon may emit both resources (entity-keyed) and artifacts (context-k
 | Helm | | ✅ |
 | Docker | | ✅ |
 | Flyway | | ✅ |
-| Slurm | | ⏳ #55 |
+| Slurm | | ✅ |
 | GitHub / GitLab | | N/A — see #56 |
 
 Lexicons that implement neither method are warn-skipped — `--live` doesn't fail the whole command for them.

--- a/lexicons/slurm/src/list-artifacts.test.ts
+++ b/lexicons/slurm/src/list-artifacts.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, exec: (cmd: string, cb: (err: Error | null, out: { stdout: string; stderr: string }) => void) => {
+    Promise.resolve(execMock(cmd)).then(
+      (out) => cb(null, out),
+      (err) => cb(err as Error, { stdout: "", stderr: "" }),
+    );
+  } };
+});
+
+const { listArtifacts } = await import("./list-artifacts");
+
+describe("slurm listArtifacts", () => {
+  beforeEach(() => {
+    execMock.mockReset();
+  });
+
+  test("happy path: maps newer-Slurm sinfo schema to partitions", async () => {
+    let receivedCmd = "";
+    execMock.mockImplementation((cmd: string) => {
+      receivedCmd = cmd;
+      return {
+        stdout: JSON.stringify({
+          sinfo: [
+            {
+              partition: { name: "compute", state: ["UP"] },
+              nodes: { count: 10, allocated: 4, idle: 6 },
+              cpus: { total: 320 },
+              memory: { total: 1024000 },
+            },
+            {
+              partition: { name: "gpu", state: ["UP"] },
+              nodes: { count: 4 },
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    });
+
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+
+    expect(receivedCmd).toBe("sinfo --json");
+    expect(Object.keys(result).sort()).toEqual(["partition/compute", "partition/gpu"]);
+    expect(result["partition/compute"]).toMatchObject({
+      type: "Slurm::Partition",
+      physicalId: "compute",
+      status: "UP",
+      attributes: { nodeCount: 10, nodesAllocated: 4, nodesIdle: 6, cpus: 320, memory: 1024000 },
+    });
+  });
+
+  test("sinfo not installed → returns {}", async () => {
+    execMock.mockImplementation(() => { throw new Error("sinfo: command not found"); });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result).toEqual({});
+  });
+
+  test("partition state surfaces (UP, DOWN, DRAIN)", async () => {
+    execMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        sinfo: [
+          { partition: { name: "p1", state: ["UP"] } },
+          { partition: { name: "p2", state: ["DOWN"] } },
+          { partition: { name: "p3", state: ["DRAIN"] } },
+        ],
+      }),
+      stderr: "",
+    });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result["partition/p1"].status).toBe("UP");
+    expect(result["partition/p2"].status).toBe("DOWN");
+    expect(result["partition/p3"].status).toBe("DRAIN");
+  });
+
+  test("empty cluster (no partitions) → {}", async () => {
+    execMock.mockResolvedValue({ stdout: JSON.stringify({ sinfo: [] }), stderr: "" });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result).toEqual({});
+  });
+
+  test("older Slurm flat schema is also handled", async () => {
+    execMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        partitions: [
+          { name: "compute", state: "UP" },
+        ],
+      }),
+      stderr: "",
+    });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result["partition/compute"]).toMatchObject({ status: "UP" });
+  });
+
+  test("duplicate partition entries from sinfo (per node-state bucket) are deduped", async () => {
+    execMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        sinfo: [
+          { partition: { name: "compute", state: ["UP"] }, nodes: { count: 6, idle: 6 } },
+          { partition: { name: "compute", state: ["UP"] }, nodes: { count: 4, allocated: 4 } },
+        ],
+      }),
+      stderr: "",
+    });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    // Only the first row wins — partition state is what matters for drift
+    expect(Object.keys(result)).toEqual(["partition/compute"]);
+  });
+
+  test("malformed JSON output → returns {}", async () => {
+    execMock.mockResolvedValue({ stdout: "not json", stderr: "" });
+    const result = await listArtifacts({ environment: "prod", entities: new Map() });
+    expect(result).toEqual({});
+  });
+});

--- a/lexicons/slurm/src/list-artifacts.ts
+++ b/lexicons/slurm/src/list-artifacts.ts
@@ -1,0 +1,106 @@
+/**
+ * Live introspection of a Slurm cluster via `sinfo --json`.
+ *
+ * The Slurm lexicon's chant entities describe sbatch-script authoring.
+ * Cluster-runtime queries — partitions, nodes, jobs — are conceptually
+ * orthogonal. We surface partition state because it's reasonably stable
+ * (drift = config change), and skip job history because it's high-churn
+ * (every snapshot would diff).
+ *
+ *   sinfo --json  →  partitions
+ *
+ * Slurm not installed → returns `{}` cleanly. The sinfo JSON schema
+ * varies by Slurm version; this implementation reads several common
+ * paths and degrades to "unknown" when fields are missing.
+ */
+
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { ArtifactMetadata } from "@intentius/chant/lexicon";
+
+const execAsync = promisify(exec);
+
+interface SinfoPartitionEntry {
+  // Newer Slurm (22+): { partition: { name, state }, nodes, cpus, memory }
+  partition?: { name?: string; state?: string[] | string };
+  nodes?: { count?: number; total?: number; allocated?: number; idle?: number };
+  cpus?: { total?: number };
+  memory?: { total?: number };
+  // Older fallback: flat fields
+  name?: string;
+  state?: string;
+  partition_name?: string;
+}
+
+interface SinfoResponse {
+  // Newer Slurm: { sinfo: [...] }
+  sinfo?: SinfoPartitionEntry[];
+  // Older fallback: top-level array
+  partitions?: SinfoPartitionEntry[];
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined && v !== null && v !== "") out[k] = v;
+  }
+  return out;
+}
+
+function partitionName(entry: SinfoPartitionEntry): string | undefined {
+  return entry.partition?.name ?? entry.name ?? entry.partition_name;
+}
+
+function partitionState(entry: SinfoPartitionEntry): string {
+  const s = entry.partition?.state ?? entry.state;
+  if (Array.isArray(s)) return s.join(",") || "UNKNOWN";
+  if (typeof s === "string") return s;
+  return "UNKNOWN";
+}
+
+export async function listArtifacts(_options: {
+  environment: string;
+  entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
+}): Promise<Record<string, ArtifactMetadata>> {
+  const result: Record<string, ArtifactMetadata> = {};
+
+  let stdout: string;
+  try {
+    ({ stdout } = await execAsync("sinfo --json"));
+  } catch {
+    // sinfo not on PATH or no Slurm cluster context — return empty
+    return result;
+  }
+
+  let parsed: SinfoResponse;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return result;
+  }
+
+  const entries = parsed.sinfo ?? parsed.partitions ?? [];
+  for (const entry of entries) {
+    const name = partitionName(entry);
+    if (!name) continue;
+    const key = `partition/${name}`;
+    // Skip duplicates — sinfo rows can repeat the same partition with different
+    // node-state buckets; we just want one row per partition for drift purposes.
+    if (key in result) continue;
+
+    result[key] = {
+      type: "Slurm::Partition",
+      physicalId: name,
+      status: partitionState(entry),
+      attributes: pruneUndefined({
+        nodeCount: entry.nodes?.count ?? entry.nodes?.total,
+        nodesAllocated: entry.nodes?.allocated,
+        nodesIdle: entry.nodes?.idle,
+        cpus: entry.cpus?.total,
+        memory: entry.memory?.total,
+      }),
+    };
+  }
+
+  return result;
+}

--- a/lexicons/slurm/src/plugin.ts
+++ b/lexicons/slurm/src/plugin.ts
@@ -218,4 +218,9 @@ export const slurmPlugin: LexiconPlugin = {
     const { generateDocs } = await import("./codegen/docs");
     return generateDocs(options);
   },
+
+  async listArtifacts(options) {
+    const { listArtifacts } = await import("./list-artifacts");
+    return listArtifacts(options);
+  },
 };


### PR DESCRIPTION
## Summary

Closes #55. Brings Slurm into the artifact-supported lexicon set.

**Design decision (per issue #55): `sinfo`, not `sacct`.** Partitions are configured infrastructure (drift = config change). `sacct` returns job history, which would diff every snapshot — wrong shape for drift detection.

```bash
sinfo --json
```

Each partition → one artifact:

```ts
partition/<name> = {
  type: "Slurm::Partition",
  physicalId: "<name>",
  status: <partition.state>,    // "UP" | "DOWN" | "DRAIN" | ...
  attributes: { nodeCount, nodesAllocated, nodesIdle, cpus, memory },
}
```

## Schema tolerance

The `sinfo --json` schema varies by Slurm version. This implementation handles both:
- Newer (Slurm 22+): `{ sinfo: [{ partition: { name, state }, nodes: {...} }] }`
- Older: `{ partitions: [{ name, state }] }`

Falls back to `UNKNOWN` for missing fields. `sinfo` not installed → `{}` cleanly. Duplicate partition rows (sinfo emits one per node-state bucket) are deduped to one row per partition.

## Tests (7 new)

- Happy path: newer schema with two partitions (compute, gpu)
- `sinfo` not installed → `{}`, no throw
- Partition state mapping (UP / DOWN / DRAIN)
- Empty cluster → `{}`
- Older flat schema also works
- Duplicate partition rows deduped
- Malformed JSON → `{}`

## Verification

- `just build` clean
- `npx vitest run lexicons/slurm/` → all green

## Out of scope (per issue body)

- Job history via `sacct` — separate `listRecentRuns()` contract if needed
- Per-node detail beyond partition aggregation

## Depends on

- #51 (the `listArtifacts()` contract) — already merged