### PR TITLE
docs(github,gitlab): document runtime observation as N/A (#56)

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -96,7 +96,7 @@ A single lexicon may emit both resources (entity-keyed) and artifacts (context-k
 | Docker | | ✅ |
 | Flyway | | ✅ |
 | Slurm | | ✅ |
-| GitHub / GitLab | | N/A — see #56 |
+| GitHub / GitLab | | N/A — see lexicon READMEs |
 
 Lexicons that implement neither method are warn-skipped — `--live` doesn't fail the whole command for them.
 

--- a/lexicons/github/README.md
+++ b/lexicons/github/README.md
@@ -1,0 +1,21 @@
+# @intentius/chant-lexicon-github
+
+GitHub Actions lexicon for [chant](https://intentius.io/chant/) — declare workflow definitions as typed TypeScript that serializes to `.github/workflows/*.yml`.
+
+```bash
+npm install --save-dev @intentius/chant @intentius/chant-lexicon-github
+```
+
+## Runtime observation: N/A
+
+`chant state snapshot` and `chant state diff --live` operate by querying a runtime equivalent of each declared resource. The GitHub lexicon doesn't fit that model:
+
+- The lexicon's chant entities describe **GitHub Actions workflow definitions**, which are git-tracked. Drift in the definition itself is just `git diff` — no observation surface needed.
+- Workflow **runs** are events (per-execution), not declared state. They're observable via the GitHub API but the abstraction is `listRecentRuns()`, not `describeResources()` or `listArtifacts()`. That's a separate plugin contract if/when it's needed.
+- "Is this workflow enabled in the GitHub UI?" is theoretically observable but a marginal use case.
+
+If a concrete observation use case surfaces, file a focused issue rather than retrofitting `listArtifacts()` to fit.
+
+## License
+
+See the main project LICENSE file.

--- a/lexicons/gitlab/README.md
+++ b/lexicons/gitlab/README.md
@@ -17,6 +17,16 @@ npm install --save-dev @intentius/chant @intentius/chant-lexicon-gitlab
 | [@intentius/chant](https://www.npmjs.com/package/@intentius/chant) | Core type system, CLI, build pipeline |
 | [@intentius/chant-lexicon-aws](https://www.npmjs.com/package/@intentius/chant-lexicon-aws) | AWS CloudFormation lexicon |
 
+## Runtime observation: N/A
+
+`chant state snapshot` and `chant state diff --live` operate by querying a runtime equivalent of each declared resource. The GitLab lexicon doesn't fit that model:
+
+- The lexicon's chant entities (`Job`, `Workflow`, `Default`, `Image`, `Rule`, etc.) describe **CI pipeline definitions**, which are git-tracked. Drift in the definition itself is just `git diff` — no observation surface needed.
+- Pipeline **runs** are events (per-execution), not declared state. They're observable via the GitLab API but the abstraction is `listRecentRuns()`, not `describeResources()` or `listArtifacts()`. That's a separate plugin contract if/when it's needed.
+- "Is this workflow enabled in the GitLab UI?" is theoretically observable but a marginal use case.
+
+If a concrete observation use case surfaces, file a focused issue rather than retrofitting `listArtifacts()` to fit.
+
 ## License
 
 See the main project LICENSE file.


### PR DESCRIPTION
## Summary

Closes #56. Final piece of the artifact-observation initiative — documents why the github and gitlab lexicons don't (and shouldn't) implement `describeResources()` or `listArtifacts()`.

## What this changes

- New `lexicons/github/README.md` (didn't exist before) with a "Runtime observation: N/A" section
- Same section appended to `lexicons/gitlab/README.md`
- `cli/state.mdx` coverage table updated to point to lexicon READMEs for the N/A reasoning

## The reasoning (in the READMEs)

- Workflow/pipeline definitions are git-tracked. Drift in the definition is just `git diff`.
- Workflow/pipeline **runs** are events, not declared state. Observable via API, but the right abstraction would be `listRecentRuns()` — a different plugin contract that would need to be designed separately.
- Workflow enablement state is theoretically observable but a marginal use case.

If a concrete need surfaces, file a focused issue rather than retrofitting `listArtifacts()` to fit.

## Verification

- `just build` clean
- Doc-only — no test changes

## Wraps up

This is the last of the 6 split-out issues from #50. After this merges, the artifact-observation initiative is complete:

| | |
|---|---|
| #51 | ✅ contract + state-pipeline integration |
| #52 | ✅ Helm |
| #53 | ✅ Docker |
| #54 | ✅ Flyway |
| #55 | ✅ Slurm |
| #56 | this PR |