### PR TITLE
feat(k8s): exportResources via live cluster export

### DIFF
--- a/docs/src/content/docs/lexicon-authoring/observation.mdx
+++ b/docs/src/content/docs/lexicon-authoring/observation.mdx
@@ -272,6 +272,7 @@ exportResources?(options: {
   environment: string;
   selector?: ResourceSelector;   // { type?, name? }
   owned?: boolean;               // inert until ownership marking lands
+  verbatim?: boolean;            // keep server-defaulted fields; default strips
 }): Promise<ExportedTemplate>;
 ```
 
@@ -288,6 +289,7 @@ Live-export coverage today:
 | Lexicon | `exportResources()` | How it reads live config |
 |---|---|---|
 | AWS | ✅ | `aws cloudformation get-template --template-stage Original`, parsed by the CloudFormation import parser |
+| K8s | ✅ | `kubectl get <kinds> -A -o json`, stripped of `status`/`managedFields`/server metadata (kept under `--verbatim`), parsed by the K8s import parser |
 
 ## See also
 

--- a/lexicons/k8s/src/describe-resources.ts
+++ b/lexicons/k8s/src/describe-resources.ts
@@ -22,7 +22,7 @@ const execAsync = promisify(exec);
  * Map chant entity types to `kubectl get` resource names. Add entries here
  * as new types are needed.
  */
-const KUBECTL_RESOURCE: Record<string, string> = {
+export const KUBECTL_RESOURCE: Record<string, string> = {
   "K8s::Apps::Deployment": "deployment.apps",
   "K8s::Apps::StatefulSet": "statefulset.apps",
   "K8s::Apps::DaemonSet": "daemonset.apps",

--- a/lexicons/k8s/src/export-resources.ts
+++ b/lexicons/k8s/src/export-resources.ts
@@ -1,0 +1,60 @@
+/**
+ * Live export for the Kubernetes lexicon — implements
+ * LexiconPlugin.exportResources() so `chant import --from <cluster-env>`
+ * regenerates live objects as chant TypeScript.
+ *
+ * Reads live objects with `kubectl get <kinds> -A -o json`, strips
+ * server-managed noise to reach the declared shape (kept under `verbatim`),
+ * and maps to the import IR via the shared K8sParser. All I/O lives here; the
+ * cleaning and IR-building logic is pure in `./import/live-export`.
+ */
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
+import { KUBECTL_RESOURCE } from "./describe-resources";
+import { buildExportFromObjects } from "./import/live-export";
+
+const execAsync = promisify(exec);
+
+interface KubectlList {
+  items?: unknown[];
+}
+
+export async function exportResources(options: {
+  environment: string;
+  selector?: ResourceSelector;
+  owned?: boolean;
+  verbatim?: boolean;
+}): Promise<ExportedTemplate> {
+  // Resolve which kinds to query. A type selector narrows to one kind;
+  // otherwise sweep every kind chant knows how to map.
+  const kinds = options.selector?.type
+    ? [KUBECTL_RESOURCE[options.selector.type]].filter(Boolean)
+    : Array.from(new Set(Object.values(KUBECTL_RESOURCE)));
+
+  if (kinds.length === 0) {
+    return { resources: [], parameters: [] };
+  }
+
+  // One List per kind keeps parsing simple and isolates a missing-kind error
+  // to that kind rather than failing the whole export.
+  const objects: unknown[] = [];
+  for (const kind of kinds) {
+    try {
+      const { stdout } = await execAsync(
+        ["kubectl", "get", kind, "-A", "-o", "json"].join(" "),
+      );
+      const list = JSON.parse(stdout) as KubectlList;
+      if (Array.isArray(list.items)) objects.push(...list.items);
+    } catch {
+      // Kind not present in the cluster / RBAC denied — skip it, don't fail
+      // the whole export.
+    }
+  }
+
+  // `owned` is accepted but inert until ownership marking lands (#120).
+  return buildExportFromObjects(objects, {
+    verbatim: options.verbatim,
+    selector: options.selector,
+  });
+}

--- a/lexicons/k8s/src/import/live-export.test.ts
+++ b/lexicons/k8s/src/import/live-export.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import { stripServerFields, buildExportFromObjects } from "./live-export";
+import { K8sGenerator } from "./generator";
+
+// A live object as `kubectl get -o json` would return it — full of
+// server-written fields the user never authored.
+const liveDeployment = () => ({
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  metadata: {
+    name: "web",
+    namespace: "default",
+    uid: "abc-123",
+    resourceVersion: "9981",
+    generation: 4,
+    creationTimestamp: "2026-01-01T00:00:00Z",
+    managedFields: [{ manager: "kubectl", operation: "Apply" }],
+    annotations: {
+      "kubectl.kubernetes.io/last-applied-configuration": "{...}",
+      "team": "platform",
+    },
+    labels: { app: "web" },
+  },
+  spec: { replicas: 3, selector: { matchLabels: { app: "web" } } },
+  status: { readyReplicas: 3, replicas: 3 },
+});
+
+const liveService = () => ({
+  apiVersion: "v1",
+  kind: "Service",
+  metadata: { name: "web", namespace: "default", uid: "svc-1", resourceVersion: "12" },
+  spec: { ports: [{ port: 80 }], clusterIP: "10.0.0.1" },
+  status: { loadBalancer: {} },
+});
+
+describe("stripServerFields (#116)", () => {
+  test("removes status, managedFields, and server metadata", () => {
+    const cleaned = stripServerFields(liveDeployment());
+    expect(cleaned.status).toBeUndefined();
+    const md = cleaned.metadata as Record<string, unknown>;
+    expect(md.managedFields).toBeUndefined();
+    expect(md.uid).toBeUndefined();
+    expect(md.resourceVersion).toBeUndefined();
+    expect(md.generation).toBeUndefined();
+    expect(md.creationTimestamp).toBeUndefined();
+  });
+
+  test("drops server annotations but keeps authored ones", () => {
+    const cleaned = stripServerFields(liveDeployment());
+    const annotations = (cleaned.metadata as Record<string, unknown>).annotations as Record<string, string>;
+    expect(annotations["kubectl.kubernetes.io/last-applied-configuration"]).toBeUndefined();
+    expect(annotations.team).toBe("platform");
+  });
+
+  test("keeps authored spec and labels", () => {
+    const cleaned = stripServerFields(liveDeployment());
+    expect(cleaned.spec).toEqual({ replicas: 3, selector: { matchLabels: { app: "web" } } });
+    expect((cleaned.metadata as Record<string, unknown>).labels).toEqual({ app: "web" });
+  });
+
+  test("does not mutate the input", () => {
+    const input = liveDeployment();
+    stripServerFields(input);
+    expect(input.status).toBeDefined();
+    expect(input.metadata.managedFields).toBeDefined();
+  });
+});
+
+describe("buildExportFromObjects (#116)", () => {
+  test("maps live objects to export IR, stripped by default", () => {
+    const ir = buildExportFromObjects([liveDeployment(), liveService()]);
+    expect(ir.resources).toHaveLength(2);
+    const dep = ir.resources.find((r) => r.type === "K8s::Apps::Deployment")!;
+    expect(dep.properties.status).toBeUndefined();
+    expect((dep.properties.metadata as Record<string, unknown>).uid).toBeUndefined();
+  });
+
+  test("verbatim keeps server fields", () => {
+    const ir = buildExportFromObjects([liveDeployment()], { verbatim: true });
+    const dep = ir.resources[0];
+    expect(dep.properties.status).toBeDefined();
+    expect((dep.properties.metadata as Record<string, unknown>).uid).toBe("abc-123");
+  });
+
+  test("selector by type narrows the export", () => {
+    const ir = buildExportFromObjects([liveDeployment(), liveService()], {
+      selector: { type: "K8s::Core::Service" },
+    });
+    expect(ir.resources.map((r) => r.type)).toEqual(["K8s::Core::Service"]);
+  });
+
+  test("selector by name matches the live resource name", () => {
+    const ir = buildExportFromObjects([liveDeployment(), liveService()], {
+      selector: { name: "web" },
+    });
+    // Both are named "web" — name alone keeps both kinds.
+    expect(ir.resources).toHaveLength(2);
+  });
+
+  test("export IR feeds K8sGenerator (templateGenerator) unchanged", () => {
+    const ir = buildExportFromObjects([liveDeployment()]);
+    const files = new K8sGenerator().generate(ir);
+    expect(files.length).toBeGreaterThan(0);
+    expect(files.map((f) => f.content).join("\n")).toContain("Deployment");
+  });
+});

--- a/lexicons/k8s/src/import/live-export.ts
+++ b/lexicons/k8s/src/import/live-export.ts
@@ -1,0 +1,80 @@
+import type { ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
+import { K8sParser } from "./parser";
+
+/**
+ * Server-managed metadata fields that the API server fills in. They are not
+ * part of the declared shape and would only add noise to regenerated source,
+ * so they are stripped unless `verbatim` is set.
+ */
+const SERVER_METADATA_FIELDS = [
+  "managedFields",
+  "uid",
+  "resourceVersion",
+  "generation",
+  "creationTimestamp",
+  "selfLink",
+  "ownerReferences",
+  "finalizers",
+];
+
+/** Annotations the cluster writes back that are not authored config. */
+const SERVER_ANNOTATIONS = [
+  "kubectl.kubernetes.io/last-applied-configuration",
+  "deployment.kubernetes.io/revision",
+];
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Strip `status`, `managedFields`, and other server-written fields to reach the
+ * declared shape. Returns a new object; the input is not mutated.
+ */
+export function stripServerFields(obj: Record<string, unknown>): Record<string, unknown> {
+  const clone = JSON.parse(JSON.stringify(obj)) as Record<string, unknown>;
+  delete clone.status;
+
+  if (isRecord(clone.metadata)) {
+    const md = clone.metadata;
+    for (const f of SERVER_METADATA_FIELDS) delete md[f];
+    if (isRecord(md.annotations)) {
+      for (const a of SERVER_ANNOTATIONS) delete md.annotations[a];
+      if (Object.keys(md.annotations).length === 0) delete md.annotations;
+    }
+  }
+  return clone;
+}
+
+/**
+ * Build full-fidelity export IR from a list of live Kubernetes objects (the
+ * `items` of a `kubectl get -o json` List). Reuses the import K8sParser by
+ * feeding it the cleaned objects as JSON documents — JSON is valid YAML, so no
+ * separate serializer is needed. Pure: all I/O stays in the caller.
+ */
+export function buildExportFromObjects(
+  objects: unknown[],
+  opts: { verbatim?: boolean; selector?: ResourceSelector } = {},
+): ExportedTemplate {
+  const cleaned = objects
+    .filter(isRecord)
+    .map((o) => (opts.verbatim ? o : stripServerFields(o)));
+
+  const content = cleaned.map((o) => JSON.stringify(o, null, 2)).join("\n---\n");
+  const ir = new K8sParser().parse(content);
+
+  const selector = opts.selector;
+  if (!selector || (selector.type === undefined && selector.name === undefined)) {
+    return ir;
+  }
+  return {
+    ...ir,
+    resources: ir.resources.filter((r) => {
+      const liveName = (r.metadata?.originalName as string | undefined) ?? r.logicalId;
+      return (
+        (selector.type === undefined || r.type === selector.type) &&
+        (selector.name === undefined || liveName === selector.name)
+      );
+    }),
+  };
+}

--- a/lexicons/k8s/src/plugin.ts
+++ b/lexicons/k8s/src/plugin.ts
@@ -572,4 +572,9 @@ const { deployment, service, serviceMonitor, prometheusRule } = MonitoredService
     const { describeResources } = await import("./describe-resources");
     return describeResources(options);
   },
+
+  async exportResources(options) {
+    const { exportResources } = await import("./export-resources");
+    return exportResources(options);
+  },
 };

--- a/packages/core/src/lexicon.ts
+++ b/packages/core/src/lexicon.ts
@@ -304,11 +304,18 @@ export interface LexiconPlugin {
    * observation/`state` code paths by accident.
    *
    * `owned` is accepted now but inert until ownership marking exists (#119/#120).
+   *
+   * `verbatim` controls fidelity: by default an implementation strips
+   * server-defaulted and server-managed fields to reach the declared shape
+   * (the form a user would have authored). `verbatim: true` keeps them. Targets
+   * whose live config is already the declared shape (e.g. a CloudFormation
+   * original template) may ignore it.
    */
   exportResources?(options: {
     environment: string;
     selector?: ResourceSelector;
     owned?: boolean;
+    verbatim?: boolean;
   }): Promise<ExportedTemplate>;
 }
 


### PR DESCRIPTION
Implements live export for the Kubernetes lexicon so `chant import --from <cluster-env>` regenerates live objects as chant TypeScript.

## What

- `k8sPlugin.exportResources({ environment, selector?, owned?, verbatim? })` reads live objects with `kubectl get <kinds> -A -o json`. A `type` selector narrows to one kind; otherwise it sweeps every kind chant maps. Missing kinds / RBAC denials are skipped, not fatal.
- `stripServerFields()` removes `status`, `metadata.managedFields`, server-written metadata (`uid`, `resourceVersion`, `generation`, `creationTimestamp`, …) and server annotations to reach the declared shape. `verbatim: true` keeps them.
- `buildExportFromObjects()` (pure, `import/live-export.ts`) reuses the import `K8sParser` by feeding cleaned objects as JSON documents (JSON is valid YAML — no extra serializer), then honors `selector { type?, name? }`. Result feeds `K8sGenerator` unchanged.

## Contract

Adds `verbatim?: boolean` to `LexiconPlugin.exportResources` so fidelity is selectable end to end (the CLI's `--verbatim` in #114 maps to it). Pre-release; AWS's narrower impl signature stays compatible. Core typechecks clean.

## Tests

`import/live-export.test.ts` (9): strip semantics (status/managedFields/server annotations removed, authored config + non-mutation preserved), default-vs-verbatim, selector by type and by name, and round-trip into chant TypeScript via `K8sGenerator`.

## Docs

`lexicon-authoring/observation.mdx`: K8s row added to the live-export coverage table; contract snippet updated with `verbatim`.

Part of #112. Closes #116.