### PR TITLE
feat(core): chant state plan — typed ChangeSet from live diff

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -70,6 +70,27 @@ Output is grouped into six categories per lexicon:
 
 Drifted entries include attribute-level deltas (`status`, `physicalId`, `lastUpdated`, and each `attributes.*` key).
 
+### `state plan <env>`
+
+Promote the live diff to a typed, **read-only** change set. Where `state diff --live` reports six observation categories, `state plan` classifies each resource into one action you can act on:
+
+```bash
+chant state plan prod
+chant state plan prod --json   # emit the ChangeSet as JSON
+```
+
+| Action | Meaning |
+|---|---|
+| **create** | Declared in source, absent from the cloud |
+| **update** | Declared and live, but the live config drifted |
+| **delete** | A chant-owned resource that is live but no longer declared |
+| **adopt** | Live but undeclared, ownership not established — a candidate to pull back into source, never an auto-delete |
+| **noop** | Declared and live with no drift, or already reconciled |
+
+`create` and `update` are precise from declared-vs-live. `delete` is only ever proposed for a resource a live ownership marker confirms is chant's — until ownership data exists, an undeclared live resource is `adopt`, never `delete`. The classification reads ownership from the live marker, never from the snapshot, so the snapshot never becomes load-bearing.
+
+`state plan` is strictly read-only: it builds, queries, and classifies. It never mutates the cloud and never deploys — `chant build` stays pure.
+
 ### Resources vs artifacts
 
 A single lexicon may report both **resources** (entity-keyed, via `describeResources()`) and **artifacts** (context-keyed, via `listArtifacts()`); `state diff --live` shows them in separate sections. Artifacts use a four-category two-way diff (no "declared" axis):

--- a/packages/core/src/cli/handlers/state.ts
+++ b/packages/core/src/cli/handlers/state.ts
@@ -4,6 +4,7 @@ import { takeSnapshot } from "../../state/snapshot";
 import { readSnapshot, readEnvironmentSnapshots, listSnapshots, fetchState, StaleStateBranchError } from "../../state/git";
 import { computeBuildDigest, diffDigests } from "../../state/digest";
 import { diffLive, diffLiveArtifacts, type LiveDiffResult, type LiveArtifactDiffResult } from "../../state/live-diff";
+import { buildChangeSet, renderChangeSet, type ChangeSet } from "../../state/change-set";
 import { loadChantConfig } from "../../config";
 import { formatError, formatWarning, formatSuccess, formatBold } from "../format";
 import type { CommandContext } from "../registry";
@@ -403,6 +404,116 @@ function renderLiveArtifactDiff(lexiconName: string, environment: string, diff: 
 }
 
 /**
+ * chant state plan <environment> [lexicon]
+ *
+ * Promote the live diff to a typed, read-only change set: per-entity
+ * create / update / delete / adopt / noop. Strictly read-only — never
+ * mutates, never deploys. Deletes are never proposed without ownership
+ * data (added in #121); an undeclared live resource is `adopt`.
+ */
+export async function runStatePlan(ctx: CommandContext): Promise<number> {
+  const { args, plugins, serializers } = ctx;
+  const environment = args.extraPositional;
+  const lexiconFilter = args.extraPositional2;
+
+  if (!environment) {
+    console.error(formatError({ message: "Environment is required: chant state plan <environment> [lexicon]" }));
+    return 1;
+  }
+
+  const targetSerializers = lexiconFilter
+    ? plugins.filter((p) => p.name === lexiconFilter).map((p) => p.serializer)
+    : serializers;
+
+  const projectPath = resolve(".");
+  const buildResult = await build(projectPath, targetSerializers);
+  if (buildResult.errors.length > 0) {
+    console.error(formatError({ message: "Build failed — fix errors before planning" }));
+    return 1;
+  }
+
+  await fetchState();
+
+  const lexicons = lexiconFilter ? [lexiconFilter] : Array.from(buildResult.manifest.lexicons);
+
+  const merged: ChangeSet = { env: environment, entries: [] };
+  let checked = 0;
+
+  for (const lexiconName of lexicons) {
+    const plugin = plugins.find((p) => p.name === lexiconName);
+    if (!plugin) continue;
+    if (!plugin.describeResources) {
+      // Plan is entity-keyed; artifact-only lexicons have no declared axis.
+      if (!args.json) {
+        console.error(formatWarning({
+          message: `${lexiconName}: lexicon does not implement describeResources — skipping (no declared axis to plan against)`,
+        }));
+      }
+      continue;
+    }
+
+    const declared = new Set<string>();
+    const entities = new Map<string, { entityType: string; props: Record<string, unknown> }>();
+    for (const [name, entity] of buildResult.entities) {
+      if (entity.lexicon === lexiconName) {
+        declared.add(name);
+        entities.set(name, {
+          entityType: entity.entityType,
+          props: ("props" in entity && entity.props != null ? entity.props : {}) as Record<string, unknown>,
+        });
+      }
+    }
+
+    const rawOutput = buildResult.outputs.get(lexiconName);
+    const buildOutput =
+      rawOutput === undefined
+        ? ""
+        : typeof rawOutput === "string"
+          ? rawOutput
+          : (rawOutput as SerializerResult).primary;
+
+    let observedNow: Record<string, ResourceMetadata>;
+    try {
+      observedNow = await plugin.describeResources({
+        environment,
+        buildOutput,
+        entityNames: Array.from(declared),
+        entities,
+      });
+    } catch (err) {
+      console.error(formatError({
+        message: `${lexiconName}: describeResources failed — ${err instanceof Error ? err.message : String(err)}`,
+      }));
+      continue;
+    }
+
+    const content = await readSnapshot(environment, lexiconName);
+    const observedThen = content ? (JSON.parse(content) as StateSnapshot).resources : undefined;
+
+    const cs = buildChangeSet(environment, { declared, observedNow, observedThen });
+    merged.entries.push(...cs.entries);
+    checked++;
+  }
+
+  if (checked === 0) {
+    console.error(formatWarning({
+      message: "No lexicons implement describeResources — nothing to plan",
+    }));
+    return 1;
+  }
+
+  merged.entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  if (args.json) {
+    console.log(JSON.stringify(merged, null, 2));
+  } else {
+    console.log(renderChangeSet(merged));
+  }
+
+  return 0;
+}
+
+/**
  * chant state log [environment]
  */
 export async function runStateLog(ctx: CommandContext): Promise<number> {
@@ -430,7 +541,7 @@ export async function runStateLog(ctx: CommandContext): Promise<number> {
 export async function runStateUnknown(ctx: CommandContext): Promise<number> {
   console.error(formatError({
     message: `Unknown state subcommand: ${ctx.args.extraPositional ?? ctx.args.path}`,
-    hint: "Available: chant state snapshot, chant state show, chant state diff, chant state log",
+    hint: "Available: chant state snapshot, chant state show, chant state diff, chant state plan, chant state log",
   }));
   return 1;
 }

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -13,7 +13,7 @@ import { runServeLsp, runServeMcp, runServeUnknown } from "./handlers/serve";
 import { runInit, runInitLexicon } from "./handlers/init";
 import { runList, runImport, runUpdate, runDoctor } from "./handlers/misc";
 import { runMigrate } from "./handlers/migrate";
-import { runStateSnapshot, runStateShow, runStateDiff, runStateLog, runStateUnknown } from "./handlers/state";
+import { runStateSnapshot, runStateShow, runStateDiff, runStatePlan, runStateLog, runStateUnknown } from "./handlers/state";
 import { runGraph } from "./handlers/graph";
 import { runOp, runOpList, runOpStatus, runOpSignal, runOpCancel, runOpLog } from "./handlers/run";
 
@@ -160,6 +160,8 @@ State:
   state show <env>      Show latest state snapshot
   state diff <env>      Compare current build against last snapshot
                         --live: query cloud now and detect drift
+  state plan <env>      Typed change set (create/update/delete/adopt) vs live
+                        --json: emit the ChangeSet as JSON
   state log [env]       History of state snapshots
 
 Lexicon development:
@@ -276,6 +278,7 @@ const registry: CommandDef[] = [
   { name: "state snapshot", requiresPlugins: true, handler: runStateSnapshot },
   { name: "state show", handler: runStateShow },
   { name: "state diff", requiresPlugins: true, handler: runStateDiff },
+  { name: "state plan", requiresPlugins: true, handler: runStatePlan },
   { name: "state log", handler: runStateLog },
 
   // Serve subcommands

--- a/packages/core/src/state/change-set.test.ts
+++ b/packages/core/src/state/change-set.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+import { buildChangeSet, renderChangeSet, summarize } from "./change-set";
+import type { ResourceMetadata } from "../lexicon";
+
+const meta = (over: Partial<ResourceMetadata> = {}): ResourceMetadata => ({
+  type: "Fake::Resource",
+  status: "OK",
+  ...over,
+});
+
+describe("buildChangeSet (#118)", () => {
+  test("declared but not live → create", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(["bucket"]),
+      observedNow: {},
+      observedThen: undefined,
+    });
+    const e = cs.entries.find((x) => x.name === "bucket")!;
+    expect(e.action).toBe("create");
+    expect(e.evidence).toEqual({ declared: true, inSnapshot: false, live: false });
+    expect(e.ownership).toBe("unknown");
+  });
+
+  test("declared and live with drift since snapshot → update with deltas", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(["queue"]),
+      observedNow: { queue: meta({ status: "ACTIVE" }) },
+      observedThen: { queue: meta({ status: "CREATING" }) },
+    });
+    const e = cs.entries.find((x) => x.name === "queue")!;
+    expect(e.action).toBe("update");
+    expect(e.deltas).toEqual([{ path: "status", oldValue: "CREATING", newValue: "ACTIVE" }]);
+  });
+
+  test("declared and live, unchanged → noop", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(["queue"]),
+      observedNow: { queue: meta({ status: "ACTIVE" }) },
+      observedThen: { queue: meta({ status: "ACTIVE" }) },
+    });
+    expect(cs.entries.find((x) => x.name === "queue")!.action).toBe("noop");
+  });
+
+  test("live but undeclared → adopt, never delete (no ownership yet)", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(),
+      observedNow: { orphan: meta() },
+      observedThen: undefined,
+    });
+    const e = cs.entries.find((x) => x.name === "orphan")!;
+    expect(e.action).toBe("adopt");
+    expect(e.ownership).toBe("unknown");
+  });
+
+  test("never proposes a delete without ownership data", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(["a"]),
+      observedNow: { b: meta(), c: meta() }, // two orphans
+      observedThen: { b: meta(), c: meta() },
+    });
+    expect(cs.entries.some((e) => e.action === "delete")).toBe(false);
+    expect(cs.entries.filter((e) => e.action === "adopt").map((e) => e.name)).toEqual(["b", "c"]);
+  });
+
+  test("only in snapshot (gone now, undeclared) → noop", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(),
+      observedNow: {},
+      observedThen: { ghost: meta() },
+    });
+    expect(cs.entries.find((x) => x.name === "ghost")!.action).toBe("noop");
+  });
+
+  test("entries are sorted by name", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(["z", "a", "m"]),
+      observedNow: {},
+      observedThen: undefined,
+    });
+    expect(cs.entries.map((e) => e.name)).toEqual(["a", "m", "z"]);
+  });
+});
+
+describe("summarize / renderChangeSet", () => {
+  const cs = buildChangeSet("prod", {
+    declared: new Set(["create-me", "keep-me"]),
+    observedNow: { "keep-me": meta(), orphan: meta() },
+    observedThen: { "keep-me": meta() },
+  });
+
+  test("summarize counts each action", () => {
+    const counts = summarize(cs);
+    expect(counts.create).toBe(1);
+    expect(counts.noop).toBe(1);
+    expect(counts.adopt).toBe(1);
+    expect(counts.delete).toBe(0);
+  });
+
+  test("render shows the env and grouped sections", () => {
+    const out = renderChangeSet(cs);
+    expect(out).toContain("Plan for prod");
+    expect(out).toContain("CREATE:");
+    expect(out).toContain("create-me");
+    expect(out).toContain("ADOPT:");
+    expect(out).toContain("orphan");
+  });
+});

--- a/packages/core/src/state/change-set.ts
+++ b/packages/core/src/state/change-set.ts
@@ -1,0 +1,165 @@
+/**
+ * Change set: a typed, read-only projection of a live diff.
+ *
+ * `chant state diff --live` computes a three-way comparison — declared now /
+ * last snapshot / live now — and prints it. `buildChangeSet` promotes that
+ * same signal into a classified create/update/delete/adopt/noop set that other
+ * tooling (reconcile, apply) can act on.
+ *
+ * Strictly read-only and pure: no I/O, no mutation. The classification reads
+ * ownership from the live marker only (populated downstream); until ownership
+ * exists, an undeclared live resource is `adopt`, never `delete`. The snapshot
+ * is evidence, never the basis for a mutation decision — it must never become
+ * load-bearing.
+ */
+import { diffLive, type AttributeChange, type DiffLiveInput } from "./live-diff";
+
+/**
+ * What the projection proposes for a single resource.
+ *
+ * - `create` — declared in source, absent from live.
+ * - `update` — declared and live, but live config drifted.
+ * - `delete` — a chant-owned resource that is live but no longer declared.
+ *   Only emitted once ownership is known (#121); never inferred from the
+ *   snapshot.
+ * - `adopt` — live but undeclared, ownership not established → a candidate to
+ *   pull back into source, never an auto-delete.
+ * - `noop` — declared and live with no drift, or already reconciled.
+ */
+export type ChangeAction = "create" | "update" | "delete" | "adopt" | "noop";
+
+/**
+ * Who answers "is this resource chant's?". `unknown` until a live ownership
+ * marker is queried (#120). The change set never escalates `unknown` to a
+ * delete.
+ */
+export type Ownership = "owned" | "foreign" | "unknown";
+
+export interface ChangeSetEntry {
+  /** chant entity name. */
+  name: string;
+  /** Resource type, when known from either side. */
+  type?: string;
+  action: ChangeAction;
+  /** The three-way evidence the classification was derived from. */
+  evidence: {
+    /** Present in the current build. */
+    declared: boolean;
+    /** Present in the last snapshot. */
+    inSnapshot: boolean;
+    /** Observed in the live system right now. */
+    live: boolean;
+  };
+  /** Attribute-level changes, for `update`. */
+  deltas?: AttributeChange[];
+  /** Live-marker ownership. Defaults to `unknown`. */
+  ownership: Ownership;
+}
+
+export interface ChangeSet {
+  env: string;
+  entries: ChangeSetEntry[];
+}
+
+/**
+ * Build a typed change set from the same inputs `diffLive` consumes.
+ *
+ * `create`/`update` are precise from declared-vs-live. `delete` is never
+ * emitted here — an undeclared live resource classifies as `adopt` until
+ * ownership is known.
+ */
+export function buildChangeSet(env: string, input: DiffLiveInput): ChangeSet {
+  const diff = diffLive(input);
+  const { declared, observedNow } = input;
+  const observedThen = input.observedThen ?? {};
+
+  const driftByName = new Map(
+    diff.driftedSinceSnapshot.map((d) => [d.name, d.changes] as const),
+  );
+
+  const names = new Set<string>([
+    ...declared,
+    ...Object.keys(observedNow),
+    ...Object.keys(observedThen),
+  ]);
+
+  const entries: ChangeSetEntry[] = [];
+  for (const name of names) {
+    const isDeclared = declared.has(name);
+    const live = Object.prototype.hasOwnProperty.call(observedNow, name);
+    const inSnapshot = Object.prototype.hasOwnProperty.call(observedThen, name);
+    const type = observedNow[name]?.type ?? observedThen[name]?.type;
+    const evidence = { declared: isDeclared, inSnapshot, live };
+
+    let action: ChangeAction;
+    let deltas: AttributeChange[] | undefined;
+
+    if (isDeclared && !live) {
+      // Declared in source, not in the cloud → create.
+      action = "create";
+    } else if (isDeclared && live) {
+      const drift = driftByName.get(name);
+      if (drift && drift.length > 0) {
+        action = "update";
+        deltas = drift;
+      } else {
+        action = "noop";
+      }
+    } else if (live) {
+      // Live but undeclared. Cannot become a delete without ownership — adopt.
+      action = "adopt";
+    } else {
+      // Only in the snapshot: already gone, nothing to reconcile.
+      action = "noop";
+    }
+
+    entries.push({ name, type, action, evidence, deltas, ownership: "unknown" });
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  return { env, entries };
+}
+
+const ACTION_ORDER: ChangeAction[] = ["create", "update", "delete", "adopt", "noop"];
+
+/** Count entries per action. */
+export function summarize(cs: ChangeSet): Record<ChangeAction, number> {
+  const counts: Record<ChangeAction, number> = {
+    create: 0,
+    update: 0,
+    delete: 0,
+    adopt: 0,
+    noop: 0,
+  };
+  for (const e of cs.entries) counts[e.action]++;
+  return counts;
+}
+
+/** Human-readable render of a change set. Pure — returns a string. */
+export function renderChangeSet(cs: ChangeSet): string {
+  const counts = summarize(cs);
+  const header = ACTION_ORDER.map((a) => `${counts[a]} ${a}`).join(", ");
+  const lines: string[] = [`Plan for ${cs.env}: ${header}`];
+
+  for (const action of ACTION_ORDER) {
+    const group = cs.entries.filter((e) => e.action === action);
+    if (group.length === 0) continue;
+    lines.push(`\n${action.toUpperCase()}:`);
+    for (const e of group) {
+      const own = e.ownership === "unknown" ? "" : ` [${e.ownership}]`;
+      lines.push(`  ${e.name}${e.type ? ` (${e.type})` : ""}${own}`);
+      for (const d of e.deltas ?? []) {
+        lines.push(`      ${d.path}: ${fmt(d.oldValue)} → ${fmt(d.newValue)}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function fmt(v: unknown): string {
+  if (v === undefined) return "<unset>";
+  if (typeof v === "string") return v.length > 60 ? v.slice(0, 57) + "..." : v;
+  const json = JSON.stringify(v);
+  return json.length > 60 ? json.slice(0, 57) + "..." : json;
+}

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -2,3 +2,5 @@ export * from "./types";
 export * from "./git";
 export * from "./digest";
 export * from "./snapshot";
+export * from "./live-diff";
+export * from "./change-set";


### PR DESCRIPTION
Promotes `chant state diff --live`'s three-way comparison (declared / last snapshot / live) into a typed, read-only change set.

## What

- `buildChangeSet(env, input)` (`packages/core/src/state/change-set.ts`) — pure classifier producing `ChangeSet { env, entries }` where each `ChangeSetEntry { name, type?, action, evidence, deltas?, ownership }`.
- Actions: `create | update | delete | adopt | noop`.
  - `create` — declared, absent from live.
  - `update` — declared and live, with drift; carries attribute deltas.
  - `adopt` — live but undeclared; cannot become a `delete` without ownership.
  - `noop` — declared+live unchanged, or already gone.
  - `delete` — reserved for owned orphans; **never emitted here** (lands in #121).
- `ownership` defaults to `unknown`. The classifier never reads the snapshot to decide a mutation — the snapshot is evidence, not authority.
- `chant state plan <env> [lexicon]` — human renderer + `--json`. Strictly read-only.

## Tests

`packages/core/src/state/change-set.test.ts` (9): each action path, "never proposes a delete without ownership", sorting, summarize/render.

## Docs

`cli/state.mdx` gains a `state plan` subcommand section with the action table and the read-only / no-load-bearing-snapshot guarantees. (Sidebar nav + cross-links land in #129.)

Part of #112. Closes #118.