### PR TITLE
docs: add What's New page + lexicon observation coverage matrix

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig({
 						{ label: 'Quick Start', slug: 'getting-started/quick-start' },
 						{ label: 'Project Structure', slug: 'getting-started/project-structure' },
 						{ label: 'Configuration', slug: 'getting-started/configuration' },
+						{ label: "What's New", slug: 'whats-new' },
 					],
 				},
 				{

--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -85,6 +85,8 @@ For the conceptual distinction between resources and artifacts, see [Drift Detec
 
 ### Coverage today
 
+See the [Runtime observation coverage matrix](/chant/lexicons/overview/#runtime-observation-coverage) on the Lexicons overview page for the canonical version with query-mechanism notes. Summary:
+
 | Lexicon | `describeResources()` | `listArtifacts()` |
 |---|---|---|
 | AWS | ✅ |  |

--- a/docs/src/content/docs/concepts/drift-detection.mdx
+++ b/docs/src/content/docs/concepts/drift-detection.mdx
@@ -93,7 +93,7 @@ chant's observational model is a deliberate choice, not a missing feature. The c
 - **No automatic remediation.** Drift tells you something changed; it doesn't snap the cloud back. That's an agent or a human decision because the right answer is domain-specific.
 - **No automatic plan/apply.** Without authoritative state, chant can't compute a precise change set the way Terraform does. Diff output is informational; the apply step is your existing tooling.
 - **No locking.** Two operators snapshotting the same env at the same time race on the orphan branch. The push uses `--force-with-lease` so the second writer fails fast rather than silently overwriting (see [Concurrent snapshots](/chant/cli/state/#concurrent-snapshots)).
-- **Coverage is per-lexicon.** A lexicon without `describeResources()` / `listArtifacts()` is warn-skipped. The user-facing matrix in [`chant state`](/chant/cli/state/#coverage-today) lists where coverage exists today.
+- **Coverage is per-lexicon.** A lexicon without `describeResources()` / `listArtifacts()` is warn-skipped. The [Runtime observation coverage matrix](/chant/lexicons/overview/#runtime-observation-coverage) lists where coverage exists today.
 
 Read these trade-offs in context in [How chant compares](/chant/concepts/comparison/#honest-trade-offs).
 

--- a/docs/src/content/docs/guide/watching-state.mdx
+++ b/docs/src/content/docs/guide/watching-state.mdx
@@ -55,7 +55,7 @@ The two phases compile down to a workflow that, on each tick:
 1. **`Snapshot`** — calls the `stateSnapshot` activity, which shells out to `chant state snapshot prod`. The result is committed to the `chant/state` orphan branch. (Concurrent runs are protected by `--force-with-lease` — see [Concurrent snapshots](/chant/cli/state/#concurrent-snapshots).)
 2. **`Diff`** — calls `stateDiff` with `live: true`. The activity returns `{ output, exitCode, drifted }`. The `drifted` boolean is captured as a workflow search attribute via `outcomeAttribute: { name: "Drift", from: "drifted" }`.
 
-Set `live: false` on the composite to use digest-only diff (faster, no cloud queries) for environments without `describeResources()` coverage. With `live: true` (the default) you get external-mutation detection.
+Set `live: false` on the composite to use digest-only diff (faster, no cloud queries) for environments without `describeResources()` coverage. With `live: true` (the default) you get external-mutation detection. (See the [Runtime observation coverage matrix](/chant/lexicons/overview/#runtime-observation-coverage) for which lexicons report what.)
 
 ## The Temporal UI experience
 

--- a/docs/src/content/docs/lexicons/overview.mdx
+++ b/docs/src/content/docs/lexicons/overview.mdx
@@ -21,6 +21,26 @@ A **lexicon** is a collection of types and semantic lint rules for an operationa
 | Slurm | `@intentius/chant-lexicon-slurm` | 10 resources (conf + REST) | [Reference](/chant/lexicons/slurm/) |
 | Temporal | `@intentius/chant-lexicon-temporal` | 4 resources + Op workflow engine | [Reference](/chant/lexicons/temporal/) |
 
+## Runtime observation coverage
+
+Lexicons opt into the `chant state diff <env> --live` pipeline by implementing one of two plugin methods: `describeResources()` (entity-keyed — for 1:1 cloud resources) or `listArtifacts()` (context-keyed — for runtime concepts created by tooling outside chant's entity model). See [Drift Detection — Resources and artifacts](/chant/concepts/drift-detection/#resources-and-artifacts) for the conceptual distinction, and [Implementing Observation](/chant/lexicon-authoring/observation/) for the author-side walkthrough.
+
+| Lexicon | `describeResources()` | `listArtifacts()` | Notes |
+|---|---|---|---|
+| AWS | ✅ |  | `aws cloudformation describe-stack-resources` |
+| Azure | ✅ |  | `az resource show` per declared entity; resource-group is the env name |
+| GCP (Config Connector) | ✅ |  | `kubectl get <gvk>` against the GKE management cluster |
+| Kubernetes | ✅ |  | `kubectl get <kind>` per declared entity; ~20 common types |
+| Temporal | ✅ |  | Temporal client — namespaces, search attributes, schedules |
+| Helm |  | ✅ | `helm list -A -o json` — releases as artifacts |
+| Docker |  | ✅ | `docker ps`, `docker image ls`, `docker network ls` (NDJSON) |
+| Flyway |  | ✅ | `flyway info -outputType=json` per declared `Flyway::Environment` |
+| Slurm |  | ✅ | `sinfo` partition state |
+| GitHub Actions |  |  | N/A — workflow definitions are git-tracked; drift is `git diff` ([rationale](https://github.com/INTENTIUS/chant/blob/main/lexicons/github/README.md#runtime-observation-na)) |
+| GitLab CI/CD |  |  | N/A — same rationale ([README](https://github.com/INTENTIUS/chant/blob/main/lexicons/gitlab/README.md#runtime-observation-na)) |
+
+Lexicons that implement neither are warn-skipped — `--live` doesn't fail the whole command for them.
+
 ## What a Lexicon Provides
 
 ### Types

--- a/docs/src/content/docs/whats-new.mdx
+++ b/docs/src/content/docs/whats-new.mdx
@@ -1,0 +1,69 @@
+---
+title: What's New
+description: Recent capabilities shipped in chant — observation contracts, drift detection, WatchOp, Op codegen improvements, and more
+---
+
+A hand-curated rollup of capabilities shipped recently. If you learned chant before this lands, this page is the catch-up. Each entry links to the closing issue or PR for the full context.
+
+For the day-to-day reference docs see [`chant state`](/chant/cli/state/), [Watching State](/chant/guide/watching-state/), [Drift Detection](/chant/concepts/drift-detection/), and [Implementing Observation](/chant/lexicon-authoring/observation/).
+
+## Observation & drift detection
+
+The biggest single thread. `chant state diff` went from a digest-vs-digest fingerprint check to a real live-vs-declared-vs-snapshot diff that catches out-of-band cloud mutations across nine lexicons.
+
+| # | Capability |
+|---|---|
+| [#26](https://github.com/INTENTIUS/chant/issues/26) | `chant state diff <env> --live` — three-way diff (declared / observed-now / observed-then), six resource categories (missing / orphan / disappeared / newly observed / drifted / unchanged) with attribute-level deltas |
+| [#27](https://github.com/INTENTIUS/chant/issues/27) | Temporal lexicon `describeResources()` — namespaces, search attributes, schedules |
+| [#39](https://github.com/INTENTIUS/chant/issues/39) | `describeResources()` contract gains entity-prop pass-through — lexicons now receive declared props (e.g. K8s `metadata.name`/`namespace`) and can map cloud-side identifiers back to chant entity names |
+| [#42](https://github.com/INTENTIUS/chant/issues/42) | Five `describeResources()` implementations — AWS, Azure, GCP (Config Connector), Kubernetes, Temporal |
+| [#51](https://github.com/INTENTIUS/chant/issues/51) | `listArtifacts()` plugin contract — context-keyed observation for lexicons whose chant entities describe authoring primitives rather than 1:1 cloud resources |
+| [#52](https://github.com/INTENTIUS/chant/issues/52) | Helm `listArtifacts()` — Helm releases via `helm list -A -o json` |
+| [#53](https://github.com/INTENTIUS/chant/issues/53) | Docker `listArtifacts()` — containers / images / networks via three independent NDJSON queries |
+| [#54](https://github.com/INTENTIUS/chant/issues/54) | Flyway `listArtifacts()` — per-environment migration history |
+| [#55](https://github.com/INTENTIUS/chant/issues/55) | Slurm `listArtifacts()` — partition state via `sinfo` |
+| [#56](https://github.com/INTENTIUS/chant/issues/56) | GitHub / GitLab — runtime observation documented as N/A; both describe git-tracked authoring primitives where drift is `git diff` |
+| [#30](https://github.com/INTENTIUS/chant/issues/30) | `chant/state` orphan branch concurrency — pushes use `--force-with-lease`; concurrent snapshots fail fast instead of silently overwriting |
+| [#31](https://github.com/INTENTIUS/chant/issues/31) | `WatchOp` composite — periodic state observation by pairing an `Op` (Snapshot + Diff phases) with a `TemporalSchedule` |
+
+## Op runtime
+
+The Op composite gained two ergonomic upgrades that were previously hand-coded boilerplate in every example.
+
+| # | Capability |
+|---|---|
+| [#28](https://github.com/INTENTIUS/chant/issues/28) | Op codegen auto-emits `upsertSearchAttributes()` — `OpName` at workflow start, `Phase` at each phase boundary, plus any user-declared `searchAttributes`. No more hand-rolled boilerplate; `chant run list` and Temporal UI filters work out of the box |
+| [#41](https://github.com/INTENTIUS/chant/issues/41) | `outcomeAttribute` on activity steps — capture an activity's return value (e.g. `stateDiff`'s `drifted` boolean) as a workflow search attribute. Used by `WatchOp` to surface `Drift = "true"`/`"false"` per run |
+| [#29](https://github.com/INTENTIUS/chant/issues/29), [#40](https://github.com/INTENTIUS/chant/issues/40) | Test coverage for `cli/handlers/state.ts`, `run.ts`, `graph.ts`, and `runOp` — refactor surface is now safe |
+
+## Build pipeline & lexicon fixes
+
+| # | Capability |
+|---|---|
+| [#21](https://github.com/INTENTIUS/chant/issues/21) | Lexicon root `index.ts` re-exports — three composites that examples imported through deep paths now exported from the package root; silent build failures resolved |
+| [#23](https://github.com/INTENTIUS/chant/issues/23), [#25](https://github.com/INTENTIUS/chant/pull/25) | Azure schema parser — upstream renamed `NetworkInterfaceIPConfiguration` / `SubnetPropertiesFormat` / `SecurityRule` to `Common*`-prefixed names; bare property aliases now apply correctly, CI green |
+| [#38](https://github.com/INTENTIUS/chant/issues/38) | `chant build` writes output paths whose parent directory doesn't exist (mkdir-p) — previously failed with `ENOENT` on first build of a project with nested output dirs |
+
+## Doc rollup
+
+After all the runtime work shipped, the docs site got a sweep to surface it:
+
+| # | Capability |
+|---|---|
+| [#63](https://github.com/INTENTIUS/chant/issues/63) | Accuracy fixes — stale claims, broken links, rollup misses across `index.mdx`, comparison, philosophy, installation, quick-start, cli/overview |
+| [#64](https://github.com/INTENTIUS/chant/issues/64) | [Watching State](/chant/guide/watching-state/) — first-class user-guide page for `WatchOp` (was previously a subsection of the Ops guide) |
+| [#65](https://github.com/INTENTIUS/chant/issues/65) | [Implementing Observation](/chant/lexicon-authoring/observation/) — lexicon-author walkthrough of `describeResources()` and `listArtifacts()` with patterns from all 9 shipping implementations |
+| [#66](https://github.com/INTENTIUS/chant/issues/66) | [Drift Detection](/chant/concepts/drift-detection/) — concept page for the observational state model, ten diff categories, and when drift detection earns its keep |
+| [#67](https://github.com/INTENTIUS/chant/issues/67) | This page + the [lexicon observation coverage matrix](/chant/lexicons/overview/#runtime-observation-coverage) |
+
+## Earlier — the Op core (#5–#11)
+
+These shipped before the observation thread but underpin everything above. Listed for completeness:
+
+- [#5](https://github.com/INTENTIUS/chant/issues/5) Node.js migration + dev toolchain cleanup
+- [#6](https://github.com/INTENTIUS/chant/issues/6) Temporal lexicon — `TemporalNamespace`, `TemporalSchedule`, `SearchAttribute`, plus the lint rules and composites
+- [#7](https://github.com/INTENTIUS/chant/issues/7) Op composite + build pipeline integration
+- [#8](https://github.com/INTENTIUS/chant/issues/8) `chant run` CLI
+- [#9](https://github.com/INTENTIUS/chant/issues/9) MCP tools for Op
+- [#10](https://github.com/INTENTIUS/chant/issues/10) Migrate spells to Ops
+- [#11](https://github.com/INTENTIUS/chant/issues/11) Op replaces spells with Temporal-backed deployment workflows


### PR DESCRIPTION
Closes #67.

Two small additions to make the recent runtime work discoverable for users who learned chant before the observation thread shipped.

## What's new

### `whats-new.mdx`

A hand-curated rollup of #21–#62, grouped by area:

- **Observation & drift detection** (#26, #27, #39, #42, #51–#56, #30, #31) — the biggest single thread, from `state diff --live` through five `describeResources()` and four `listArtifacts()` implementations to `WatchOp` and concurrent-snapshot locking
- **Op runtime** (#28, #41, #29, #40) — auto-emit `upsertSearchAttributes`, `outcomeAttribute` for activity-result search attrs, test coverage on the CLI handlers
- **Build pipeline & lexicon fixes** (#21, #23/#25, #38) — lexicon root re-exports, Azure parser fix, `chant build` mkdir-p
- **Doc rollup** (#63–#67) — accuracy fixes, Watching State, Implementing Observation, Drift Detection, this page
- **Earlier — Op core (#5–#11)** for completeness

One-line summary per entry with link to the closing issue. Sidebar entry under Getting Started.

### Runtime observation coverage matrix

Added a \"Runtime observation coverage\" section to `lexicons/overview.mdx` with the Lexicon × `describeResources()` / `listArtifacts()` table including a query-mechanism note per lexicon. Cross-linked from:

- `cli/state.mdx#coverage-today` (now points at the canonical matrix while keeping the abbreviated table for quick reference)
- `concepts/drift-detection.mdx` (in the Honest trade-offs section)
- `guide/watching-state.mdx` (next to the `live: false` mention)

## Verification

- `cd docs && npm run build` → 304 pages built clean (+1 from baseline)

## Test plan
- [x] Docs build succeeds locally
- [x] All issue links resolve
- [x] All cross-page links resolve
- [ ] CI green