### PR TITLE
docs: concepts/durable-workflows (Temporal differentiator) + SEO + scope clauses

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A type system for operations.
 
+Synthesis is pure and local. There is no authoritative state file — chant computes a precise change set against the live system using cloud-side ownership markers, so you get a plan without hosting state. When an apply needs durability — approval gates, rollback, crash-resume — chant compiles your orchestration to [durable workflows](https://intentius.io/chant/concepts/durable-workflows/): Temporal-native when you want durability, zero-dependency when you don't.
+
 **[Read the docs →](https://intentius.io/chant/getting-started/introduction/)**
 
 > chant is in active development. Packages are published under the [`@intentius`](https://www.npmjs.com/org/intentius) org on npm.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -36,6 +36,7 @@ export default defineConfig({
 						{ label: 'Choosing Your Deployment Model', slug: 'concepts/deployment-paths' },
 						{ label: 'State and Governance', slug: 'concepts/governance' },
 						{ label: 'Drift Detection', slug: 'concepts/drift-detection' },
+						{ label: 'Durable Workflows', slug: 'concepts/durable-workflows' },
 					],
 				},
 				{
@@ -71,7 +72,7 @@ export default defineConfig({
 						{ label: 'Flyway + PostgreSQL + GitLab', slug: 'tutorials/flyway-postgresql' },
 						{ label: 'CockroachDB Multi-Region', slug: 'tutorials/cockroachdb-multi-region' },
 						{ label: 'GitLab Cells on GKE', slug: 'tutorials/gitlab-cells' },
-						{ label: 'Temporal Workflow-Driven Deploy', slug: 'tutorials/temporal-crdb-deploy' },
+						{ label: 'Durable Infrastructure Workflows', slug: 'tutorials/temporal-crdb-deploy' },
 						{ label: 'Fargate + Lucene/Solr + EFS', slug: 'tutorials/fargate-lucene-efs-solr' },
 						{ label: 'Ray + KubeRay on GKE', slug: 'tutorials/ray-kuberay-gke' },
 						{ label: 'Slurm EDA HPC on AWS', slug: 'tutorials/slurm-aws-hpc' },

--- a/docs/src/content/docs/concepts/durable-workflows.mdx
+++ b/docs/src/content/docs/concepts/durable-workflows.mdx
@@ -1,0 +1,51 @@
+---
+title: Durable Workflows for Infrastructure (Temporal IaC)
+description: Why infrastructure orchestration wants durable execution — approval gates, compensation, and crash-resume — and how chant uses Temporal for it.
+---
+
+Most infrastructure-as-code stops at synthesis: it produces the artifact and hands off. The orchestration that actually applies it — the gates, the retries, the rollback when step seven of nine fails — lives in shell scripts, CI YAML, and the operator's memory. chant takes the opposite position. Orchestration is declared as code in `*.op.ts` files and runs as an inspectable, durable workflow.
+
+No other IaC toolchain exposes its orchestration as first-class durable execution. This page explains why that matters, and why it stays optional.
+
+**Temporal-native when you want durability, zero-dependency when you don't.** The primitives — build, lint, synthesize, plan — need no executor at all. The local executor runs Ops in-process for one-shot `chant run`. Temporal is the upgrade you reach for when an Op needs to outlive a single process.
+
+## What durable execution buys an apply
+
+A non-trivial apply is a multi-step sequence against systems that fail independently. Three properties separate a durable workflow from a script that happens to call the same APIs.
+
+### Approval gates
+
+A destructive change should pause for a human. In a script that means a blocking prompt that dies with the terminal, or an out-of-band ticket the script can't see. A durable workflow waits on a signal — for minutes or for days — without holding a process open. The wait survives a worker restart. The approval is part of the workflow history, not a Slack message someone has to remember.
+
+### Compensation and rollback
+
+When step seven of nine fails, the first six steps already happened. A durable workflow models compensation — the saga pattern — so a partial failure unwinds in reverse instead of leaving the system half-applied. The compensation logic is declared alongside the forward step, not bolted on as cleanup nobody tested.
+
+### Crash-resume without double-acting
+
+A worker that dies mid-apply resumes from the last completed step, not from the top, and without re-running steps that already took effect. Determinism plus event-sourced history is what makes "resume" safe rather than a second chance to double-charge.
+
+## Why this is Temporal, and why it is optional
+
+These three properties — durable waits, compensation, exactly-once resume — are what Temporal exists to provide. chant does not reimplement them; it compiles your declared Ops into Temporal worker code and lets the platform own durability.
+
+That is also exactly why it is optional. The primitives that don't need durability don't pay for it:
+
+- `chant build`, `chant lint`, `chant state plan` are pure and executor-free.
+- One-shot Ops run on the **local executor** in-process — no cluster, no dependency.
+- Only gated or destructive Ops — the ones where a multi-hour approval wait or a crash mid-apply is unacceptable — are Temporal-bound.
+
+Lead with the local executor as the on-ramp. Reach for Temporal when the workflow has to survive a crash, hold a long approval, or roll back a partial failure. See [Local vs Temporal](/chant/guide/local-vs-temporal/) for the decision and [Ops](/chant/guide/ops/) for the authoring model.
+
+## Who this is for
+
+Two audiences meet here. Teams searching for durable execution for deployments — approval gates and rollback as infrastructure primitives — and finding nothing purpose-built. And existing Temporal users who already trust durable workflows for their application logic and want the same guarantees for the infrastructure underneath it.
+
+If you are comparing chant against Terraform and bounced on "no state management": durability is a different axis from state. chant has no authoritative state file, and computes a precise change set anyway via [live projection](/chant/concepts/governance/). The durable-workflow layer is what applies that change set safely when you want it to.
+
+## See also
+
+- [Ops](/chant/guide/ops/) — declaring orchestration in `*.op.ts`
+- [Local vs Temporal](/chant/guide/local-vs-temporal/) — when each executor fits
+- [Temporal Workflow-Driven Deploy](/chant/tutorials/temporal-crdb-deploy/) — a durable infrastructure workflow end to end
+- [State and Governance](/chant/concepts/governance/) — why no authoritative state file is needed

--- a/docs/src/content/docs/getting-started/introduction.mdx
+++ b/docs/src/content/docs/getting-started/introduction.mdx
@@ -9,6 +9,8 @@ chant is a TypeScript-first infrastructure tool. You define cloud resources as p
 TypeScript source → chant build → provider-specific output
 ```
 
+"No state to manage" means no authoritative state file to host, lock, or trust — not the absence of a change set. chant computes a precise create/update/delete plan against the live system using ownership markers that live on the cloud resource, so you get the plan without the file ([State and Governance](/chant/concepts/governance/)). And when an apply needs to be durable — approval gates, rollback, crash-resume — chant compiles your orchestration to [durable workflows](/chant/concepts/durable-workflows/): Temporal-native when you want durability, zero-dependency when you don't.
+
 You get real `import`/`export`, editor autocompletion, and semantic lint rules that catch misconfigurations before deployment — all in a single local pass.
 
 ## Choose Your Path

--- a/docs/src/content/docs/tutorials/temporal-crdb-deploy.mdx
+++ b/docs/src/content/docs/tutorials/temporal-crdb-deploy.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Temporal Workflow-Driven Deployment"
-description: "Replace a 200-line bash deploy script with a durable, observable, resumable Temporal workflow — using the CockroachDB multi-region GKE example as the target."
+title: "Durable Infrastructure Workflows (Temporal)"
+description: "Build a durable infrastructure workflow: replace a 200-line bash deploy script with a durable, observable, resumable Temporal workflow — using the CockroachDB multi-region GKE example as the target."
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -10,6 +10,8 @@ This tutorial covers the **raw Temporal path**: you write your own workflow Type
 </Aside>
 
 A 50-minute infrastructure deployment is a bad fit for a bash script. When it fails at phase 7, you re-run from scratch. When it's running, you grep logs. When a loop hangs, you wait. This tutorial shows how to replace that bash script with a [Temporal](https://temporal.io) workflow — durable, observable, and resumable — layered on top of the chant-generated YAML.
+
+Temporal-native when you want durability, zero-dependency when you don't: the chant synthesis underneath is pure and local, and one-shot Ops run on the local executor with no cluster. You reach for the durable workflow here precisely because a 50-minute apply needs to survive a crash and resume mid-run. For the conceptual case, see [Durable Workflows](/chant/concepts/durable-workflows/).
 
 ## What you'll build
 


### PR DESCRIPTION
Foregrounds Temporal as a differentiator and discovery channel, independent of the state work.

## What

- **New `concepts/durable-workflows.mdx`** — why infra orchestration wants durable execution (approval gates, compensation/rollback, crash-resume), in the measured tone of `governance.mdx`. Temporal keywords in the title and frontmatter `description` for search intent ("Temporal IaC", "durable execution for deployments").
- **De-risking clause** repeated wherever Temporal is foregrounded: *"Temporal-native when you want durability, zero-dependency when you don't."* Every Temporal-forward surface leads with the local executor as the on-ramp.
- **Tutorial reframed** — `temporal-crdb-deploy` becomes "Durable Infrastructure Workflows" (title, description, sidebar label) with the de-risking clause in its intro.
- **Scope clause** added to `getting-started/introduction` and the `README` so a reader comparing against Terraform doesn't bounce on "no state management" — it clarifies that means no authoritative state file, not no change set.
- **Sidebar** — "Durable Workflows" added under Core Concepts.

## Docs only

No code changes. All internal links verified against existing slugs.

Part of #112. Closes #130.