### PR TITLE
feat(core): add exportResources() to LexiconPlugin contract

### DIFF
--- a/docs/src/content/docs/lexicon-authoring/observation.mdx
+++ b/docs/src/content/docs/lexicon-authoring/observation.mdx
@@ -261,6 +261,28 @@ Use the static factories to keep diff-engine and Op-activity tests free of `chil
 
 For the user-facing version of this matrix and how the diff output is grouped, see [`chant state`](/chant/cli/state/#coverage-today).
 
+## Live export — `exportResources()`
+
+`describeResources()` returns **scrubbed output metadata** for diffing. It cannot regenerate a resource — `attributes` are cloud-assigned outputs, not the input config you wrote. Live import needs the other half: the full input config, read from the live API.
+
+That is a separate, opt-in capability:
+
+```typescript
+exportResources?(options: {
+  environment: string;
+  selector?: ResourceSelector;   // { type?, name? }
+  owned?: boolean;               // inert until ownership marking lands
+}): Promise<ExportedTemplate>;
+```
+
+`ExportedTemplate` is the existing import IR (`TemplateIR`) — so the result feeds your lexicon's `templateGenerator()` unchanged — branded distinct from the observation types. The brand is the contract's guardrail: a full-fidelity export (which may carry secrets) can never flow into the `state` code paths, which consume `ResourceMetadata` through the `ObservationLexicon` view that omits `exportResources` entirely.
+
+<Aside type="caution">
+Keep the scrubbing boundary single-purpose. `describeResources()` scrubs for diffing; `exportResources()` returns full config for regeneration. Never overload one method for both — the secret-exposure surface stays in one place.
+</Aside>
+
+Implementing this is what powers [`chant import --from <env>`](/chant/cli/import/). A full authoring walkthrough — per-provider fidelity, the `--verbatim` switch, and the ownership marker — lands in the live-export authoring guide.
+
 ## See also
 
 - [`chant state`](/chant/cli/state/) — user-facing CLI reference

--- a/packages/core/src/cli/handlers/state.ts
+++ b/packages/core/src/cli/handlers/state.ts
@@ -9,7 +9,7 @@ import { formatError, formatWarning, formatSuccess, formatBold } from "../format
 import type { CommandContext } from "../registry";
 import type { StateSnapshot } from "../../state/types";
 import type { SerializerResult } from "../../serializer";
-import type { LexiconPlugin, ResourceMetadata, ArtifactMetadata } from "../../lexicon";
+import type { ObservationLexicon, ResourceMetadata, ArtifactMetadata } from "../../lexicon";
 import type { BuildResult } from "../../build";
 
 /**
@@ -213,7 +213,7 @@ async function runStateDiffDigest(args: DigestDiffArgs): Promise<number> {
 interface LiveDiffArgs {
   environment: string;
   lexicons: string[];
-  plugins: LexiconPlugin[];
+  plugins: ObservationLexicon[];
   buildResult: BuildResult;
 }
 

--- a/packages/core/src/lexicon-export.test.ts
+++ b/packages/core/src/lexicon-export.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "vitest";
+import type {
+  LexiconPlugin,
+  ObservationLexicon,
+  ExportedTemplate,
+  ResourceSelector,
+} from "./lexicon";
+import type { TypeScriptGenerator } from "./import/generator";
+import type { TemplateIR } from "./import/parser";
+
+// A throwaway generator standing in for any lexicon's real templateGenerator().
+const generator: TypeScriptGenerator = {
+  generate(ir: TemplateIR) {
+    return ir.resources.map((r) => ({
+      path: `${r.logicalId}.ts`,
+      content: `export const ${r.logicalId} = ${JSON.stringify(r.properties)};`,
+    }));
+  },
+};
+
+// A minimal lexicon that implements live export — the acceptance shape.
+const exportingLexicon: Pick<LexiconPlugin, "name" | "exportResources"> = {
+  name: "fake",
+  async exportResources(opts: {
+    environment: string;
+    selector?: ResourceSelector;
+    owned?: boolean;
+  }): Promise<ExportedTemplate> {
+    const selector = opts.selector;
+    const all: ExportedTemplate = {
+      resources: [
+        { logicalId: "Bucket", type: "Fake::Bucket", properties: { versioning: true } },
+        { logicalId: "Queue", type: "Fake::Queue", properties: { fifo: false } },
+      ],
+      parameters: [],
+      metadata: { environment: opts.environment, owned: opts.owned ?? false },
+    };
+    if (!selector) return all;
+    return {
+      ...all,
+      resources: all.resources.filter(
+        (r) =>
+          (selector.type === undefined || r.type === selector.type) &&
+          (selector.name === undefined || r.logicalId === selector.name),
+      ),
+    };
+  },
+};
+
+describe("exportResources contract (#113)", () => {
+  test("an ExportedTemplate feeds templateGenerator() unchanged", async () => {
+    const ir = await exportingLexicon.exportResources!({ environment: "prod" });
+    // ExportedTemplate is structurally a TemplateIR — no adapter needed.
+    const files = generator.generate(ir);
+    expect(files.map((f) => f.path)).toEqual(["Bucket.ts", "Queue.ts"]);
+    expect(files[0].content).toContain("versioning");
+  });
+
+  test("selector narrows the exported set", async () => {
+    const ir = await exportingLexicon.exportResources!({
+      environment: "prod",
+      selector: { name: "Queue" },
+    });
+    expect(ir.resources).toHaveLength(1);
+    expect(ir.resources[0].logicalId).toBe("Queue");
+  });
+
+  test("owned is accepted but inert (carried into metadata, no filtering yet)", async () => {
+    const ir = await exportingLexicon.exportResources!({ environment: "prod", owned: true });
+    expect(ir.metadata?.owned).toBe(true);
+    expect(ir.resources).toHaveLength(2);
+  });
+
+  test("type separation: observation view cannot reach exportResources", () => {
+    // A full plugin is assignable to the narrowed observation view…
+    const full = exportingLexicon as unknown as LexiconPlugin;
+    const observed: ObservationLexicon = full;
+    // …but exportResources is not visible on it. Compile-time guarantee:
+    // @ts-expect-error exportResources is omitted from ObservationLexicon
+    void observed.exportResources;
+    expect(typeof observed.name).toBe("string");
+  });
+
+  test("type separation: scrubbed metadata is not an ExportedTemplate", () => {
+    // A ResourceMetadata-shaped object lacks resources/parameters, so it can
+    // never be passed where an ExportedTemplate (full config) is expected.
+    const scrubbed = { type: "Fake::Bucket", status: "OK" };
+    // @ts-expect-error observation metadata is not a full-fidelity export
+    const asExport: ExportedTemplate = scrubbed;
+    expect(asExport).toBeDefined();
+  });
+});

--- a/packages/core/src/lexicon.ts
+++ b/packages/core/src/lexicon.ts
@@ -2,7 +2,7 @@ import type { Serializer } from "./serializer";
 import type { LintRule } from "./lint/rule";
 import type { RuleSpec } from "./lint/declarative";
 import type { PostSynthCheck } from "./lint/post-synth";
-import type { TemplateParser } from "./import/parser";
+import type { TemplateParser, TemplateIR } from "./import/parser";
 import type { TypeScriptGenerator } from "./import/generator";
 import type { ArtifactIntegrity } from "./lexicon-integrity";
 import type { CompletionContext, CompletionItem, HoverContext, HoverInfo, CodeActionContext, CodeAction } from "./lsp/types";
@@ -288,7 +288,66 @@ export interface LexiconPlugin {
     environment: string;
     entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
   }): Promise<Record<string, ArtifactMetadata>>;
+
+  // Live export (cloud → code)
+  /**
+   * Export full-fidelity import IR from a live API — the cloud→code primitive
+   * that lets chant regenerate TypeScript from running cloud/cluster state.
+   *
+   * Deliberately separate from {@link describeResources}: that returns scrubbed
+   * *output* metadata for diffing, this returns full *input* config — enough to
+   * regenerate a resource, and therefore possibly containing secrets. The
+   * scrubbing boundary stays single-purpose; never overload one method for both.
+   *
+   * The return type {@link ExportedTemplate} is branded distinct from the
+   * observation types so a full-fidelity export can never flow into the
+   * observation/`state` code paths by accident.
+   *
+   * `owned` is accepted now but inert until ownership marking exists (#119/#120).
+   */
+  exportResources?(options: {
+    environment: string;
+    selector?: ResourceSelector;
+    owned?: boolean;
+  }): Promise<ExportedTemplate>;
 }
+
+/**
+ * The observation view of a lexicon — every capability except live export.
+ *
+ * State/observation code (snapshots, `state diff --live`) consumes lexicons
+ * through this type so that `exportResources` is unreachable from those paths:
+ * a full-fidelity {@link ExportedTemplate} (which may carry secrets) must never
+ * be read where scrubbed {@link ResourceMetadata} is expected. A full
+ * {@link LexiconPlugin} is assignable to this type; accessing `exportResources`
+ * on it is a compile error.
+ */
+export type ObservationLexicon = Omit<LexiconPlugin, "exportResources">;
+
+/**
+ * Narrows which live resources {@link LexiconPlugin.exportResources} and the
+ * `owned` filter operate on. Both fields are optional; omit to export all.
+ */
+export interface ResourceSelector {
+  /** Restrict to a single chant resource type (e.g. "AWS::S3::Bucket"). */
+  readonly type?: string;
+  /** Restrict to a single resource name. */
+  readonly name?: string;
+}
+
+/**
+ * Full-fidelity import IR read from a live API, branded distinct from the
+ * scrubbed observation metadata. It IS a {@link TemplateIR} — it feeds the
+ * existing `templateGenerator()` unchanged — but the phantom brand keeps it
+ * from being passed where observation metadata is expected, and keeps
+ * observation metadata from being passed where an export is expected.
+ *
+ * The brand is type-only; nothing is added at runtime.
+ */
+export type ExportedTemplate = TemplateIR & {
+  /** Phantom marker — never present at runtime. */
+  readonly __fidelity?: "full-config";
+};
 
 /**
  * Metadata about a deployed resource, returned by describeResources.

--- a/packages/core/src/state/snapshot.ts
+++ b/packages/core/src/state/snapshot.ts
@@ -2,7 +2,7 @@
  * Snapshot orchestration: queries plugins for deployed resource metadata,
  * assembles StateSnapshots, computes build digests, and writes to git.
  */
-import type { LexiconPlugin, ResourceMetadata, ArtifactMetadata } from "../lexicon";
+import type { ObservationLexicon, ResourceMetadata, ArtifactMetadata } from "../lexicon";
 import type { BuildResult } from "../build";
 import type { SerializerResult } from "../serializer";
 import type { StateSnapshot } from "./types";
@@ -82,7 +82,7 @@ export interface TakeSnapshotResult {
  */
 export async function takeSnapshot(
   environment: string,
-  plugins: LexiconPlugin[],
+  plugins: ObservationLexicon[],
   buildResult: BuildResult,
   opts?: { cwd?: string },
 ): Promise<TakeSnapshotResult> {


### PR DESCRIPTION
Adds the missing primitive that lets chant generate TypeScript from live cloud/cluster state: a lexicon capability returning full-fidelity import IR from a live API.

## What

- `LexiconPlugin.exportResources?(opts)` returns `Promise<ExportedTemplate>` — full input config, suitable for regeneration via the existing `templateGenerator()`.
- `ExportedTemplate` brands `TemplateIR` so a full-fidelity export (which may carry secrets) cannot flow into the observation/`state` code paths, and scrubbed metadata can never be mistaken for an export.
- `ResourceSelector { type?, name? }` narrows the export set.
- `owned` is accepted but inert until ownership marking lands (#119/#120).
- The `state` code paths (`takeSnapshot`, live-diff) now consume lexicons through a new `ObservationLexicon = Omit<LexiconPlugin, "exportResources">` view, so no state handler can call `exportResources` — enforced at compile time.

## Why

`describeResources()` returns scrubbed *output* metadata for diffing; you cannot regenerate a resource from it. This adds the separate, single-purpose connector: live API → full `TemplateIR`. Kept distinct so the secret-exposure boundary stays in one place.

## Tests

`packages/core/src/lexicon-export.test.ts`:
- An `ExportedTemplate` feeds `templateGenerator()` unchanged.
- Selector narrows the set; `owned` is inert.
- Type separation: `ObservationLexicon` cannot reach `exportResources` (`@ts-expect-error`); scrubbed metadata is not an `ExportedTemplate` (`@ts-expect-error`).

## Docs

`lexicon-authoring/observation.mdx` gains a "Live export" section documenting the new capability and the scrubbing boundary (full authoring walkthrough deferred to #128).

Part of #112. Closes #113.