### PR TITLE
docs: fix residual link-check errors + add PR-only lychee CI (#75)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,52 @@
+name: docs-check
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'lexicons/*/docs/**'
+      - 'lexicons/*/src/codegen/**'
+      - 'packages/core/src/codegen/**'
+      - 'scripts/build-docs.sh'
+      - 'scripts/build-diagrams.sh'
+      - 'justfile'
+      - '.github/workflows/docs-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm install
+
+      - name: Install Graphviz
+        run: sudo apt-get install -y graphviz
+
+      - name: Cache lexicon schemas
+        uses: actions/cache@v4
+        with:
+          path: ~/.chant
+          key: lexicon-schemas-${{ hashFiles('lexicons/*/src/**/fetch.ts', 'lexicons/*/src/**/versions.ts') }}
+          restore-keys: |
+            lexicon-schemas-
+
+      - name: Build unified docs
+        run: chmod +x scripts/build-docs.sh && ./scripts/build-docs.sh
+
+      - name: Run lychee link check
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --offline --no-progress
+            --root-dir ${{ github.workspace }}/.docs-dist
+            --exclude '\.(css|js|mjs|svg|png|jpe?g|ico|woff2?|map|json|xml|webp|avif|gif)$'
+            --exclude 'pagefind/'
+            '.docs-dist/chant/**/*.html'
+          fail: true

--- a/docs/src/content/docs/guide/ops.mdx
+++ b/docs/src/content/docs/guide/ops.mdx
@@ -197,7 +197,7 @@ export async function albDeployWorkflow(): Promise<void> {
 
 For an Op with N phases this is **N+1 upsert calls total**. Values are wrapped as single-element arrays for the classic `@temporalio/workflow` API.
 
-> **Registration is separate.** Auto-emit assumes the attributes are already registered server-side. Declare them with the [`SearchAttribute`](/chant/reference/lexicons/temporal/) resource so `chant build` emits the registration commands. See also [`chant state`](/chant/cli/state/) for snapshotting registered attributes against a live cluster.
+> **Registration is separate.** Auto-emit assumes the attributes are already registered server-side. Declare them with the [`SearchAttribute`](/chant/lexicons/temporal/resources/#searchattribute) resource so `chant build` emits the registration commands. See also [`chant state`](/chant/cli/state/) for snapshotting registered attributes against a live cluster.
 
 User-provided keys merge over the `OpName` default; if you set `searchAttributes: { OpName: "custom" }` the user value wins.
 

--- a/docs/src/content/docs/lexicon-authoring/docs-site.mdx
+++ b/docs/src/content/docs/lexicon-authoring/docs-site.mdx
@@ -124,6 +124,19 @@ description: "Brief description for SEO and sidebar"
 Content goes here...
 ```
 
+## Cross-Site Links
+
+The 13 docs sites (main + 12 lexicons) build independently and stitch into a single tree at `.docs-dist/chant/`. Astro's `base: '/chant'` only prefixes its own sidebar/slug entries — root-relative links written in MDX body content don't get prefixed automatically.
+
+A shared `rehype-base-url` plugin (`packages/core/src/codegen/rehype-base-url.mjs`) closes the gap: it walks the HAST tree and prepends the site's `base` to `<a href>` values that start with `/`. The lexicon codegen wires this into every generated `astro.config.mjs`, so new lexicons get it for free.
+
+Two gotchas:
+
+- **Linking across namespaces from a lexicon page.** A lexicon site's base is `/chant/lexicons/<name>`, so `[guide](/guide/composite-resources/)` in `lexicons/aws/...` would get prefixed to `/chant/lexicons/aws/guide/composite-resources/` (wrong). Write the full project path — `/chant/guide/composite-resources/` — and the plugin's idempotency check (`projectBase: '/chant'`) leaves it alone.
+- **Sibling pages in MDX.** `[foo](./foo)` from `aks-composites.mdx` resolves to `aks-composites/foo` (child), not the sibling `foo` page. Use `../foo/` (or the absolute `/chant/...` form).
+
+`just docs-check-links` runs lychee against the built `.docs-dist/chant/` tree and catches both classes of breakage.
+
 ## Reference
 
 - K8s docs: `lexicons/k8s/docs/` — 11 pages with full sidebar navigation

--- a/docs/src/content/docs/tutorials/flyway-postgresql.mdx
+++ b/docs/src/content/docs/tutorials/flyway-postgresql.mdx
@@ -94,4 +94,3 @@ The CloudFormation template receives the SSM path as a parameter (`DbPasswordSsm
 - [AWS CloudFormation lexicon](/chant/lexicons/aws/) — VpcDefault, RdsInstance, and more
 - [Flyway lexicon](/chant/lexicons/flyway/) — FlywayProject, FlywayConfig, Environment
 - [GitLab CI/CD lexicon](/chant/lexicons/gitlab/) — job types, stages, pipeline composites
-- [Multi-Lexicon Projects guide](/chant/guide/multi-lexicon/) — patterns for mixed-lexicon src/ directories

--- a/docs/src/content/docs/tutorials/gitlab-cells.mdx
+++ b/docs/src/content/docs/tutorials/gitlab-cells.mdx
@@ -274,5 +274,4 @@ The smoke test starts a k3d cluster, deploys nginx and the cell router, spins up
 - [GCP Config Connector lexicon](/chant/lexicons/gcp/) — Cloud SQL, Memorystore, GCS, and other composites
 - [Helm lexicon](/chant/lexicons/helm/) — HelmRelease, wrapper chart pattern, value overrides
 - [GitLab CI/CD lexicon](/chant/lexicons/gitlab/) — pipeline composites, multi-stage patterns, environments
-- [Multi-Lexicon Projects guide](/chant/guide/multi-lexicon/) — patterns for mixed-lexicon src/ directories
 - [GitLab Cells architecture blueprint](https://docs.gitlab.com/ee/architecture/blueprints/cells/) — the upstream design this implements

--- a/lexicons/aws/docs/src/content/docs/composites.mdx
+++ b/lexicons/aws/docs/src/content/docs/composites.mdx
@@ -2,7 +2,7 @@
 title: "Composites"
 description: "Composite resources, built-in composites, action constants, and withDefaults presets in the AWS CloudFormation lexicon"
 ---
-Composites group related resources into reusable factories. See also the core [Composite Resources](/guide/composite-resources/) guide.
+Composites group related resources into reusable factories. See also the core [Composite Resources](/chant/guide/composite-resources/) guide.
 
 ```typescript title="lambda-api.ts"
 import { Role, Function, Permission, Code, Environment, Sub, Role_Policy } from "@intentius/chant-lexicon-aws";

--- a/lexicons/aws/docs/src/content/docs/index.mdx
+++ b/lexicons/aws/docs/src/content/docs/index.mdx
@@ -17,14 +17,14 @@ npm install --save-dev @intentius/chant-lexicon-aws
 
 | Metric | Count |
 |--------|-------|
-| Resources | 1592 |
-| Property types | 13357 |
+| Resources | 1596 |
+| Property types | 13437 |
 | Services | 278 |
 | Intrinsic functions | 9 |
 | Pseudo-parameters | 8 |
 | Lint rules | 32 |
 
-**Lexicon version:** 0.1.4  
+**Lexicon version:** 0.1.12  
 **Namespace:** `AWS`
 
 - [CloudFormation Concepts](./cloudformation)

--- a/lexicons/aws/src/codegen/docs.ts
+++ b/lexicons/aws/src/codegen/docs.ts
@@ -390,7 +390,7 @@ Returns the list of Availability Zones for a region:
         slug: "composites",
         title: "Composites",
         description: "Composite resources, built-in composites, action constants, and withDefaults presets in the AWS CloudFormation lexicon",
-        content: `Composites group related resources into reusable factories. See also the core [Composite Resources](/guide/composite-resources/) guide.
+        content: `Composites group related resources into reusable factories. See also the core [Composite Resources](/chant/guide/composite-resources/) guide.
 
 {{file:lambda-api/src/lambda-api.ts}}
 

--- a/lexicons/azure/docs/src/content/docs/index.mdx
+++ b/lexicons/azure/docs/src/content/docs/index.mdx
@@ -17,14 +17,14 @@ npm install --save-dev @intentius/chant-lexicon-azure
 
 | Metric | Count |
 |--------|-------|
-| Resources | 2039 |
-| Property types | 312218 |
-| Services | 243 |
+| Resources | 1969 |
+| Property types | 333871 |
+| Services | 231 |
 | Intrinsic functions | 9 |
 | Pseudo-parameters | 6 |
 | Lint rules | 23 |
 
-**Lexicon version:** 0.1.4  
+**Lexicon version:** 0.1.12  
 **Namespace:** `Azure`
 
 - [Intrinsic Functions](./intrinsics) — 9 built-in functions

--- a/lexicons/flyway/docs/src/content/docs/index.mdx
+++ b/lexicons/flyway/docs/src/content/docs/index.mdx
@@ -69,7 +69,7 @@ See [Lint Rules](./lint-rules) for the full list.
 | Pseudo-parameters | 8 |
 | Lint rules | 20 |
 
-**Lexicon version:** 0.1.4  
+**Lexicon version:** 0.1.12  
 **Namespace:** `Flyway`
 
 - [Flyway Concepts](./flyway-concepts)

--- a/lexicons/gcp/docs/src/content/docs/index.mdx
+++ b/lexicons/gcp/docs/src/content/docs/index.mdx
@@ -47,7 +47,7 @@ The lexicon provides **300+ resource types** across Compute, Storage, IAM, Netwo
 | Pseudo-parameters | 3 |
 | Lint rules | 26 |
 
-**Lexicon version:** 0.1.6  
+**Lexicon version:** 0.1.12  
 **Namespace:** `GCP`
 
 - [Getting Started](./getting-started)

--- a/lexicons/github/docs/src/content/docs/index.mdx
+++ b/lexicons/github/docs/src/content/docs/index.mdx
@@ -54,7 +54,7 @@ The lexicon provides **2 resources** (Workflow, Job), **13 composites** (Checkou
 | Pseudo-parameters | 0 |
 | Lint rules | 28 |
 
-**Lexicon version:** 0.1.7  
+**Lexicon version:** 0.1.12  
 **Namespace:** `GitHub`
 
 - [Getting Started](./getting-started)

--- a/lexicons/gitlab/docs/src/content/docs/index.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/index.mdx
@@ -44,7 +44,7 @@ The lexicon provides **3 resources** (Job, Workflow, Default), **16 property typ
 | Pseudo-parameters | 0 |
 | Lint rules | 23 |
 
-**Lexicon version:** 0.1.4  
+**Lexicon version:** 0.1.12  
 **Namespace:** `GitLab`
 
 - [Pipeline Concepts](./pipeline-concepts)

--- a/lexicons/helm/docs/src/content/docs/index.mdx
+++ b/lexicons/helm/docs/src/content/docs/index.mdx
@@ -74,7 +74,7 @@ helm template test dist/
 | Pseudo-parameters | 0 |
 | Lint rules | 25 |
 
-**Lexicon version:** 0.1.4  
+**Lexicon version:** 0.1.12  
 **Namespace:** `Helm`
 
 - [Getting Started](./getting-started)

--- a/lexicons/k8s/docs/src/content/docs/aks-composites.mdx
+++ b/lexicons/k8s/docs/src/content/docs/aks-composites.mdx
@@ -5,7 +5,7 @@ description: "Vendor-specific composites for Azure AKS — Workload Identity, AG
 
 import { Aside } from '@astrojs/starlight/components';
 
-These composites produce K8s YAML with AKS-specific annotations and configurations. They complement the [generic composites](./composite-examples) by adding Azure service integrations.
+These composites produce K8s YAML with AKS-specific annotations and configurations. They complement the [generic composites](../composite-examples/) by adding Azure service integrations.
 
 ## AksWorkloadIdentityServiceAccount
 
@@ -178,4 +178,4 @@ Configure add-ons via the [Azure ARM lexicon](/chant/lexicons/azure/).
 
 - [Azure AKS + Kubernetes tutorial](/chant/tutorials/aks-kubernetes/) — full deployment walkthrough
 - [Deploying to AKS](/chant/lexicons/azure/aks-kubernetes/) — Azure lexicon bridge page
-- [Generic composites](./composite-examples) — WebApp, AutoscaledService, NamespaceEnv, and more
+- [Generic composites](../composite-examples/) — WebApp, AutoscaledService, NamespaceEnv, and more

--- a/lexicons/k8s/docs/src/content/docs/eks-composites.mdx
+++ b/lexicons/k8s/docs/src/content/docs/eks-composites.mdx
@@ -5,7 +5,7 @@ description: "Vendor-specific composites for Amazon EKS — IRSA, ALB Ingress, E
 
 import { Aside } from '@astrojs/starlight/components';
 
-These composites produce K8s YAML with EKS-specific annotations and configurations. They complement the [generic composites](./composite-examples) by adding AWS service integrations.
+These composites produce K8s YAML with EKS-specific annotations and configurations. They complement the [generic composites](../composite-examples/) by adding AWS service integrations.
 
 ## IrsaServiceAccount
 
@@ -186,4 +186,4 @@ Configure add-ons via the [AWS CloudFormation lexicon](/chant/lexicons/aws/).
 
 - [AWS EKS + Kubernetes tutorial](/chant/tutorials/eks-kubernetes/) — full deployment walkthrough
 - [Deploying to EKS](/chant/lexicons/aws/eks-kubernetes/) — AWS lexicon bridge page
-- [Generic composites](./composite-examples) — WebApp, AutoscaledService, NamespaceEnv, and more
+- [Generic composites](../composite-examples/) — WebApp, AutoscaledService, NamespaceEnv, and more

--- a/lexicons/k8s/docs/src/content/docs/gke-composites.mdx
+++ b/lexicons/k8s/docs/src/content/docs/gke-composites.mdx
@@ -5,7 +5,7 @@ description: "Vendor-specific composites for Google GKE — Workload Identity, G
 
 import { Aside } from '@astrojs/starlight/components';
 
-These composites produce K8s YAML with GKE-specific annotations and configurations. They complement the [generic composites](./composite-examples) by adding GCP service integrations.
+These composites produce K8s YAML with GKE-specific annotations and configurations. They complement the [generic composites](../composite-examples/) by adding GCP service integrations.
 
 ## WorkloadIdentityServiceAccount
 
@@ -244,4 +244,4 @@ Configure add-ons via the [GCP Config Connector lexicon](/chant/lexicons/gcp/).
 
 - [GCP GKE + Kubernetes tutorial](/chant/tutorials/gke-kubernetes/) — full deployment walkthrough
 - [Deploying to GKE](/chant/lexicons/gcp/gke-kubernetes/) — GCP lexicon bridge page
-- [Generic composites](./composite-examples) — WebApp, AutoscaledService, NamespaceEnv, and more
+- [Generic composites](../composite-examples/) — WebApp, AutoscaledService, NamespaceEnv, and more

--- a/lexicons/k8s/docs/src/content/docs/index.mdx
+++ b/lexicons/k8s/docs/src/content/docs/index.mdx
@@ -65,7 +65,7 @@ The lexicon provides **147 resource types** (Deployment, Service, ConfigMap, Sta
 | Pseudo-parameters | 0 |
 | Lint rules | 29 |
 
-**Lexicon version:** 0.1.6  
+**Lexicon version:** 0.1.12  
 **Namespace:** `K8s`
 
 - [Getting Started](./getting-started)

--- a/lexicons/temporal/docs/src/content/docs/index.mdx
+++ b/lexicons/temporal/docs/src/content/docs/index.mdx
@@ -16,7 +16,7 @@ Reference documentation for the **Temporal** lexicon.
 | Pseudo-parameters | 0 |
 | Lint rules | 4 |
 
-**Lexicon version:** 0.1.6  
+**Lexicon version:** 0.1.12  
 **Namespace:** `Temporal`
 
 - [Lint Rules](./rules) — 4 rules

--- a/lexicons/temporal/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/temporal/docs/src/content/docs/lint-rules.mdx
@@ -10,4 +10,4 @@ Future versions may add rules such as:
 - `TMP002` — `TemporalSchedule` with `overlap: "AllowAll"` should have a comment explaining the intent
 - `TMP003` — `TemporalNamespace` retention shorter than 3 days may cause data loss
 
-To write custom rules for your project, see the [lint-rules authoring guide](/chant/docs/lexicon-authoring/lint-rules/).
+To write custom rules for your project, see the [lint-rules authoring guide](/chant/lexicon-authoring/lint-rules/).

--- a/lexicons/temporal/docs/src/content/docs/ops.mdx
+++ b/lexicons/temporal/docs/src/content/docs/ops.mdx
@@ -187,4 +187,4 @@ chant run cancel <name> --force
 chant run log <name>
 ```
 
-See [Worker Profiles](./worker-profiles) for how to configure Temporal connection settings in `chant.config.ts`.
+See [Worker Profiles](../worker-profiles/) for how to configure Temporal connection settings in `chant.config.ts`.


### PR DESCRIPTION
## Summary

Finishes #75 after PR #76 landed the lychee target + rehype plugin (603 → 18). This PR takes lychee from **18 → 0** by fixing four bug classes and wires lychee into CI on PRs.

- **Relative-link confusion** (8 errors): `./composite-examples` and `./worker-profiles` in MDX resolve to a child path under the current page directory, not a sibling page. Fixed in k8s `{aks,eks,gke}-composites.mdx` and `temporal/ops.mdx` by switching to `../foo/`.
- **Stale absolute paths** (3 errors): `guide/ops.mdx` SearchAttribute link, `temporal/lint-rules.mdx` lint-rules guide link, and `lexicons/aws/src/codegen/docs.ts` composites template (writes the full `/chant/...` path so the rehype plugin's `projectBase` guard leaves it alone).
- **`guide/multi-lexicon`** (2 errors): target page never existed; no current guide covers mixed-lexicon `src/` patterns, so the dead bullets are dropped from two tutorials' Further Reading lists rather than redirected to an unrelated page.
- **Stale TypeDoc `api/README.md`** (6 errors): local cruft only — `docs/src/content/docs/api/` is `.gitignored`, typedoc is a dangling dep that no script invokes, and the snapshot symbols listed in the stale README either don't exist anymore or are internal. CI runs on a clean checkout where this dir doesn't exist, so no source fix needed.

## CI

New `.github/workflows/docs-check.yml` builds the unified site and runs lychee on PRs that touch `docs/**`, `lexicons/*/docs/**`, `lexicons/*/src/codegen/**`, `packages/core/src/codegen/**`, or the build script. Uses the same lychee invocation as the justfile target.

## Docs

Short author note added to `lexicon-authoring/docs-site.mdx` documenting the two gotchas the rehype plugin can't fix automatically.

## Side effect

`docs-build` regenerated every lexicon's `index.mdx` under v0.1.12 schema counts (the last regen was at v0.1.4). Mechanical drift, same pattern as prior link-check passes (#76, ee079c6).

## Test plan

- [x] `just docs-check-links` — 603 → 0 errors
- [x] `just build` — tsc passes
- [ ] CI: confirm the new `docs-check` workflow runs on this PR and passes