### PR TITLE
feat(op): local-only Op executor as a first-class peer to Temporal

### DIFF
--- a/.github/workflows/chant.yml
+++ b/.github/workflows/chant.yml
@@ -51,6 +51,12 @@ jobs:
       - name: Build example project
         run: npx tsx packages/core/src/cli/main.ts build lexicons/aws/examples/lambda-function/src --output template.json
 
+      - name: Run Op in local mode (regression guard)
+        working-directory: examples/local-op-quickstart
+        run: |
+          npx tsx ../../packages/core/src/cli/main.ts run hello --local --json > result.json
+          node -e "process.exit(JSON.parse(require('fs').readFileSync('result.json','utf8')).ok ? 0 : 1)"
+
       - name: Upload SARIF results
         if: always()
         uses: github/codeql-action/upload-sarif@v4

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -50,6 +50,7 @@ export default defineConfig({
 						{ label: 'Linting & Type-Checking', slug: 'guide/linting' },
 						{ label: 'Building', slug: 'guide/building' },
 						{ label: 'Ops', slug: 'guide/ops' },
+						{ label: 'Local vs Temporal', slug: 'guide/local-vs-temporal' },
 						{ label: 'Watching State', slug: 'guide/watching-state' },
 						{ label: 'Importing Templates', slug: 'guide/importing-templates' },
 						{ label: 'Multi-Stack Projects', slug: 'guide/multi-stack' },

--- a/docs/src/content/docs/cli/run.mdx
+++ b/docs/src/content/docs/cli/run.mdx
@@ -16,25 +16,31 @@ chant run log <name> [flags]
 
 ## Description
 
-`chant run` starts and manages **Op** workflows — named, phased Temporal workflows defined in `*.op.ts` files. Running an Op spawns a Temporal worker process and submits the workflow. Requires `@intentius/chant-lexicon-temporal` and a reachable Temporal server.
+`chant run` starts and manages **Op** workflows — named, phased workflows defined in `*.op.ts` files.
 
-Connection settings come from `chant.config.ts` under `temporal.profiles`. See [Worker Profiles](/chant/lexicons/temporal/worker-profiles/) for configuration.
+`chant run <name>` runs **local by default**: the Op executes in-process with no Temporal server, worker, or built `worker.ts`. Pass `--temporal` to run against a Temporal cluster instead (worker spawn + workflow submission). One flag selects the runtime — no config is inspected. See [Local vs Temporal](/chant/guide/local-vs-temporal/) for the trade-off.
+
+Local mode covers phase sequencing, retries, activity profiles, and `onFailure` compensation. Gates, schedules, durable resume, and the run-management subcommands (`list` / `status` / `log` / `signal` / `cancel`) require `--temporal` and a reachable Temporal server. Connection settings come from `chant.config.ts` under `temporal.profiles`; see [Worker Profiles](/chant/lexicons/temporal/worker-profiles/).
 
 ## Subcommands
 
 ### `run <name>`
 
-Start an Op: spawns the compiled worker for that Op and submits the workflow to Temporal. Polls status every 3 seconds until the workflow completes or fails.
+Run an Op. Local by default — executes in-process, rendering each phase and step as it runs. With `--temporal`, spawns the compiled worker and submits the workflow to Temporal, polling status every 3 seconds until it completes or fails.
 
 ```bash
-chant run alb-deploy
-chant run alb-deploy --profile cloud
-chant run alb-deploy --report   # print deployment report instead of running
+chant run alb-deploy              # local executor (default)
+chant run alb-deploy --json       # structured result on stdout
+chant run alb-deploy --temporal             # run via Temporal
+chant run alb-deploy --temporal --profile cloud
+chant run alb-deploy --temporal --report    # print deployment report instead of running
 ```
+
+A gate or schedule in the Op fails fast in local mode with an actionable message — re-run with `--temporal`.
 
 ### `run list`
 
-List all discovered Ops (`*.op.ts` files) with their current Temporal run status.
+List all discovered Ops (`*.op.ts` files) with their current Temporal run status. Requires `--temporal`.
 
 ```bash
 chant run list
@@ -80,8 +86,11 @@ chant run log alb-deploy
 
 | Flag | Description |
 |------|-------------|
-| `-p, --profile <name>` | Temporal worker profile to use (from `chant.config.ts`) |
-| `--report` | Print a deployment report instead of running (`run <name>` only) |
+| `--local` | Run with the local in-process executor — the default (`run <name>`) |
+| `--temporal` | Run via a Temporal cluster: gates, schedules, durable resume (`run <name>`) |
+| `--json` | Emit the structured run result as JSON on stdout (`run <name>`) |
+| `-p, --profile <name>` | Temporal worker profile to use (from `chant.config.ts`); implies Temporal mode |
+| `--report` | Print a deployment report instead of running (`run <name> --temporal` only) |
 | `--force` | Required for `run cancel` |
 
 ## Exit Codes
@@ -94,5 +103,6 @@ chant run log alb-deploy
 ## See Also
 
 - [Ops guide](/chant/guide/ops/) — define `*.op.ts` files
+- [Local vs Temporal](/chant/guide/local-vs-temporal/) — choose the runtime
 - [Worker Profiles](/chant/lexicons/temporal/worker-profiles/) — configure Temporal connection
 - [`chant graph`](/chant/cli/graph/) — visualize Op dependency graph

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -71,6 +71,38 @@ chant build
 
 The build command discovers all `.ts` files, collects exported declarables, resolves dependencies, and serializes to the target format.
 
+## Step 5: Run an Op
+
+Resources synthesize to artifacts. **Ops** *execute* — phased, with retries and rollback. Write a minimal one:
+
+```typescript
+// hello.op.ts
+import { Op, phase, shell } from "@intentius/chant-lexicon-temporal";
+
+export default Op({
+  name: "hello",
+  overview: "Minimal local Op — no Temporal server required",
+  taskQueue: "hello",
+  phases: [
+    phase("Greet", [
+      shell("echo hello from chant"),
+    ]),
+  ],
+});
+```
+
+```bash
+chant run hello
+```
+
+```
+[phase] Greet
+  ✓ shellCmd(cmd=echo hello from chant)   42ms
+Op "hello" completed in 0.1s
+```
+
+No Temporal **server** required — chant runs Ops locally by default. (The Op imports from `@intentius/chant-lexicon-temporal`, so install that package — but nothing has to be running.) For durable resume, gates, and schedules, configure a Temporal profile and pass `--temporal`. See [Local vs Temporal](/chant/guide/local-vs-temporal/).
+
 ## Next Steps
 
 - [Project Structure](/chant/getting-started/project-structure/) — understand what `chant init` created

--- a/docs/src/content/docs/guide/local-vs-temporal.mdx
+++ b/docs/src/content/docs/guide/local-vs-temporal.mdx
@@ -1,0 +1,61 @@
+---
+title: Local vs Temporal
+description: Choose between chant's local in-process Op executor and the Temporal runtime
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Ops run in one of two modes. They execute the same `*.op.ts` definitions and the
+same activities — they differ only in what they offer on top of phase
+sequencing.
+
+`chant run <name>` runs **local by default**. Pass `--temporal` to run against a
+Temporal cluster. There is no config to inspect and no implicit switch — one
+flag selects the runtime.
+
+## Capability comparison
+
+| | Local mode | Temporal mode |
+|---|---|---|
+| Phase sequencing + retry | ✓ | ✓ |
+| `onFailure` compensation | ✓ | ✓ |
+| Activity profiles (timeout / retry) | ✓ | ✓ |
+| Structured stdout, exit code, `--json` | ✓ | ✓ |
+| Gates (human approval) | ✗ (errors) | ✓ |
+| Schedules | ✗ (errors) | ✓ |
+| Durable resume after a crash | ✗ | ✓ |
+| `chant run history / status / log` | ✗ | ✓ |
+| Search-attribute persistence | ✗ (outcomes go to stdout) | ✓ |
+
+## The graduation story
+
+- **Dev loops, CI, drift / observation Ops → local.** No server, no Docker, no
+  cloud. `chant run hello` works in under a minute on a laptop with nothing
+  running. Retries and `onFailure` rollback still apply.
+- **Long-running deploys, gated rollouts, scheduled jobs → Temporal.** When you
+  need a workflow to survive a process crash, pause for human approval, or run
+  on a schedule, configure a Temporal profile and pass `--temporal`.
+
+Start local. Move an Op to Temporal the day it needs durability — the Op
+definition does not change.
+
+<Aside type="note" title="Local mode still installs the lexicon">
+A local Op imports `Op` / `phase` / `shell` from `@intentius/chant-lexicon-temporal`,
+so the package is still a dependency. What local mode avoids is the running
+**server** — no Temporal cluster, worker process, or `temporal server start-dev`.
+</Aside>
+
+## What local mode does on a gate or schedule
+
+If an Op contains a `gate()` (or a schedule) and you do not pass `--temporal`,
+`chant run` fails fast — before any phase executes — naming the offending step
+and pointing you at `--temporal`:
+
+```
+error: gate "approve-prod" is not supported in local mode — gates and
+schedules need a durable runtime. Re-run with --temporal.
+```
+
+This is intentional: gates and schedules require cross-process persistence that
+an in-process executor cannot provide. See [Ops](/chant/guide/ops/) for the full
+Op model and [`chant run`](/chant/cli/run/) for the flags.

--- a/docs/src/content/docs/guide/ops.mdx
+++ b/docs/src/content/docs/guide/ops.mdx
@@ -16,10 +16,10 @@ Deciding whether Ops is the right deployment model for your project? See [Choosi
 - **Gates** — pause for human approval or an external-system event (DNS delegation, change windows).
 - **Automatic rollback** — `onFailure` phases compensate on failure instead of hand-rolled scripts.
 
-`chant build` compiles each `*.op.ts` into generated Temporal worker code. `chant run <name>` spawns the worker and submits the workflow.
+`chant run <name>` runs an Op **locally by default** — in-process, with no Temporal server. `chant build` compiles each `*.op.ts` into generated Temporal worker code for when you run with `--temporal`, which spawns the worker and submits the workflow. See [Local vs Temporal](/chant/guide/local-vs-temporal/) for the trade-off.
 
 <Aside type="note" title="Prerequisites">
-Requires `@intentius/chant-lexicon-temporal` and a reachable Temporal server (or [Temporal Cloud](https://cloud.temporal.io) — free tier available). See [Worker Profiles](/chant/lexicons/temporal/worker-profiles/) for connection configuration.
+Requires `@intentius/chant-lexicon-temporal` (the package). Local mode needs nothing running. `--temporal` additionally requires a reachable Temporal server (or [Temporal Cloud](https://cloud.temporal.io) — free tier available); see [Worker Profiles](/chant/lexicons/temporal/worker-profiles/) for connection configuration.
 </Aside>
 
 <Diagram name="ops-execution-model" alt="Op execution model: sequential phases, parallel phases, gate steps, and onFailure compensation" caption="Op execution model — phases, gates, and compensation" />

--- a/examples/local-op-quickstart/.gitignore
+++ b/examples/local-op-quickstart/.gitignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+.chant/
+result.json

--- a/examples/local-op-quickstart/README.md
+++ b/examples/local-op-quickstart/README.md
@@ -1,0 +1,34 @@
+# local-op-quickstart
+
+The smallest possible Op — runs in-process with **no Temporal server, Docker, or cloud**.
+
+```bash
+npm install
+chant run hello
+```
+
+```
+[phase] Greet
+  ✓ shellCmd(cmd=echo hello from chant)   42ms
+Op "hello" completed in 0.1s
+```
+
+`chant run` executes Ops locally by default: phased, with per-step retries and
+`onFailure` compensation. Machine-readable output:
+
+```bash
+chant run hello --json
+```
+
+## Graduating to Temporal
+
+Local mode covers dev loops, CI, and drift/observation Ops. For durable resume
+after a crash, human **gates**, and **schedules**, configure a Temporal profile
+in `chant.config.ts` and run with `--temporal`:
+
+```bash
+chant run hello --temporal
+```
+
+See [Local vs Temporal](https://intentius.dev/chant/guide/local-vs-temporal/) for
+the full trade-off.

--- a/examples/local-op-quickstart/chant.config.ts
+++ b/examples/local-op-quickstart/chant.config.ts
@@ -1,0 +1,2 @@
+import type { ChantConfig } from "@intentius/chant";
+export default { lexicons: ["temporal"] } satisfies ChantConfig;

--- a/examples/local-op-quickstart/ops/hello.op.ts
+++ b/examples/local-op-quickstart/ops/hello.op.ts
@@ -1,0 +1,20 @@
+import { Op, phase, shell } from "@intentius/chant-lexicon-temporal";
+
+/**
+ * Minimal Op that runs locally with no Temporal server.
+ *
+ * `chant run hello` executes this in-process — phased, with retries — using the
+ * local executor (the default). No Temporal worker, server, or cloud required.
+ * For durable resume, gates, and schedules, configure a Temporal profile and
+ * pass `--temporal`.
+ */
+export default Op({
+  name: "hello",
+  overview: "Minimal local Op — no Temporal server required",
+  taskQueue: "hello",
+  phases: [
+    phase("Greet", [
+      shell("echo hello from chant"),
+    ]),
+  ],
+});

--- a/examples/local-op-quickstart/package.json
+++ b/examples/local-op-quickstart/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "local-op-quickstart-example",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "chant build ops -o dist",
+    "lint": "chant lint ops",
+    "run": "chant run hello",
+    "run:json": "chant run hello --json",
+    "deploy": "chant run hello"
+  },
+  "dependencies": {
+    "@intentius/chant": "*",
+    "@intentius/chant-lexicon-temporal": "*"
+  }
+}

--- a/examples/local-op-quickstart/tsconfig.json
+++ b/examples/local-op-quickstart/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["ops", "chant.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/lexicons/gitlab/docs/src/content/docs/skills.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/skills.mdx
@@ -39,7 +39,7 @@ The skill is invocable as a slash command: `/chant-gitlab`
 
 Operational glue for translating GitHub Actions workflows to GitLab CI/CD. The skill detects the user's intent (paste a `.github/workflows/*.yml`, ask about migrating, etc.), invokes `chant migrate`, surfaces the report, and suggests GitLab-native upgrade moments like `--use-composites`.
 
-See [Migration](./migration) for the full CLI surface, supported translations, and limitations.
+See [Migration](../migration) for the full CLI surface, supported translations, and limitations.
 
 ## MCP integration
 
@@ -53,7 +53,7 @@ The lexicon also provides MCP (Model Context Protocol) tools and resources that 
 | `scaffold` | Generate starter files |
 | `search` | Search available resource types |
 | `gitlab:diff` | Compare current build output against previous |
-| `gitlab:migrate` | Translate a GitHub Actions workflow into GitLab CI/CD (see [Migration](./migration)) |
+| `gitlab:migrate` | Translate a GitHub Actions workflow into GitLab CI/CD (see [Migration](../migration)) |
 
 | MCP resource | Description |
 |--------------|-------------|

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -657,7 +657,7 @@ The skill is invocable as a slash command: \`/chant-gitlab\`
 
 Operational glue for translating GitHub Actions workflows to GitLab CI/CD. The skill detects the user's intent (paste a \`.github/workflows/*.yml\`, ask about migrating, etc.), invokes \`chant migrate\`, surfaces the report, and suggests GitLab-native upgrade moments like \`--use-composites\`.
 
-See [Migration](./migration) for the full CLI surface, supported translations, and limitations.
+See [Migration](../migration) for the full CLI surface, supported translations, and limitations.
 
 ## MCP integration
 
@@ -671,7 +671,7 @@ The lexicon also provides MCP (Model Context Protocol) tools and resources that 
 | \`scaffold\` | Generate starter files |
 | \`search\` | Search available resource types |
 | \`gitlab:diff\` | Compare current build output against previous |
-| \`gitlab:migrate\` | Translate a GitHub Actions workflow into GitLab CI/CD (see [Migration](./migration)) |
+| \`gitlab:migrate\` | Translate a GitHub Actions workflow into GitLab CI/CD (see [Migration](../migration)) |
 
 | MCP resource | Description |
 |--------------|-------------|

--- a/lexicons/temporal/src/config.ts
+++ b/lexicons/temporal/src/config.ts
@@ -69,6 +69,13 @@ export interface TemporalActivityProfile {
     maximumAttempts?: number;
     /** Cap on retry intervals (e.g. "5m"). */
     maximumInterval?: string;
+    /**
+     * Error names (`Error.name`) that fail immediately without retry. Honored
+     * in both modes: the generated worker spreads this profile into
+     * `proxyActivities`, so Temporal's RetryPolicy uses it; the local executor
+     * reads it directly to short-circuit its retry loop.
+     */
+    nonRetryableErrorTypes?: string[];
   };
 }
 

--- a/lexicons/temporal/src/op/activities/build.ts
+++ b/lexicons/temporal/src/op/activities/build.ts
@@ -13,10 +13,11 @@ export interface ChantBuildArgs {
  * Run `npm run build` in the given project directory.
  * Uses fastIdempotent profile — 5m timeout, 3 retries.
  */
-export async function chantBuild(args: ChantBuildArgs): Promise<void> {
+export async function chantBuild(args: ChantBuildArgs, signal?: AbortSignal): Promise<void> {
   const { stdout, stderr } = await execAsync("npm run build", {
     cwd: args.path,
     env: { ...process.env, ...args.env },
+    signal,
   });
   if (stdout) console.log(stdout);
   if (stderr) console.error(stderr);

--- a/lexicons/temporal/src/op/activities/gitlab.ts
+++ b/lexicons/temporal/src/op/activities/gitlab.ts
@@ -1,6 +1,7 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { Context } from "@temporalio/activity";
+import { safeHeartbeat } from "./heartbeat";
+import { sleep } from "./util";
 
 const execAsync = promisify(exec);
 
@@ -16,26 +17,29 @@ export interface GitlabPipelineArgs {
 /**
  * Trigger a GitLab CI pipeline and wait for it to complete successfully.
  * Requires `glab` CLI authenticated in the environment.
- * Uses longInfra profile — 20m timeout, heartbeat every 60s.
+ * Uses longInfra profile — 20m timeout, heartbeat every poll.
  */
-export async function gitlabPipeline(args: GitlabPipelineArgs): Promise<void> {
+export async function gitlabPipeline(args: GitlabPipelineArgs, signal?: AbortSignal): Promise<void> {
   const ref = args.ref ?? "HEAD";
   const interval = args.intervalMs ?? 30_000;
 
   // Trigger
   const { stdout: triggerOut } = await execAsync(
     `glab ci run --project ${args.name} --ref ${ref}`,
+    { signal },
   );
   console.log(triggerOut);
 
   // Poll status
   let attempt = 0;
   while (true) {
+    if (signal?.aborted) throw new Error("gitlabPipeline aborted");
     attempt++;
-    Context.current().heartbeat({ step: "gitlabPipeline", project: args.name, attempt });
+    safeHeartbeat({ step: "gitlabPipeline", project: args.name, attempt });
 
     const { stdout } = await execAsync(
       `glab ci status --project ${args.name} --format json`,
+      { signal },
     );
 
     let status: string | undefined;
@@ -51,6 +55,6 @@ export async function gitlabPipeline(args: GitlabPipelineArgs): Promise<void> {
       throw new Error(`GitLab pipeline for ${args.name} ended with status: ${status}`);
     }
 
-    await new Promise((r) => setTimeout(r, interval));
+    await sleep(interval, signal);
   }
 }

--- a/lexicons/temporal/src/op/activities/heartbeat-context.test.ts
+++ b/lexicons/temporal/src/op/activities/heartbeat-context.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect, vi } from "vitest";
+
+// Positive path: prove the shim actually heartbeats once `@temporalio/activity`
+// is present. The SDK isn't installed in this repo, so we virtual-mock it with a
+// fake `Context` whose `heartbeat` we can observe. Lives in its own file so the
+// module-level cache in heartbeat.ts starts fresh (vitest isolates files), and
+// so heartbeat.test.ts can keep exercising the no-SDK path unmocked.
+const { heartbeat } = vi.hoisted(() => ({ heartbeat: vi.fn() }));
+
+vi.mock("@temporalio/activity", () => ({
+  Context: { current: () => ({ heartbeat }) },
+}));
+
+describe("safeHeartbeat with @temporalio/activity present", () => {
+  test("heartbeats once the lazy import resolves", async () => {
+    const { safeHeartbeat } = await import("./heartbeat");
+
+    // First call only kicks off the one-time lazy load and returns immediately.
+    safeHeartbeat({ step: "first" });
+    expect(heartbeat).not.toHaveBeenCalled();
+
+    // After the dynamic import settles, subsequent calls heartbeat through to
+    // the (mocked) activity Context, preserving the passed details.
+    await vi.waitFor(() => {
+      safeHeartbeat({ step: "after-load" });
+      expect(heartbeat).toHaveBeenCalledWith({ step: "after-load" });
+    });
+  });
+});

--- a/lexicons/temporal/src/op/activities/heartbeat.test.ts
+++ b/lexicons/temporal/src/op/activities/heartbeat.test.ts
@@ -1,0 +1,10 @@
+import { describe, test, expect } from "vitest";
+import { safeHeartbeat } from "./heartbeat";
+
+describe("safeHeartbeat", () => {
+  test("no-ops outside a Temporal worker instead of throwing", () => {
+    // No activity execution context and (in this env) no @temporalio/activity.
+    expect(() => safeHeartbeat({ step: "test" })).not.toThrow();
+    expect(() => safeHeartbeat()).not.toThrow();
+  });
+});

--- a/lexicons/temporal/src/op/activities/heartbeat.ts
+++ b/lexicons/temporal/src/op/activities/heartbeat.ts
@@ -1,0 +1,59 @@
+/**
+ * Activity heartbeat shim.
+ *
+ * Activities heartbeat so a Temporal worker knows they are still alive. Two
+ * things make a naive `Context.current().heartbeat()` call unsafe outside a
+ * worker:
+ *
+ *   1. `@temporalio/activity` may not be installed at all — chant's local
+ *      executor runs these same activity implementations with no Temporal SDK
+ *      present. A static `import` would make the entire activity library fail
+ *      to load. So we resolve `Context` lazily via dynamic import and cache it.
+ *   2. Even when installed, `Context.current()` throws when called outside an
+ *      activity execution context. We swallow that too.
+ *
+ * Net effect: identical activity code heartbeats under a Temporal worker and
+ * no-ops locally, and the activity library imports cleanly without the SDK.
+ */
+
+interface ActivityContext {
+  current(): { heartbeat(details?: unknown): void };
+}
+
+// undefined = not yet attempted; null = unavailable; object = resolved Context.
+let cachedContext: ActivityContext | null | undefined;
+let loading: Promise<void> | undefined;
+
+function ensureContext(): void {
+  if (cachedContext !== undefined || loading) return;
+  // Variable specifier so bundlers/tsc do not statically require the optional dep.
+  const spec = "@temporalio/activity";
+  loading = import(spec)
+    .then((mod: unknown) => {
+      cachedContext = (mod as { Context?: ActivityContext }).Context ?? null;
+    })
+    .catch(() => {
+      cachedContext = null;
+    });
+}
+
+/**
+ * Emit an activity heartbeat if running under a Temporal worker; otherwise no-op.
+ *
+ * The first call kicks off a one-time lazy load of `@temporalio/activity` and
+ * returns immediately; once resolved, subsequent calls heartbeat. Heartbeats
+ * are periodic (every ~15s, well inside the 60s heartbeat timeout), so the
+ * single missed first tick is harmless.
+ */
+export function safeHeartbeat(details?: unknown): void {
+  if (cachedContext === undefined) {
+    ensureContext();
+    return;
+  }
+  if (cachedContext === null) return;
+  try {
+    cachedContext.current().heartbeat(details);
+  } catch {
+    // Not inside an activity execution context — nothing to do.
+  }
+}

--- a/lexicons/temporal/src/op/activities/helm.ts
+++ b/lexicons/temporal/src/op/activities/helm.ts
@@ -1,6 +1,6 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { Context } from "@temporalio/activity";
+import { safeHeartbeat } from "./heartbeat";
 
 const execAsync = promisify(exec);
 
@@ -19,20 +19,20 @@ export interface HelmInstallArgs {
 
 /**
  * Run `helm upgrade --install <name> <chart>`.
- * Uses longInfra profile — 20m timeout, heartbeat every 60s.
+ * Uses longInfra profile — 20m timeout, heartbeat every 15s.
  */
-export async function helmInstall(args: HelmInstallArgs): Promise<void> {
+export async function helmInstall(args: HelmInstallArgs, signal?: AbortSignal): Promise<void> {
   const parts = ["helm", "upgrade", "--install", "--wait", args.name, args.chart];
   if (args.namespace) parts.push("--namespace", args.namespace, "--create-namespace");
   if (args.values) parts.push("-f", args.values);
   for (const [k, v] of Object.entries(args.set ?? {})) parts.push("--set", `${k}=${v}`);
 
   const heartbeatInterval = setInterval(() => {
-    Context.current().heartbeat({ step: "helm install", release: args.name });
+    safeHeartbeat({ step: "helm install", release: args.name });
   }, 15_000);
 
   try {
-    const { stdout, stderr } = await execAsync(parts.join(" "));
+    const { stdout, stderr } = await execAsync(parts.join(" "), { signal });
     if (stdout) console.log(stdout);
     if (stderr) console.error(stderr);
   } finally {

--- a/lexicons/temporal/src/op/activities/kubectl.ts
+++ b/lexicons/temporal/src/op/activities/kubectl.ts
@@ -1,6 +1,6 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { Context } from "@temporalio/activity";
+import { safeHeartbeat } from "./heartbeat";
 
 const execAsync = promisify(exec);
 
@@ -12,17 +12,18 @@ export interface KubectlApplyArgs {
 
 /**
  * Run `kubectl apply -f <manifest>`.
- * Uses longInfra profile — 20m timeout, heartbeat every 60s.
+ * Uses longInfra profile — 20m timeout, heartbeat every 15s.
  */
-export async function kubectlApply(args: KubectlApplyArgs): Promise<void> {
+export async function kubectlApply(args: KubectlApplyArgs, signal?: AbortSignal): Promise<void> {
   const ctx = args.context ? `--context ${args.context}` : "";
   const heartbeatInterval = setInterval(() => {
-    Context.current().heartbeat({ step: "kubectl apply", manifest: args.manifest });
+    safeHeartbeat({ step: "kubectl apply", manifest: args.manifest });
   }, 15_000);
 
   try {
     const { stdout, stderr } = await execAsync(
       `kubectl apply -f ${args.manifest} ${ctx} --wait=true`,
+      { signal },
     );
     if (stdout) console.log(stdout);
     if (stderr) console.error(stderr);

--- a/lexicons/temporal/src/op/activities/shell.ts
+++ b/lexicons/temporal/src/op/activities/shell.ts
@@ -15,10 +15,11 @@ export interface ShellCmdArgs {
  * Run an arbitrary shell command.
  * Uses fastIdempotent profile — 5m timeout, 3 retries.
  */
-export async function shellCmd(args: ShellCmdArgs): Promise<string> {
+export async function shellCmd(args: ShellCmdArgs, signal?: AbortSignal): Promise<string> {
   const { stdout, stderr } = await execAsync(args.cmd, {
     cwd: args.cwd,
     env: { ...process.env, ...args.env },
+    signal,
   });
   if (stderr) console.error(stderr);
   return stdout.trim();

--- a/lexicons/temporal/src/op/activities/state.ts
+++ b/lexicons/temporal/src/op/activities/state.ts
@@ -12,8 +12,8 @@ export interface StateSnapshotArgs {
  * Take a chant state snapshot for the given environment.
  * Uses fastIdempotent profile — 5m timeout, 3 retries.
  */
-export async function stateSnapshot(args: StateSnapshotArgs): Promise<void> {
-  const { stdout, stderr } = await execAsync(`chant state snapshot ${args.env}`);
+export async function stateSnapshot(args: StateSnapshotArgs, signal?: AbortSignal): Promise<void> {
+  const { stdout, stderr } = await execAsync(`chant state snapshot ${args.env}`, { signal });
   if (stdout) console.log(stdout);
   if (stderr) console.error(stderr);
 }
@@ -69,10 +69,10 @@ function detectDrift(output: string): boolean {
  * cli/state.mdx. Pair with `outcomeAttribute: { name: "Drift", from: "drifted" }`
  * on a WatchOp activity step to surface drift as a workflow search attribute.
  */
-export async function stateDiff(args: StateDiffArgs): Promise<StateDiffResult> {
+export async function stateDiff(args: StateDiffArgs, signal?: AbortSignal): Promise<StateDiffResult> {
   const liveFlag = args.live ? " --live" : "";
   try {
-    const { stdout, stderr } = await execAsync(`chant state diff ${args.env}${liveFlag}`);
+    const { stdout, stderr } = await execAsync(`chant state diff ${args.env}${liveFlag}`, { signal });
     const output = `${stdout}${stderr}`.trim();
     if (output) console.log(output);
     return { output, exitCode: 0, drifted: detectDrift(output) };

--- a/lexicons/temporal/src/op/activities/teardown.ts
+++ b/lexicons/temporal/src/op/activities/teardown.ts
@@ -10,11 +10,12 @@ export interface ChantTeardownArgs {
 
 /**
  * Run `chant teardown` in the given project path.
- * Uses longInfra profile — 20m timeout, heartbeat every 60s.
+ * Uses longInfra profile — 20m timeout.
  */
-export async function chantTeardown(args: ChantTeardownArgs): Promise<void> {
+export async function chantTeardown(args: ChantTeardownArgs, signal?: AbortSignal): Promise<void> {
   const { stdout, stderr } = await execAsync("npm run teardown", {
     cwd: args.path,
+    signal,
   });
   if (stdout) console.log(stdout);
   if (stderr) console.error(stderr);

--- a/lexicons/temporal/src/op/activities/util.ts
+++ b/lexicons/temporal/src/op/activities/util.ts
@@ -1,0 +1,24 @@
+/** Shared helpers for activity implementations. */
+
+/**
+ * Sleep for `ms`, rejecting early if `signal` aborts. Polling activities use
+ * this between attempts so a local-executor timeout or Ctrl-C interrupts the
+ * wait instead of running it to completion.
+ */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error("aborted"));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/lexicons/temporal/src/op/activities/wait.ts
+++ b/lexicons/temporal/src/op/activities/wait.ts
@@ -1,6 +1,7 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { Context } from "@temporalio/activity";
+import { safeHeartbeat } from "./heartbeat";
+import { sleep } from "./util";
 
 const execAsync = promisify(exec);
 
@@ -17,36 +18,41 @@ export interface WaitForStackArgs {
 
 /**
  * Poll until a Kubernetes Deployment or StatefulSet named `name` is fully rolled out.
- * Uses k8sWait profile — 15m timeout, heartbeat every 60s.
+ * Uses k8sWait profile — 15m timeout, heartbeat every poll.
  */
-export async function waitForStack(args: WaitForStackArgs): Promise<void> {
+export async function waitForStack(args: WaitForStackArgs, signal?: AbortSignal): Promise<void> {
   const ns = args.namespace ? `-n ${args.namespace}` : "";
   const ctx = args.context ? `--context ${args.context}` : "";
   const interval = args.intervalMs ?? 10_000;
   let attempt = 0;
 
   while (true) {
+    if (signal?.aborted) throw new Error("waitForStack aborted");
     attempt++;
-    Context.current().heartbeat({ step: "waitForStack", stack: args.name, attempt });
+    safeHeartbeat({ step: "waitForStack", stack: args.name, attempt });
 
     try {
       await execAsync(
         `kubectl rollout status deployment/${args.name} ${ns} ${ctx} --timeout=30s`,
+        { signal },
       );
       return;
     } catch {
+      if (signal?.aborted) throw new Error("waitForStack aborted");
       // Not ready yet — wait and retry
     }
 
     try {
       await execAsync(
         `kubectl rollout status statefulset/${args.name} ${ns} ${ctx} --timeout=30s`,
+        { signal },
       );
       return;
     } catch {
+      if (signal?.aborted) throw new Error("waitForStack aborted");
       // Not ready yet
     }
 
-    await new Promise((r) => setTimeout(r, interval));
+    await sleep(interval, signal);
   }
 }

--- a/lexicons/temporal/src/op/op-serializer.test.ts
+++ b/lexicons/temporal/src/op/op-serializer.test.ts
@@ -94,6 +94,22 @@ describe("serializeOps()", () => {
       expect(wf).toContain("TEMPORAL_ACTIVITY_PROFILES.longInfra");
     });
 
+    it("passes the whole profile object to proxyActivities (carries every retry field, incl. nonRetryableErrorTypes)", () => {
+      // The worker must spread the entire profile — not a hand-picked subset of
+      // fields — so retry policy reaches Temporal's ActivityOptions intact. This
+      // is what makes the --temporal path honor nonRetryableErrorTypes the same
+      // way the local executor does. Reconstructing the options inline would
+      // silently drop any field not explicitly copied; this locks that out.
+      const ops = new Map([
+        makeOp({
+          name: "deploy", overview: "o",
+          phases: [{ name: "Build", steps: [{ kind: "activity", fn: "chantBuild", args: { path: "./a" } }] }],
+        }),
+      ]);
+      const wf = serializeOps(ops)["ops/deploy/workflow.ts"];
+      expect(wf).toMatch(/proxyActivities<typeof activities>\(\s*TEMPORAL_ACTIVITY_PROFILES\.fastIdempotent,\s*\)/);
+    });
+
     it("generates sequential await calls for a non-parallel phase", () => {
       const ops = new Map([
         makeOp({

--- a/lexicons/temporal/src/resources.ts
+++ b/lexicons/temporal/src/resources.ts
@@ -91,7 +91,8 @@ export interface TemporalScheduleProps {
     searchAttributes?: Record<string, unknown>;
     /**
      * Retry policy for the triggered workflow execution.
-     * When set, the generated schedule script includes `workflowStartOptions.retry`.
+     * When set, the generated schedule script emits it as the schedule
+     * action's `retry` (Temporal `ScheduleOptions` action.retry).
      */
     workflowRetryPolicy?: {
       /** Initial retry interval (e.g. "10s"). Default: Temporal server default (~1s). */

--- a/lexicons/temporal/src/serializer.test.ts
+++ b/lexicons/temporal/src/serializer.test.ts
@@ -251,6 +251,59 @@ describe("temporal serializer", () => {
     expect(result.files["schedules/with-policy.ts"]).toContain("BufferOne");
   });
 
+  it("emits action.retry from workflowRetryPolicy, including nonRetryableErrorTypes", () => {
+    const entities = new Map([makeSchedule("with-retry", {
+      action: {
+        workflowType: "w", taskQueue: "q",
+        workflowRetryPolicy: {
+          initialInterval: "10s",
+          backoffCoefficient: 2,
+          maximumAttempts: 5,
+          maximumInterval: "5m",
+          nonRetryableErrorTypes: ["ValidationError"],
+        },
+      },
+    })]);
+    const ts = (temporalSerializer.serialize(entities) as { files: Record<string, string> }).files["schedules/with-retry.ts"];
+    expect(ts).toContain("retry:");
+    expect(ts).toContain('"initialInterval": "10s"');
+    expect(ts).toContain('"maximumAttempts": 5');
+    expect(ts).toContain('"nonRetryableErrorTypes"');
+    expect(ts).toContain('"ValidationError"');
+  });
+
+  it("omits action.retry when no workflowRetryPolicy is set", () => {
+    const ts = (temporalSerializer.serialize(new Map([makeSchedule("no-retry")])) as { files: Record<string, string> }).files["schedules/no-retry.ts"];
+    expect(ts).not.toContain("retry:");
+  });
+
+  it("emits action timeouts, memo, and searchAttributes when set", () => {
+    const entities = new Map([makeSchedule("with-action-opts", {
+      action: {
+        workflowType: "w", taskQueue: "q",
+        workflowExecutionTimeout: "1h",
+        workflowRunTimeout: "30m",
+        memo: { owner: "platform" },
+        searchAttributes: { Env: "prod" },
+      },
+    })]);
+    const ts = (temporalSerializer.serialize(entities) as { files: Record<string, string> }).files["schedules/with-action-opts.ts"];
+    expect(ts).toContain('workflowExecutionTimeout: "1h"');
+    expect(ts).toContain('workflowRunTimeout: "30m"');
+    expect(ts).toContain("memo:");
+    expect(ts).toContain('"owner": "platform"');
+    expect(ts).toContain("searchAttributes:");
+    expect(ts).toContain('"Env": "prod"');
+  });
+
+  it("omits action timeouts, memo, and searchAttributes when unset", () => {
+    const ts = (temporalSerializer.serialize(new Map([makeSchedule("bare-action")])) as { files: Record<string, string> }).files["schedules/bare-action.ts"];
+    expect(ts).not.toContain("workflowExecutionTimeout:");
+    expect(ts).not.toContain("workflowRunTimeout:");
+    expect(ts).not.toContain("memo:");
+    expect(ts).not.toContain("searchAttributes:");
+  });
+
   // ── Mixed entities ─────────────────────────────────────────────
 
   it("returns SerializerResult with all keys for mixed entities", () => {

--- a/lexicons/temporal/src/serializer.ts
+++ b/lexicons/temporal/src/serializer.ts
@@ -222,8 +222,32 @@ function serializeSchedule(scheduleId: string, props: TemporalScheduleProps): st
     `      workflowType: ${JSON.stringify(props.action.workflowType)},`,
     `      taskQueue: ${JSON.stringify(props.action.taskQueue)},`,
     `      args: ${JSON.stringify(props.action.args ?? [])},`,
-    `    },`,
   ];
+
+  // Optional workflow timeouts → ScheduleOptions action.workflow*Timeout.
+  if (props.action.workflowExecutionTimeout) {
+    lines.push(`      workflowExecutionTimeout: ${JSON.stringify(props.action.workflowExecutionTimeout)},`);
+  }
+  if (props.action.workflowRunTimeout) {
+    lines.push(`      workflowRunTimeout: ${JSON.stringify(props.action.workflowRunTimeout)},`);
+  }
+
+  // Retry policy for the triggered workflow → ScheduleOptions action.retry.
+  if (props.action.workflowRetryPolicy) {
+    lines.push(
+      `      retry: ${JSON.stringify(props.action.workflowRetryPolicy, null, 6).replace(/^/gm, "      ").trimStart()},`,
+    );
+  }
+
+  // Memo + search attributes attached to the triggered workflow.
+  if (props.action.memo) {
+    lines.push(`      memo: ${JSON.stringify(props.action.memo, null, 6).replace(/^/gm, "      ").trimStart()},`);
+  }
+  if (props.action.searchAttributes) {
+    lines.push(`      searchAttributes: ${JSON.stringify(props.action.searchAttributes, null, 6).replace(/^/gm, "      ").trimStart()},`);
+  }
+
+  lines.push(`    },`);
 
   if (props.policies) {
     lines.push(`    policies: ${JSON.stringify(props.policies, null, 6).replace(/^/gm, "    ").trimStart()},`);

--- a/packages/core/src/cli/handlers/run.test.ts
+++ b/packages/core/src/cli/handlers/run.test.ts
@@ -43,6 +43,9 @@ function makeArgs(overrides: Partial<ParsedArgs> = {}): ParsedArgs {
   return {
     command: "run", path: ".",
     format: "", fix: false, watch: false, verbose: false, help: false, live: false,
+    // These suites exercise the Temporal path; local mode is the CLI default,
+    // so opt in explicitly here. Local-mode behavior is covered separately below.
+    temporal: true,
     ...overrides,
   };
 }
@@ -444,5 +447,100 @@ describe("runOp", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ── local mode dispatcher + guards ──────────────────────────────────────────
+
+function localOp(name: string, steps: unknown[]) {
+  return [name, { config: { name, overview: `${name} overview`, phases: [{ name: "Phase", steps }] } }] as const;
+}
+
+describe("runOp dispatcher", () => {
+  beforeEach(() => {
+    discoverOpsMock.mockReset();
+    loadTemporalClientMock.mockReset();
+    loadChantConfigMock.mockReset();
+    resolveProfileMock.mockReset();
+    existsSyncMock.mockReset();
+    spawnChildMock.mockReset();
+  });
+
+  test("no flag → local executor (no Temporal client or worker spawned)", async () => {
+    discoverOpsMock.mockResolvedValue({
+      ops: new Map([localOp("hello", [{ kind: "activity", fn: "shellCmd", args: { cmd: "true" } }])]),
+      errors: [],
+    });
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = await runOp({ args: makeArgs({ path: "hello", temporal: false }), plugins: [], serializers: [] });
+    expect(exit).toBe(0);
+    expect(loadTemporalClientMock).not.toHaveBeenCalled();
+    expect(spawnChildMock).not.toHaveBeenCalled();
+    stderrWrite.mockRestore();
+  });
+
+  test("--temporal → Temporal path (missing worker.ts → exit 1)", async () => {
+    discoverOpsMock.mockResolvedValue({ ops: new Map([makeOp("hello")]), errors: [] });
+    loadChantConfigMock.mockResolvedValue({ config: {} });
+    resolveProfileMock.mockReturnValue({ address: "localhost:7233", namespace: "default", taskQueue: "q" });
+    existsSyncMock.mockReturnValue(false);
+    const stderr = makeStderrSpy();
+    const exit = await runOp({ args: makeArgs({ path: "hello", temporal: true }), plugins: [], serializers: [] });
+    expect(exit).toBe(1);
+    expect(stderr.join("\n")).toContain("worker.ts not found");
+  });
+
+  test("gate in local mode → fast-fail before execution, suggests --temporal", async () => {
+    discoverOpsMock.mockResolvedValue({
+      ops: new Map([localOp("gated", [{ kind: "gate", signalName: "approve-prod" }])]),
+      errors: [],
+    });
+    const stderr = makeStderrSpy();
+    const exit = await runOp({ args: makeArgs({ path: "gated", temporal: false }), plugins: [], serializers: [] });
+    expect(exit).toBe(1);
+    expect(stderr.join("\n")).toContain("--temporal");
+    expect(loadTemporalClientMock).not.toHaveBeenCalled();
+  });
+
+  test("--local and --temporal together → exit 1 before any work", async () => {
+    const stderr = makeStderrSpy();
+    const exit = await runOp({ args: makeArgs({ path: "hello", local: true, temporal: true }), plugins: [], serializers: [] });
+    expect(exit).toBe(1);
+    expect(stderr.join("\n")).toContain("mutually exclusive");
+    expect(discoverOpsMock).not.toHaveBeenCalled();
+    expect(loadTemporalClientMock).not.toHaveBeenCalled();
+  });
+
+  test("--json → structured result on stdout", async () => {
+    discoverOpsMock.mockResolvedValue({
+      ops: new Map([localOp("hello", [{ kind: "activity", fn: "shellCmd", args: { cmd: "true" } }])]),
+      errors: [],
+    });
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = await runOp({ args: makeArgs({ path: "hello", temporal: false, json: true }), plugins: [], serializers: [] });
+    expect(exit).toBe(0);
+    const printed = stdoutWrite.mock.calls.map((c) => String(c[0])).join("");
+    const parsed = JSON.parse(printed.trim());
+    expect(parsed.op).toBe("hello");
+    expect(parsed.ok).toBe(true);
+    vi.restoreAllMocks();
+  });
+});
+
+describe("Temporal-only subcommand guards", () => {
+  const cases: Array<[string, (ctx: { args: ParsedArgs; plugins: never[]; serializers: never[] }) => Promise<number>]> = [
+    ["list", runOpList],
+    ["status", runOpStatus],
+    ["log", runOpLog],
+    ["signal", runOpSignal],
+    ["cancel", runOpCancel],
+  ];
+
+  test.each(cases)("run %s without --temporal → exit 1 + actionable message", async (_name, handler) => {
+    const stderr = makeStderrSpy();
+    const exit = await handler({ args: makeArgs({ temporal: false, extraPositional: "x", extraPositional2: "y" }), plugins: [], serializers: [] });
+    expect(exit).toBe(1);
+    expect(stderr.join("\n")).toContain("not available in local mode");
   });
 });

--- a/packages/core/src/cli/handlers/run.ts
+++ b/packages/core/src/cli/handlers/run.ts
@@ -4,6 +4,9 @@ import { createConnection } from "node:net";
 import { spawn as spawnChild, type ChildProcess } from "node:child_process";
 import { loadChantConfig } from "../../config";
 import { discoverOps } from "../../op/discover";
+import { loadActivities, loadProfiles } from "../../op/activity-registry";
+import { runOpLocally, findGate, LocalGateUnsupportedError, OpRunFailure } from "../../op/local-executor";
+import { renderHuman, renderJson } from "../../op/local-output";
 import { formatError, formatWarning, formatSuccess, formatBold, formatInfo } from "../format";
 import type { CommandContext } from "../registry";
 import {
@@ -25,6 +28,21 @@ function workflowFnName(opName: string): string {
   return kebabToCamel(opName) + "Workflow";
 }
 
+/**
+ * Guard for Temporal-only commands (run list/status/log/signal/cancel, --report).
+ * These query durable run state that only exists under Temporal. Returns true
+ * when `--temporal` was passed; otherwise prints an actionable message and the
+ * caller should return non-zero.
+ */
+function requireTemporalMode(ctx: CommandContext, what: string): boolean {
+  if (ctx.args.temporal) return true;
+  console.error(formatError({
+    message: `\`${what}\` is not available in local mode`,
+    hint: "pass --temporal or configure a profile",
+  }));
+  return false;
+}
+
 export async function makeTemporalClient(profileName: string | undefined, projectPath: string) {
   const { config } = await loadChantConfig(projectPath);
   const profile = resolveProfile(config as Record<string, unknown>, profileName);
@@ -37,6 +55,7 @@ export async function makeTemporalClient(profileName: string | undefined, projec
 // ── chant run list ──────────────────────────────────���─────────────────────────
 
 export async function runOpList(ctx: CommandContext): Promise<number> {
+  if (!requireTemporalMode(ctx, "chant run list")) return 1;
   const { ops, errors } = await discoverOps();
 
   for (const err of errors) {
@@ -102,6 +121,7 @@ export async function runOpList(ctx: CommandContext): Promise<number> {
 // ── chant run status <name> ───────────────────────────────────────────────────
 
 export async function runOpStatus(ctx: CommandContext): Promise<number> {
+  if (!requireTemporalMode(ctx, "chant run status")) return 1;
   const name = ctx.args.extraPositional;
   if (!name) {
     console.error(formatError({ message: "Op name is required: chant run status <name>" }));
@@ -141,6 +161,7 @@ export async function runOpStatus(ctx: CommandContext): Promise<number> {
 // ── chant run log <name> ──────────────────────────────────────────────────────
 
 export async function runOpLog(ctx: CommandContext): Promise<number> {
+  if (!requireTemporalMode(ctx, "chant run log")) return 1;
   const name = ctx.args.extraPositional;
   if (!name) {
     console.error(formatError({ message: "Op name is required: chant run log <name>" }));
@@ -186,6 +207,7 @@ export async function runOpLog(ctx: CommandContext): Promise<number> {
 // ── chant run signal <name> <signal> ─────────────────────────────────────────
 
 export async function runOpSignal(ctx: CommandContext): Promise<number> {
+  if (!requireTemporalMode(ctx, "chant run signal")) return 1;
   const name = ctx.args.extraPositional;
   const signalName = ctx.args.extraPositional2;
 
@@ -212,6 +234,7 @@ export async function runOpSignal(ctx: CommandContext): Promise<number> {
 // ── chant run cancel <name> ───────────────────────────────────────────────────
 
 export async function runOpCancel(ctx: CommandContext): Promise<number> {
+  if (!requireTemporalMode(ctx, "chant run cancel")) return 1;
   const name = ctx.args.extraPositional;
   if (!name) {
     console.error(formatError({ message: "Op name is required: chant run cancel <name>" }));
@@ -274,7 +297,107 @@ function renderProgress(opName: string, history: WorkflowHistoryRaw): void {
   );
 }
 
+/**
+ * `chant run <name>` dispatcher.
+ *
+ * Local mode is the default — it runs the Op in-process with no Temporal
+ * server. `--temporal` opts into a cluster (gates, schedules, durable resume).
+ * `--report` reads a past durable run and is therefore Temporal-only.
+ */
 export async function runOp(ctx: CommandContext): Promise<number> {
+  if (ctx.args.local && ctx.args.temporal) {
+    console.error(formatError({
+      message: "--local and --temporal are mutually exclusive",
+      hint: "omit both for local mode (the default), or pass exactly one",
+    }));
+    return 1;
+  }
+  if (ctx.args.report) {
+    if (!requireTemporalMode(ctx, "chant run --report")) return 1;
+    return runOpTemporal(ctx);
+  }
+  return ctx.args.temporal ? runOpTemporal(ctx) : runOpLocal(ctx);
+}
+
+/**
+ * Run an Op in-process via the local executor — no Temporal worker, server, or
+ * built `worker.ts`. Reads the Op config straight from discovery and resolves
+ * activities from the Temporal lexicon package.
+ */
+export async function runOpLocal(ctx: CommandContext): Promise<number> {
+  const opName = ctx.args.path;
+  if (!opName || opName === ".") {
+    console.error(formatError({
+      message: "Op name is required: chant run <name>",
+      hint: "Run `chant run list --temporal` to see available Ops",
+    }));
+    return 1;
+  }
+
+  const { ops, errors } = await discoverOps();
+  for (const err of errors) console.error(formatWarning({ message: err }));
+
+  const discovered = ops.get(opName);
+  if (!discovered) {
+    const names = [...ops.keys()];
+    console.error(formatError({
+      message: `Op "${opName}" not found`,
+      hint: names.length > 0
+        ? `Available: ${names.join(", ")}`
+        : "No *.op.ts files found — create one",
+    }));
+    return 1;
+  }
+
+  const { config } = discovered;
+
+  // Pre-flight: gates/schedules need a durable runtime — fail before any step.
+  const gate = findGate(config);
+  if (gate) {
+    console.error(formatError({
+      message: new LocalGateUnsupportedError(gate.signalName).message,
+    }));
+    return 1;
+  }
+
+  let activities, profiles;
+  try {
+    [activities, profiles] = await Promise.all([loadActivities(), loadProfiles()]);
+  } catch (err) {
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  }
+
+  // Ctrl-C aborts in-flight activities (kills their child processes) instead of
+  // orphaning them. The handler is removed in `finally` so it never leaks.
+  const controller = new AbortController();
+  const onSigint = () => {
+    console.error(formatWarning({ message: "interrupted — stopping Op" }));
+    controller.abort();
+  };
+  process.once("SIGINT", onSigint);
+
+  try {
+    const result = await runOpLocally(config, activities, profiles, controller.signal);
+    if (ctx.args.json) renderJson(result); else renderHuman(result);
+    return 0;
+  } catch (err) {
+    if (err instanceof OpRunFailure) {
+      if (ctx.args.json) renderJson(err.result); else renderHuman(err.result);
+      return 1;
+    }
+    if (err instanceof LocalGateUnsupportedError) {
+      console.error(formatError({ message: err.message }));
+      return 1;
+    }
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+  }
+}
+
+async function runOpTemporal(ctx: CommandContext): Promise<number> {
   const opName = ctx.args.path;
 
   if (!opName || opName === ".") {

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -37,6 +37,9 @@ export function parseArgs(args: string[]): ParsedArgs {
     help: false,
     profile: undefined,
     report: undefined,
+    local: undefined,
+    temporal: undefined,
+    json: undefined,
     live: false,
     migrateFrom: undefined,
     migrateTo: undefined,
@@ -98,6 +101,12 @@ export function parseArgs(args: string[]): ParsedArgs {
       result.useComposites = true;
     } else if (arg === "--skill") {
       result.skill = args[++i];
+    } else if (arg === "--local") {
+      result.local = true;
+    } else if (arg === "--temporal") {
+      result.temporal = true;
+    } else if (arg === "--json") {
+      result.json = true;
     } else if (!arg.startsWith("-")) {
       if (!result.command) {
         result.command = arg;
@@ -182,6 +191,9 @@ Options:
   -v, --verbose         Show stack traces on errors
   -h, --help            Show this help message
   -p, --profile <name>  Temporal worker profile to use (run command)
+  --local               Run an Op with the local in-process executor (default)
+  --temporal            Run an Op via a Temporal cluster (gates, schedules, durable resume)
+  --json                Emit the structured run result as JSON (run command)
   --report              Print deployment report instead of running (run command)
                         OR with a path arg: SARIF report destination (migrate)
   --from <name>         Source lexicon for migrate (default: github)

--- a/packages/core/src/cli/mcp/op-tools.ts
+++ b/packages/core/src/cli/mcp/op-tools.ts
@@ -63,7 +63,7 @@ export function createOpRunTool(): ToolRegistration {
     definition: {
       name: "op-run",
       description:
-        "Submit an Op workflow to Temporal. The worker must already be running — start it first with `chant run <name>`.",
+        "Submit an Op workflow to Temporal (Temporal mode). A Temporal worker must already be running — start it with `chant run <name> --temporal`.",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -20,6 +20,12 @@ export interface ParsedArgs {
   help: boolean;
   profile?: string;
   report?: boolean;
+  /** `chant run` — force the local in-process executor (the default). */
+  local?: boolean;
+  /** `chant run` — run via a Temporal cluster instead of the local executor. */
+  temporal?: boolean;
+  /** `chant run` — emit the structured OpRunResult as JSON on stdout. */
+  json?: boolean;
   live: boolean;
   /** `chant migrate --from <name>` (default "github") */
   migrateFrom?: string;

--- a/packages/core/src/op/activity-registry.test.ts
+++ b/packages/core/src/op/activity-registry.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect, vi, afterEach } from "vitest";
+import { loadActivities, resolveActivity, type ActivityFn } from "./activity-registry";
+
+describe("loadActivities", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@intentius/chant-lexicon-temporal/op/activities");
+  });
+
+  test("loads the lexicon activity library keyed by export name", async () => {
+    const activities = await loadActivities();
+    // Real export names from lexicons/temporal/src/op/activities.
+    expect(activities.has("shellCmd")).toBe(true);
+    expect(activities.has("chantBuild")).toBe(true);
+    expect(activities.has("kubectlApply")).toBe(true);
+    expect(activities.has("stateDiff")).toBe(true);
+    expect(typeof activities.get("shellCmd")).toBe("function");
+  });
+
+  test("throws a friendly error when the lexicon is not installed", async () => {
+    vi.resetModules();
+    vi.doMock("@intentius/chant-lexicon-temporal/op/activities", () => {
+      throw new Error("Cannot find module");
+    });
+    const { loadActivities: fresh } = await import("./activity-registry");
+    await expect(fresh()).rejects.toThrow(
+      "no activities registered — install `@intentius/chant-lexicon-temporal`",
+    );
+  });
+});
+
+describe("resolveActivity", () => {
+  test("resolves a known activity by name", () => {
+    const fn: ActivityFn = async () => "ok";
+    const map = new Map<string, ActivityFn>([["shellCmd", fn]]);
+    expect(resolveActivity(map, "shellCmd")).toBe(fn);
+  });
+
+  test("throws listing known names for an unknown fn", () => {
+    const map = new Map<string, ActivityFn>([
+      ["shellCmd", async () => undefined],
+      ["chantBuild", async () => undefined],
+    ]);
+    expect(() => resolveActivity(map, "nope")).toThrow(
+      'no activity named "nope" (known: chantBuild, shellCmd)',
+    );
+  });
+});
+
+describe("loadActivities — heartbeat-shim safety", () => {
+  test("the activity library loads without @temporalio/activity installed", async () => {
+    // kubectlApply/helmInstall/waitForStack/gitlabPipeline heartbeat via the
+    // lazy shim; if the shim statically required the SDK, this import would
+    // throw (the SDK is not installed in this environment).
+    const activities = await loadActivities();
+    expect(activities.has("kubectlApply")).toBe(true);
+    expect(activities.has("waitForStack")).toBe(true);
+  });
+});

--- a/packages/core/src/op/activity-registry.ts
+++ b/packages/core/src/op/activity-registry.ts
@@ -1,0 +1,91 @@
+/**
+ * Activity registry — resolves an Op step's `fn` name to a callable activity
+ * implementation for local execution.
+ *
+ * Activities live in the Temporal lexicon (`@intentius/chant-lexicon-temporal`)
+ * but are plain async functions taking a single args object — Temporal-free to
+ * call. Local mode loads them by name instead of registering them with a worker.
+ */
+
+/**
+ * An activity is an async function taking a single args object and an optional
+ * `AbortSignal`. Local execution passes a signal that fires on timeout or
+ * Ctrl-C so the activity can kill in-flight child processes; the Temporal
+ * worker invokes activities with args only (cancellation comes from its own
+ * `Context`), so the signal is always optional.
+ */
+export type ActivityFn = (args: Record<string, unknown>, signal?: AbortSignal) => Promise<unknown>;
+
+/**
+ * Dynamically import the Temporal lexicon's activity library and return a map
+ * of every exported function keyed by its export name (`shellCmd`, `chantBuild`,
+ * `kubectlApply`, …).
+ *
+ * Throws a friendly error if the lexicon is not installed — local execution
+ * needs the activity implementations even though it never starts a worker.
+ */
+export async function loadActivities(): Promise<Map<string, ActivityFn>> {
+  let mod: Record<string, unknown>;
+  try {
+    // Variable specifier so tsc does not statically resolve the optional dep.
+    const spec = "@intentius/chant-lexicon-temporal/op/activities";
+    mod = (await import(spec)) as Record<string, unknown>;
+  } catch {
+    throw new Error(
+      "no activities registered — install `@intentius/chant-lexicon-temporal`",
+    );
+  }
+
+  const activities = new Map<string, ActivityFn>();
+  for (const [name, value] of Object.entries(mod)) {
+    if (typeof value === "function") {
+      activities.set(name, value as ActivityFn);
+    }
+  }
+  return activities;
+}
+
+/** Structural shape of a TEMPORAL_ACTIVITY_PROFILES entry (timeout + retry). */
+export interface ActivityProfile {
+  startToCloseTimeout?: string;
+  heartbeatTimeout?: string;
+  retry?: {
+    initialInterval?: string;
+    backoffCoefficient?: number;
+    maximumAttempts?: number;
+    maximumInterval?: string;
+    /** Error names (`Error.name`) that should fail immediately without retry. */
+    nonRetryableErrorTypes?: string[];
+  };
+}
+
+/**
+ * Dynamically import the lexicon's `TEMPORAL_ACTIVITY_PROFILES` (pure data, no
+ * Temporal SDK). Returns an empty record if the lexicon is absent — the
+ * executor then falls back to built-in defaults per step.
+ */
+export async function loadProfiles(): Promise<Record<string, ActivityProfile>> {
+  try {
+    const spec = "@intentius/chant-lexicon-temporal";
+    const mod = (await import(spec)) as { TEMPORAL_ACTIVITY_PROFILES?: Record<string, ActivityProfile> };
+    return mod.TEMPORAL_ACTIVITY_PROFILES ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolve a step's `fn` against the loaded activity map.
+ * Throws a clear error listing known names if the activity is missing.
+ */
+export function resolveActivity(
+  activities: Map<string, ActivityFn>,
+  fn: string,
+): ActivityFn {
+  const activity = activities.get(fn);
+  if (!activity) {
+    const known = [...activities.keys()].sort().join(", ");
+    throw new Error(`no activity named "${fn}" (known: ${known})`);
+  }
+  return activity;
+}

--- a/packages/core/src/op/index.ts
+++ b/packages/core/src/op/index.ts
@@ -4,3 +4,8 @@ export { OpResource } from "./resource";
 export type { OpConfig, PhaseDefinition, StepDefinition, ActivityStep, GateStep } from "./types";
 export { discoverOps } from "./discover";
 export type { DiscoveredOp, OpDiscoveryResult } from "./discover";
+export { loadActivities, loadProfiles, resolveActivity } from "./activity-registry";
+export type { ActivityFn, ActivityProfile } from "./activity-registry";
+export { runOpLocally, parseDuration, findGate, LocalGateUnsupportedError, OpRunFailure } from "./local-executor";
+export type { StepRecord, OpRunResult } from "./local-executor";
+export { renderHuman, renderJson } from "./local-output";

--- a/packages/core/src/op/local-executor.test.ts
+++ b/packages/core/src/op/local-executor.test.ts
@@ -1,0 +1,247 @@
+import { describe, test, expect, vi } from "vitest";
+import type { OpConfig } from "./types";
+import type { ActivityFn, ActivityProfile } from "./activity-registry";
+import {
+  runOpLocally,
+  parseDuration,
+  findGate,
+  LocalGateUnsupportedError,
+  OpRunFailure,
+} from "./local-executor";
+
+// Fast profiles so retry/timeout tests run in milliseconds.
+const PROFILES: Record<string, ActivityProfile> = {
+  fastIdempotent: {
+    startToCloseTimeout: "5m",
+    retry: { maximumAttempts: 3, initialInterval: "5ms", backoffCoefficient: 2 },
+  },
+  quickTimeout: {
+    startToCloseTimeout: "50ms",
+    retry: { maximumAttempts: 2, initialInterval: "1ms", backoffCoefficient: 1 },
+  },
+  single: { startToCloseTimeout: "5m", retry: { maximumAttempts: 1 } },
+};
+
+function op(partial: Partial<OpConfig>): OpConfig {
+  return { name: "test-op", overview: "", phases: [], ...partial };
+}
+
+describe("parseDuration", () => {
+  test("parses single and compound durations", () => {
+    expect(parseDuration("5m")).toBe(300_000);
+    expect(parseDuration("30s")).toBe(30_000);
+    expect(parseDuration("100ms")).toBe(100);
+    expect(parseDuration("1h30m")).toBe(5_400_000);
+    expect(parseDuration("48h")).toBe(172_800_000);
+  });
+  test("throws on garbage", () => {
+    expect(() => parseDuration("soon")).toThrow(/unparseable/);
+  });
+});
+
+describe("runOpLocally — sequencing", () => {
+  test("runs phases and steps in declared order", async () => {
+    const order: string[] = [];
+    const make = (tag: string): ActivityFn => async () => { order.push(tag); };
+    const activities = new Map<string, ActivityFn>([
+      ["a", make("a")], ["b", make("b")], ["c", make("c")],
+    ]);
+    const config = op({
+      phases: [
+        { name: "P1", steps: [{ kind: "activity", fn: "a" }] },
+        { name: "P2", steps: [{ kind: "activity", fn: "b" }] },
+        { name: "P3", steps: [{ kind: "activity", fn: "c" }] },
+      ],
+    });
+    const result = await runOpLocally(config, activities, PROFILES);
+    expect(order).toEqual(["a", "b", "c"]);
+    expect(result.ok).toBe(true);
+    expect(result.records.map((r) => r.fn)).toEqual(["a", "b", "c"]);
+  });
+
+  test("parallel phase runs steps concurrently (~max, not sum)", async () => {
+    const slow = (ms: number): ActivityFn => async () => { await new Promise((r) => setTimeout(r, ms)); };
+    const activities = new Map<string, ActivityFn>([["s1", slow(60)], ["s2", slow(60)]]);
+    const config = op({
+      phases: [{ name: "P", parallel: true, steps: [
+        { kind: "activity", fn: "s1" }, { kind: "activity", fn: "s2" },
+      ] }],
+    });
+    const start = Date.now();
+    await runOpLocally(config, activities, PROFILES);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(110); // ~60 (max), well under 120 (sum)
+  });
+});
+
+describe("runOpLocally — retry + timeout", () => {
+  test("retries until success", async () => {
+    let calls = 0;
+    const flaky: ActivityFn = async () => {
+      calls++;
+      if (calls < 3) throw new Error("transient");
+      return "ok";
+    };
+    const config = op({ phases: [{ name: "P", steps: [{ kind: "activity", fn: "flaky" }] }] });
+    const result = await runOpLocally(config, new Map([["flaky", flaky]]), PROFILES);
+    expect(calls).toBe(3);
+    expect(result.records[0].status).toBe("ok");
+  });
+
+  test("times out a slow attempt and retries", async () => {
+    let calls = 0;
+    const slow: ActivityFn = async () => {
+      calls++;
+      // First attempt hangs past the 50ms timeout; second resolves fast.
+      await new Promise((r) => setTimeout(r, calls === 1 ? 200 : 1));
+    };
+    // Map the default profile to quickTimeout (50ms timeout, 2 attempts).
+    const config = op({
+      phases: [{ name: "P", steps: [{ kind: "activity", fn: "slow" }] }],
+    });
+    const profiles = { ...PROFILES, fastIdempotent: PROFILES.quickTimeout };
+    const result = await runOpLocally(config, new Map([["slow", slow]]), profiles);
+    expect(calls).toBe(2);
+    expect(result.records[0].status).toBe("ok");
+  });
+
+  test("rejects after exhausting retries", async () => {
+    const always: ActivityFn = async () => { throw new Error("nope"); };
+    const config = op({ phases: [{ name: "P", steps: [{ kind: "activity", fn: "always" }] }] });
+    await expect(runOpLocally(config, new Map([["always", always]]), PROFILES)).rejects.toBeInstanceOf(OpRunFailure);
+  });
+});
+
+describe("runOpLocally — cancellation", () => {
+  test("aborts the activity's signal on timeout", async () => {
+    let abortedSeen = false;
+    const hang: ActivityFn = async (_args, signal) => {
+      await new Promise<void>((resolve) => {
+        signal?.addEventListener("abort", () => { abortedSeen = true; resolve(); });
+        setTimeout(resolve, 5000); // would hang far past the timeout if not aborted
+      });
+      throw new Error("abandoned");
+    };
+    const config = op({ phases: [{ name: "P", steps: [{ kind: "activity", fn: "hang" }] }] });
+    const profiles = { ...PROFILES, fastIdempotent: { startToCloseTimeout: "30ms", retry: { maximumAttempts: 1 } } };
+    await expect(runOpLocally(config, new Map([["hang", hang]]), profiles)).rejects.toBeInstanceOf(OpRunFailure);
+    expect(abortedSeen).toBe(true);
+  });
+
+  test("stops retrying once the run signal aborts (Ctrl-C)", async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    const failOnAbort: ActivityFn = async () => {
+      calls++;
+      controller.abort(); // simulate SIGINT mid-attempt
+      throw new Error("boom");
+    };
+    const config = op({ phases: [{ name: "P", steps: [{ kind: "activity", fn: "failOnAbort" }] }] });
+    // fastIdempotent permits 3 attempts; the abort must cut it to 1.
+    await expect(
+      runOpLocally(config, new Map([["failOnAbort", failOnAbort]]), PROFILES, controller.signal),
+    ).rejects.toBeInstanceOf(OpRunFailure);
+    expect(calls).toBe(1);
+  });
+
+  test("skips onFailure compensation when aborted", async () => {
+    const controller = new AbortController();
+    const comp = vi.fn();
+    const main: ActivityFn = async () => { controller.abort(); throw new Error("boom"); };
+    const config = op({
+      phases: [{ name: "Main", steps: [{ kind: "activity", fn: "main" }] }],
+      onFailure: [{ name: "C", steps: [{ kind: "activity", fn: "comp" }] }],
+    });
+    const activities = new Map<string, ActivityFn>([["main", main], ["comp", async () => { comp(); }]]);
+    await expect(runOpLocally(config, activities, PROFILES, controller.signal)).rejects.toBeInstanceOf(OpRunFailure);
+    expect(comp).not.toHaveBeenCalled();
+  });
+});
+
+describe("runOpLocally — non-retryable errors", () => {
+  test("fails immediately on a non-retryable error type", async () => {
+    let calls = 0;
+    const fatal: ActivityFn = async () => {
+      calls++;
+      const e = new Error("bad manifest");
+      e.name = "ValidationError";
+      throw e;
+    };
+    const profiles = {
+      ...PROFILES,
+      fastIdempotent: {
+        startToCloseTimeout: "5m",
+        retry: { maximumAttempts: 3, initialInterval: "1ms", nonRetryableErrorTypes: ["ValidationError"] },
+      },
+    };
+    const config = op({ phases: [{ name: "P", steps: [{ kind: "activity", fn: "fatal" }] }] });
+    await expect(runOpLocally(config, new Map([["fatal", fatal]]), profiles)).rejects.toBeInstanceOf(OpRunFailure);
+    expect(calls).toBe(1);
+  });
+});
+
+describe("runOpLocally — outcomeAttribute", () => {
+  test("captures a dot-path from the return value", async () => {
+    const diff: ActivityFn = async () => ({ output: "...", exitCode: 0, drifted: false });
+    const config = op({
+      phases: [{ name: "Check", steps: [
+        { kind: "activity", fn: "stateDiff", outcomeAttribute: { name: "Drift", from: "drifted" } },
+      ] }],
+    });
+    const result = await runOpLocally(config, new Map([["stateDiff", diff]]), PROFILES);
+    expect(result.records[0].outcome).toEqual({ name: "Drift", value: false });
+  });
+});
+
+describe("runOpLocally — onFailure", () => {
+  test("runs compensation phases in reverse and rejects with ok=false", async () => {
+    const order: string[] = [];
+    const make = (tag: string, fail = false): ActivityFn => async () => {
+      order.push(tag);
+      if (fail) throw new Error("boom");
+    };
+    const activities = new Map<string, ActivityFn>([
+      ["main", make("main", true)],
+      ["comp1", make("comp1")],
+      ["comp2", make("comp2")],
+    ]);
+    const config = op({
+      phases: [{ name: "Main", steps: [{ kind: "activity", fn: "main" }] }],
+      onFailure: [
+        { name: "C1", steps: [{ kind: "activity", fn: "comp1" }] },
+        { name: "C2", steps: [{ kind: "activity", fn: "comp2" }] },
+      ],
+    });
+    const err = await runOpLocally(config, activities, PROFILES).catch((e) => e);
+    expect(err).toBeInstanceOf(OpRunFailure);
+    expect(err.result.ok).toBe(false);
+    // Main fails (3 attempts), then compensation runs in reverse: comp2, comp1.
+    expect(order).toEqual(["main", "main", "main", "comp2", "comp1"]);
+  });
+});
+
+describe("runOpLocally — gate rejection", () => {
+  test("rejects before running any step when a gate is present", async () => {
+    const ran = vi.fn();
+    const activities = new Map<string, ActivityFn>([["a", async () => { ran(); }]]);
+    const config = op({
+      phases: [
+        { name: "P", steps: [
+          { kind: "activity", fn: "a" },
+          { kind: "gate", signalName: "approve-prod" },
+        ] },
+      ],
+    });
+    await expect(runOpLocally(config, activities, PROFILES)).rejects.toBeInstanceOf(LocalGateUnsupportedError);
+    await expect(runOpLocally(config, activities, PROFILES)).rejects.toThrow(/--temporal/);
+    expect(ran).not.toHaveBeenCalled();
+  });
+
+  test("findGate locates a gate in phases or onFailure", () => {
+    expect(findGate(op({ phases: [{ name: "P", steps: [{ kind: "activity", fn: "a" }] }] }))).toBeUndefined();
+    const gated = findGate(op({
+      phases: [{ name: "P", steps: [{ kind: "gate", signalName: "g" }] }],
+    }));
+    expect(gated?.signalName).toBe("g");
+  });
+});

--- a/packages/core/src/op/local-executor.ts
+++ b/packages/core/src/op/local-executor.ts
@@ -1,0 +1,300 @@
+/**
+ * Local Op executor — runs an Op's phases in-process with no Temporal worker.
+ *
+ * A first-class peer to Temporal mode for dev loops, CI, and drift/observation
+ * Ops. Provides phase sequencing, parallel phases, per-step retry + timeout via
+ * activity profiles, `outcomeAttribute` capture, and `onFailure` compensation.
+ * Gates and schedules are unsupported and rejected before any phase runs.
+ *
+ * The executor is deliberately decoupled from the Temporal lexicon: activity
+ * implementations and profiles are passed in (loaded dynamically by the CLI),
+ * so core never statically depends on `@intentius/chant-lexicon-temporal`.
+ */
+
+import type { OpConfig, PhaseDefinition, ActivityStep, GateStep, StepDefinition } from "./types";
+import { resolveActivity, type ActivityFn, type ActivityProfile } from "./activity-registry";
+
+// ── Records ─────────────────────────────────────────────────────────────────
+
+export interface StepRecord {
+  phase: string;
+  fn: string;
+  args: Record<string, unknown>;
+  status: "ok" | "fail" | "skipped";
+  durationMs: number;
+  outcome?: { name: string; value: unknown };
+  error?: string;
+}
+
+export interface OpRunResult {
+  op: string;
+  records: StepRecord[];
+  totalMs: number;
+  ok: boolean;
+}
+
+// ── Errors ────────────────────────────────────────────────────────────────��─
+
+/** Thrown when an Op contains a gate (or schedule) that local mode cannot run. */
+export class LocalGateUnsupportedError extends Error {
+  constructor(public readonly signalName: string) {
+    super(
+      `gate "${signalName}" is not supported in local mode — gates and schedules ` +
+        `need a durable runtime. Re-run with --temporal.`,
+    );
+    this.name = "LocalGateUnsupportedError";
+  }
+}
+
+/** Thrown on terminal Op failure; carries the partial run result for rendering. */
+export class OpRunFailure extends Error {
+  constructor(public readonly result: OpRunResult) {
+    super(`Op "${result.op}" failed`);
+    this.name = "OpRunFailure";
+  }
+}
+
+/** Internal: a phase aborted; carries records produced before the abort. */
+class PhaseFailure extends Error {
+  constructor(public readonly records: StepRecord[]) {
+    super("phase failed");
+    this.name = "PhaseFailure";
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────��─
+
+const DEFAULT_PROFILE = "fastIdempotent";
+const FALLBACK_TIMEOUT_MS = 5 * 60_000;
+
+const isActivity = (s: StepDefinition): s is ActivityStep => s.kind === "activity";
+const isGate = (s: StepDefinition): s is GateStep => s.kind === "gate";
+
+/** Parse a Temporal duration string ("5m", "30s", "1h30m", "100ms") to ms. */
+export function parseDuration(s: string): number {
+  const units: Record<string, number> = { ms: 1, s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+  let total = 0;
+  let matched = false;
+  for (const m of s.matchAll(/(\d+)(ms|s|m|h|d)/g)) {
+    total += Number(m[1]) * units[m[2]];
+    matched = true;
+  }
+  if (!matched) throw new Error(`unparseable duration: "${s}"`);
+  return total;
+}
+
+/** Resolve a dot-path into a value; returns the whole value when path is absent. */
+function resolvePath(value: unknown, path?: string): unknown {
+  if (!path) return value;
+  return path.split(".").reduce<unknown>(
+    (acc, key) => (acc == null ? acc : (acc as Record<string, unknown>)[key]),
+    value,
+  );
+}
+
+/** Find the first gate step anywhere in the Op (phases + onFailure), if any. */
+export function findGate(config: OpConfig): GateStep | undefined {
+  const all = [...config.phases, ...(config.onFailure ?? [])];
+  for (const phase of all) {
+    const gate = phase.steps.find(isGate);
+    if (gate) return gate;
+  }
+  return undefined;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Race a single activity attempt against its start-to-close timeout. On timeout
+ * (or when the run-level `parentSignal` aborts, e.g. Ctrl-C) the attempt's
+ * `AbortSignal` fires so the activity can kill its child process, then the call
+ * rejects so the retry loop can react. The losing promise is swallowed to keep
+ * its eventual rejection from surfacing as an unhandled rejection.
+ */
+async function callWithTimeout(
+  fn: ActivityFn,
+  args: Record<string, unknown>,
+  timeoutMs: number,
+  parentSignal?: AbortSignal,
+): Promise<unknown> {
+  const controller = new AbortController();
+  const onParentAbort = () => controller.abort();
+  if (parentSignal) {
+    if (parentSignal.aborted) controller.abort();
+    else parentSignal.addEventListener("abort", onParentAbort, { once: true });
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`activity timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  const call = Promise.resolve(fn(args, controller.signal));
+  call.catch(() => {}); // losing-race rejection must not become unhandled
+
+  try {
+    return await Promise.race([call, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+    if (parentSignal) parentSignal.removeEventListener("abort", onParentAbort);
+  }
+}
+
+// ── Step + phase execution ────────────────────────────────────────────────��─
+
+/** Run one activity step with retry + timeout. Never throws — returns a record. */
+async function runStep(
+  step: ActivityStep,
+  phaseName: string,
+  activities: Map<string, ActivityFn>,
+  profiles: Record<string, ActivityProfile>,
+  signal?: AbortSignal,
+): Promise<StepRecord> {
+  const args = step.args ?? {};
+  const base = { phase: phaseName, fn: step.fn, args };
+  const start = Date.now();
+
+  let fn: ActivityFn;
+  try {
+    fn = resolveActivity(activities, step.fn);
+  } catch (err) {
+    return { ...base, status: "fail", durationMs: 0, error: errMessage(err) };
+  }
+
+  const profile = profiles[step.profile ?? DEFAULT_PROFILE] ?? {};
+  const timeoutMs = profile.startToCloseTimeout
+    ? parseDuration(profile.startToCloseTimeout)
+    : FALLBACK_TIMEOUT_MS;
+  const maxAttempts =
+    profile.retry?.maximumAttempts && profile.retry.maximumAttempts > 0
+      ? profile.retry.maximumAttempts
+      : 1;
+  const initial = profile.retry?.initialInterval ? parseDuration(profile.retry.initialInterval) : 0;
+  const backoff = profile.retry?.backoffCoefficient ?? 1;
+  const maxInterval = profile.retry?.maximumInterval
+    ? parseDuration(profile.retry.maximumInterval)
+    : Infinity;
+  const nonRetryable = profile.retry?.nonRetryableErrorTypes ?? [];
+
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const result = await callWithTimeout(fn, args, timeoutMs, signal);
+      const record: StepRecord = { ...base, status: "ok", durationMs: Date.now() - start };
+      if (step.outcomeAttribute) {
+        record.outcome = {
+          name: step.outcomeAttribute.name,
+          value: resolvePath(result, step.outcomeAttribute.from),
+        };
+      }
+      return record;
+    } catch (err) {
+      lastErr = err;
+      // Stop retrying on abort (Ctrl-C / timeout cascade) or a non-retryable error.
+      const fatal =
+        signal?.aborted || (err instanceof Error && nonRetryable.includes(err.name));
+      if (!fatal && attempt < maxAttempts) {
+        const wait = Math.min(initial * Math.pow(backoff, attempt - 1), maxInterval);
+        if (wait > 0) await sleep(wait);
+        continue;
+      }
+      break;
+    }
+  }
+  return { ...base, status: "fail", durationMs: Date.now() - start, error: errMessage(lastErr) };
+}
+
+/** Run a phase. Throws PhaseFailure (with records so far) if any step fails. */
+async function runPhase(
+  phase: PhaseDefinition,
+  activities: Map<string, ActivityFn>,
+  profiles: Record<string, ActivityProfile>,
+  signal?: AbortSignal,
+): Promise<StepRecord[]> {
+  // Defensive: gates are pre-flighted, but never execute one if it slips through.
+  const gate = phase.steps.find(isGate);
+  if (gate) throw new LocalGateUnsupportedError(gate.signalName);
+
+  const steps = phase.steps.filter(isActivity);
+
+  if (phase.parallel) {
+    const records = await Promise.all(
+      steps.map((s) => runStep(s, phase.name, activities, profiles, signal)),
+    );
+    if (records.some((r) => r.status === "fail")) throw new PhaseFailure(records);
+    return records;
+  }
+
+  const records: StepRecord[] = [];
+  for (let i = 0; i < steps.length; i++) {
+    const record = await runStep(steps[i], phase.name, activities, profiles, signal);
+    records.push(record);
+    if (record.status === "fail") {
+      // Mark the remaining steps in this phase as skipped, then abort.
+      for (const skipped of steps.slice(i + 1)) {
+        records.push({
+          phase: phase.name,
+          fn: skipped.fn,
+          args: skipped.args ?? {},
+          status: "skipped",
+          durationMs: 0,
+        });
+      }
+      throw new PhaseFailure(records);
+    }
+  }
+  return records;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────��─
+
+/**
+ * Execute an Op locally. Resolves with the run result on success; rejects with
+ * `OpRunFailure` (carrying the partial result) on terminal failure, after
+ * running any `onFailure` phases in reverse order. Throws
+ * `LocalGateUnsupportedError` up front if the Op contains a gate.
+ */
+export async function runOpLocally(
+  config: OpConfig,
+  activities: Map<string, ActivityFn>,
+  profiles: Record<string, ActivityProfile>,
+  signal?: AbortSignal,
+): Promise<OpRunResult> {
+  const gate = findGate(config);
+  if (gate) throw new LocalGateUnsupportedError(gate.signalName);
+
+  const records: StepRecord[] = [];
+  const start = Date.now();
+
+  try {
+    for (const phase of config.phases) {
+      if (signal?.aborted) throw new PhaseFailure([]);
+      records.push(...(await runPhase(phase, activities, profiles, signal)));
+    }
+  } catch (err) {
+    if (err instanceof PhaseFailure) records.push(...err.records);
+
+    // Compensation: run onFailure phases in reverse order (best-effort). Skipped
+    // on abort (Ctrl-C) — the user asked to stop, so don't start new work.
+    if (!signal?.aborted) {
+      for (const phase of [...(config.onFailure ?? [])].reverse()) {
+        try {
+          records.push(...(await runPhase(phase, activities, profiles, signal)));
+        } catch (compErr) {
+          if (compErr instanceof PhaseFailure) records.push(...compErr.records);
+        }
+      }
+    }
+
+    throw new OpRunFailure({ op: config.name, records, totalMs: Date.now() - start, ok: false });
+  }
+
+  return { op: config.name, records, totalMs: Date.now() - start, ok: true };
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/core/src/op/local-output.test.ts
+++ b/packages/core/src/op/local-output.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from "vitest";
+import type { OpRunResult } from "./local-executor";
+import { renderHuman, renderJson } from "./local-output";
+
+const RESULT: OpRunResult = {
+  op: "hello",
+  totalMs: 100,
+  ok: true,
+  records: [
+    { phase: "Greet", fn: "shellCmd", args: { cmd: "echo hello from chant" }, status: "ok", durationMs: 42 },
+    { phase: "Check", fn: "stateDiff", args: { env: "prod" }, status: "ok", durationMs: 1200,
+      outcome: { name: "Drift", value: false } },
+  ],
+};
+
+describe("renderHuman", () => {
+  test("renders phase banners, step lines, outcomes, and a summary", () => {
+    const lines: string[] = [];
+    renderHuman(RESULT, (l) => lines.push(l));
+    const out = lines.join("\n");
+    expect(out).toContain("[phase] Greet");
+    expect(out).toContain("✓ shellCmd(cmd=echo hello from chant)   42ms");
+    expect(out).toContain("[phase] Check");
+    expect(out).toContain("[outcome] Drift=false");
+    expect(out).toContain("✓ stateDiff(env=prod)   1.2s");
+    expect(out).toContain('Op "hello" completed in 0.1s');
+  });
+
+  test("renders failures with ✗ and the error", () => {
+    const failed: OpRunResult = {
+      op: "deploy", totalMs: 50, ok: false,
+      records: [{ phase: "Apply", fn: "kubectlApply", args: { manifest: "x.yaml" }, status: "fail", durationMs: 10, error: "boom" }],
+    };
+    const lines: string[] = [];
+    renderHuman(failed, (l) => lines.push(l));
+    const out = lines.join("\n");
+    expect(out).toContain("✗ kubectlApply(manifest=x.yaml)");
+    expect(out).toContain("boom");
+    expect(out).toContain('Op "deploy" failed');
+  });
+});
+
+describe("renderJson", () => {
+  test("prints valid JSON parseable back to OpRunResult", () => {
+    const lines: string[] = [];
+    renderJson(RESULT, (l) => lines.push(l));
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]) as OpRunResult;
+    expect(parsed.op).toBe("hello");
+    expect(parsed.ok).toBe(true);
+    expect(parsed.records).toHaveLength(2);
+    expect(parsed.records[1].outcome).toEqual({ name: "Drift", value: false });
+  });
+});

--- a/packages/core/src/op/local-output.ts
+++ b/packages/core/src/op/local-output.ts
@@ -1,0 +1,63 @@
+/**
+ * Renderers for local Op execution. Both consume the same `OpRunResult`:
+ * `renderHuman` is the default (logs to stderr), `renderJson` prints the
+ * machine-readable record array to stdout and nothing else.
+ */
+
+import type { OpRunResult, StepRecord } from "./local-executor";
+
+type Writer = (line: string) => void;
+
+const stderr: Writer = (line) => process.stderr.write(line + "\n");
+const stdout: Writer = (line) => process.stdout.write(line + "\n");
+
+function formatArgs(args: Record<string, unknown>): string {
+  return Object.entries(args)
+    .map(([k, v]) => `${k}=${typeof v === "string" ? v : JSON.stringify(v)}`)
+    .join(", ");
+}
+
+function formatDuration(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Render a run result as human-readable progress. Defaults to stderr so stdout
+ * stays clean for piping (the `--json` renderer owns stdout).
+ */
+export function renderHuman(result: OpRunResult, write: Writer = stderr): void {
+  let currentPhase: string | undefined;
+  for (const record of result.records) {
+    if (record.phase !== currentPhase) {
+      currentPhase = record.phase;
+      write(`[phase] ${currentPhase}`);
+    }
+    const mark = record.status === "ok" ? "✓" : record.status === "fail" ? "✗" : "•";
+    const call = `${record.fn}(${formatArgs(record.args)})`;
+    if (record.status === "skipped") {
+      write(`  ${mark} ${call}   skipped`);
+    } else {
+      write(`  ${mark} ${call}   ${formatDuration(record.durationMs)}`);
+    }
+    if (record.outcome) {
+      write(`    [outcome] ${record.outcome.name}=${String(record.outcome.value)}`);
+    }
+    if (record.error) {
+      write(`    ${record.error}`);
+    }
+  }
+
+  const total = `${(result.totalMs / 1000).toFixed(1)}s`;
+  if (result.ok) {
+    write(`Op "${result.op}" completed in ${total}`);
+  } else {
+    write(`Op "${result.op}" failed after ${total}`);
+  }
+}
+
+/** Render a run result as JSON on stdout (and nothing else on stdout). */
+export function renderJson(result: OpRunResult, write: Writer = stdout): void {
+  write(JSON.stringify(result));
+}
+
+export type { OpRunResult, StepRecord };


### PR DESCRIPTION
Closes #73.

Adds `chant run <op>` local in-process execution so Ops run with no Temporal server. Local is the default; `--temporal` opts into a cluster (gates, schedules, durable resume).

## Executor (`packages/core/src/op`)
- **local-executor** — phase sequencing, parallel phases, per-step retry + timeout via activity profiles, `outcomeAttribute` capture, `onFailure` compensation, gate/schedule rejection.
- **activity-registry** — dynamic-import loader resolving `step.fn` by export name; friendly missing-peer-dep error.
- **local-output** — human (stderr) + `--json` (stdout) renderers over one `OpRunResult` model.

## CLI
- Mode dispatcher (no flag → local, `--temporal` → cluster), `--local`/`--temporal`/`--json` flags, gate pre-flight fast-fail, Temporal-only subcommand guards, and `--local --temporal` conflict error.

## Robustness
- **Real cancellation** — `ActivityFn` takes an `AbortSignal`; activities thread it into `exec`; `wait`/`gitlab` poll loops honor it. Timeout and Ctrl-C (SIGINT) abort in-flight child processes instead of orphaning them; compensation is skipped on abort.
- **`nonRetryableErrorTypes`** honored in both modes — local short-circuits its retry loop; Temporal gets it via the `proxyActivities` profile passthrough.
- **Lazy heartbeat shim** — activities run unchanged with or without `@temporalio/activity`.

## Schedule serializer
Emit the full schedule action — `retry` (from `workflowRetryPolicy`), `workflowExecutionTimeout`, `workflowRunTimeout`, `memo`, `searchAttributes`. These were declared on the resource type but silently dropped.

## Example, CI, docs
- `examples/local-op-quickstart` (one `shell` Op) + a local-mode regression guard step in `chant.yml`.
- `guide/local-vs-temporal.mdx`, Quick Start, and CLI flag docs.

## Testing
Full suite green (5925 tests). New coverage: executor (sequencing, parallel, retry, timeout, cancellation, non-retryable, onFailure, outcomeAttribute, gate rejection), registry, dispatcher/flags, output renderers, heartbeat positive path (mocked SDK), and schedule-action serialization.