### PR TITLE
feat(aws): exportResources via CloudFormation GetTemplate

### DIFF
--- a/docs/src/content/docs/lexicon-authoring/observation.mdx
+++ b/docs/src/content/docs/lexicon-authoring/observation.mdx
@@ -283,6 +283,12 @@ Keep the scrubbing boundary single-purpose. `describeResources()` scrubs for dif
 
 Implementing this is what powers [`chant import --from <env>`](/chant/cli/import/). A full authoring walkthrough — per-provider fidelity, the `--verbatim` switch, and the ownership marker — lands in the live-export authoring guide.
 
+Live-export coverage today:
+
+| Lexicon | `exportResources()` | How it reads live config |
+|---|---|---|
+| AWS | ✅ | `aws cloudformation get-template --template-stage Original`, parsed by the CloudFormation import parser |
+
 ## See also
 
 - [`chant state`](/chant/cli/state/) — user-facing CLI reference

--- a/lexicons/aws/src/import/live-export.test.ts
+++ b/lexicons/aws/src/import/live-export.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { parseStackTemplate } from "./live-export";
+import { CFGenerator } from "./generator";
+
+// Mimics what `aws cloudformation get-template --output json` returns:
+// a JSON object under TemplateBody.
+const liveTemplate = {
+  AWSTemplateFormatVersion: "2010-09-09",
+  Resources: {
+    MyBucket: {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "my-bucket", VersioningConfiguration: { Status: "Enabled" } },
+    },
+    MyQueue: {
+      Type: "AWS::SQS::Queue",
+      Properties: { QueueName: "my-queue" },
+    },
+  },
+};
+
+describe("AWS exportResources mapping (#115)", () => {
+  test("maps a live CloudFormation template body to export IR", () => {
+    const ir = parseStackTemplate(liveTemplate);
+    expect(ir.resources.map((r) => r.logicalId).sort()).toEqual(["MyBucket", "MyQueue"]);
+    const bucket = ir.resources.find((r) => r.logicalId === "MyBucket")!;
+    expect(bucket.type).toBe("AWS::S3::Bucket");
+    expect(bucket.properties.BucketName).toBe("my-bucket");
+  });
+
+  test("accepts a stringified template body (YAML-origin stacks)", () => {
+    const ir = parseStackTemplate(JSON.stringify(liveTemplate));
+    expect(ir.resources).toHaveLength(2);
+  });
+
+  test("selector by name narrows the export", () => {
+    const ir = parseStackTemplate(liveTemplate, { name: "MyQueue" });
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["MyQueue"]);
+  });
+
+  test("selector by type narrows the export", () => {
+    const ir = parseStackTemplate(liveTemplate, { type: "AWS::S3::Bucket" });
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["MyBucket"]);
+  });
+
+  test("export IR feeds CFGenerator (templateGenerator) unchanged", () => {
+    const ir = parseStackTemplate(liveTemplate);
+    const files = new CFGenerator().generate(ir);
+    expect(files.length).toBeGreaterThan(0);
+    const all = files.map((f) => f.content).join("\n");
+    // CFGenerator emits chant TypeScript (constructors), not raw CFN type strings.
+    expect(all).toContain("new Bucket(");
+    expect(all).toContain("BucketName");
+  });
+});

--- a/lexicons/aws/src/import/live-export.ts
+++ b/lexicons/aws/src/import/live-export.ts
@@ -1,0 +1,32 @@
+import type { ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
+import { CFParser } from "./parser";
+
+/**
+ * Map a live CloudFormation template body to full-fidelity export IR.
+ *
+ * `aws cloudformation get-template` returns the template body as a JSON object
+ * (for JSON templates) or a string (for YAML). `CFParser` already turns either
+ * into `TemplateIR` — the same IR the import path uses — so the result feeds
+ * `templateGenerator()` (CFGenerator) unchanged. Pure: all I/O stays in the
+ * caller.
+ */
+export function parseStackTemplate(
+  templateBody: unknown,
+  selector?: ResourceSelector,
+): ExportedTemplate {
+  const content =
+    typeof templateBody === "string" ? templateBody : JSON.stringify(templateBody);
+  const ir = new CFParser().parse(content);
+
+  if (!selector || (selector.type === undefined && selector.name === undefined)) {
+    return ir;
+  }
+  return {
+    ...ir,
+    resources: ir.resources.filter(
+      (r) =>
+        (selector.type === undefined || r.type === selector.type) &&
+        (selector.name === undefined || r.logicalId === selector.name),
+    ),
+  };
+}

--- a/lexicons/aws/src/plugin.ts
+++ b/lexicons/aws/src/plugin.ts
@@ -1,5 +1,5 @@
 import { createRequire } from "module";
-import type { LexiconPlugin, IntrinsicDef, ResourceMetadata } from "@intentius/chant/lexicon";
+import type { LexiconPlugin, IntrinsicDef, ResourceMetadata, ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
 const require = createRequire(import.meta.url);
 import type { LintRule } from "@intentius/chant/lint/rule";
 import type { TemplateParser } from "@intentius/chant/import/parser";
@@ -13,6 +13,7 @@ import { fileURLToPath } from "url";
 import { awsSerializer } from "./serializer";
 import { CFParser } from "./import/parser";
 import { CFGenerator } from "./import/generator";
+import { parseStackTemplate } from "./import/live-export";
 import { awsCompletions } from "./lsp/completions";
 import { awsHover } from "./lsp/hover";
 
@@ -554,6 +555,36 @@ aws cloudformation wait stack-update-complete --stack-name my-app-prod`,
     }
 
     return resources;
+  },
+
+  async exportResources(options: {
+    environment: string;
+    selector?: ResourceSelector;
+    owned?: boolean;
+  }): Promise<ExportedTemplate> {
+    const { getRuntime } = await import("@intentius/chant/runtime-adapter");
+    const rt = getRuntime();
+
+    // Same stack-name convention as describeResources.
+    const stackName = `${options.environment}`;
+
+    const result = await rt.spawn([
+      "aws", "cloudformation", "get-template",
+      "--stack-name", stackName,
+      "--template-stage", "Original",
+      "--output", "json",
+    ]);
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to get template for stack "${stackName}": ${result.stderr}`);
+    }
+
+    const parsed = JSON.parse(result.stdout) as { TemplateBody?: unknown };
+    if (parsed.TemplateBody === undefined) {
+      throw new Error(`Stack "${stackName}" returned no TemplateBody`);
+    }
+
+    // `owned` is accepted but inert until ownership marking lands (#120).
+    return parseStackTemplate(parsed.TemplateBody, options.selector);
   },
 
   mcpTools() {


### PR DESCRIPTION
Implements live export for the AWS lexicon so `chant import --from <aws-env>` produces TypeScript matching a deployed CloudFormation stack.

## What

- `awsPlugin.exportResources({ environment, selector?, owned? })` fetches the stack's original template via `aws cloudformation get-template --template-stage Original`, then maps it to `TemplateIR`.
- `parseStackTemplate()` (`import/live-export.ts`, pure) reuses the existing `CFParser` — `get-template` returns the body as a JSON object (JSON stacks) or string (YAML stacks); both are handled. Honors `selector { type?, name? }`.
- Result feeds the existing `CFGenerator` (`templateGenerator()`) unchanged.
- `owned` accepted but inert until ownership marking lands (#120).

## Tests

`import/live-export.test.ts` (5): object + string template bodies, selector by name and by type, and round-trip into chant TypeScript via `CFGenerator`.

## Docs

`lexicon-authoring/observation.mdx` live-export coverage table seeded with the AWS row.

Part of #112. Closes #115.