### PR TITLE
feat(gcp): exportResources for Config Connector

### DIFF
--- a/docs/src/content/docs/lexicon-authoring/observation.mdx
+++ b/docs/src/content/docs/lexicon-authoring/observation.mdx
@@ -290,6 +290,7 @@ Live-export coverage today:
 |---|---|---|
 | AWS | ✅ | `aws cloudformation get-template --template-stage Original`, parsed by the CloudFormation import parser |
 | K8s | ✅ | `kubectl get <kinds> -A -o json`, stripped of `status`/`managedFields`/server metadata (kept under `--verbatim`), parsed by the K8s import parser |
+| GCP (Config Connector) | ✅ | `kubectl get <*.cnrm.cloud.google.com> -A -o json` (each CC object is its manifest), stripped of `status`/server metadata/`cnrm.cloud.google.com/*` annotations, parsed by the GCP import parser |
 
 ## See also
 

--- a/lexicons/gcp/src/describe-resources.ts
+++ b/lexicons/gcp/src/describe-resources.ts
@@ -38,7 +38,7 @@ interface KubectlResponse {
  * derivation logic local so describeResources can compute the kubectl resource
  * name without importing serializer internals.
  */
-function deriveGVK(entityType: string): { group: string; kind: string } | null {
+export function deriveGVK(entityType: string): { group: string; kind: string } | null {
   const parts = entityType.split("::");
   if (parts.length !== 3 || parts[0] !== "GCP") return null;
   const service = parts[1].toLowerCase();

--- a/lexicons/gcp/src/export-resources.ts
+++ b/lexicons/gcp/src/export-resources.ts
@@ -1,0 +1,73 @@
+/**
+ * Live export for the GCP Config Connector lexicon — implements
+ * LexiconPlugin.exportResources() so `chant import --from <gcp-env>`
+ * regenerates GCP resources as chant TypeScript.
+ *
+ * Config Connector encodes each GCP resource as a Kubernetes CRD on a
+ * management cluster, so export reads live CC objects with kubectl and maps
+ * them to the import IR. A type selector targets one kind; otherwise every
+ * `*.cnrm.cloud.google.com` resource kind is discovered and swept. All I/O
+ * lives here; cleaning and IR-building is pure in `./import/live-export`.
+ */
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
+import { deriveGVK } from "./describe-resources";
+import { buildExportFromObjects } from "./import/live-export";
+
+const execAsync = promisify(exec);
+
+interface KubectlList {
+  items?: unknown[];
+}
+
+/** Discover all Config Connector resource kinds present in the cluster. */
+async function discoverCnrmResources(): Promise<string[]> {
+  try {
+    const { stdout } = await execAsync("kubectl api-resources -o name");
+    return stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.endsWith(".cnrm.cloud.google.com"));
+  } catch {
+    return [];
+  }
+}
+
+export async function exportResources(options: {
+  environment: string;
+  selector?: ResourceSelector;
+  owned?: boolean;
+  verbatim?: boolean;
+}): Promise<ExportedTemplate> {
+  let resources: string[];
+  if (options.selector?.type) {
+    const gvk = deriveGVK(options.selector.type);
+    resources = gvk ? [`${gvk.kind.toLowerCase()}.${gvk.group}`] : [];
+  } else {
+    resources = await discoverCnrmResources();
+  }
+
+  if (resources.length === 0) {
+    return { resources: [], parameters: [] };
+  }
+
+  const objects: unknown[] = [];
+  for (const resource of resources) {
+    try {
+      const { stdout } = await execAsync(
+        ["kubectl", "get", resource, "-A", "-o", "json"].join(" "),
+      );
+      const list = JSON.parse(stdout) as KubectlList;
+      if (Array.isArray(list.items)) objects.push(...list.items);
+    } catch {
+      // Kind absent / RBAC denied — skip, don't fail the whole export.
+    }
+  }
+
+  // `owned` is accepted but inert until ownership marking lands (#120).
+  return buildExportFromObjects(objects, {
+    verbatim: options.verbatim,
+    selector: options.selector,
+  });
+}

--- a/lexicons/gcp/src/import/live-export.test.ts
+++ b/lexicons/gcp/src/import/live-export.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+import { stripServerFields, buildExportFromObjects } from "./live-export";
+import { GcpGenerator } from "./generator";
+
+// A live Config Connector object as `kubectl get -o json` returns it.
+const liveBucket = () => ({
+  apiVersion: "storage.cnrm.cloud.google.com/v1beta1",
+  kind: "StorageBucket",
+  metadata: {
+    name: "my-bucket",
+    namespace: "default",
+    uid: "u-1",
+    resourceVersion: "55",
+    generation: 2,
+    creationTimestamp: "2026-01-01T00:00:00Z",
+    managedFields: [{ manager: "cnrm" }],
+    annotations: {
+      "cnrm.cloud.google.com/management-conflict-prevention-policy": "resource",
+      "cnrm.cloud.google.com/project-id": "my-project",
+      "team": "data",
+    },
+    labels: { env: "prod" },
+  },
+  spec: { location: "US", storageClass: "STANDARD" },
+  status: { conditions: [{ type: "Ready", status: "True" }] },
+});
+
+const livePubsub = () => ({
+  apiVersion: "pubsub.cnrm.cloud.google.com/v1beta1",
+  kind: "PubSubTopic",
+  metadata: { name: "events", namespace: "default", uid: "u-2" },
+  spec: { messageRetentionDuration: "86400s" },
+  status: { conditions: [] },
+});
+
+describe("GCP stripServerFields (#117)", () => {
+  test("removes status, managedFields, and server metadata", () => {
+    const cleaned = stripServerFields(liveBucket());
+    expect(cleaned.status).toBeUndefined();
+    const md = cleaned.metadata as Record<string, unknown>;
+    expect(md.managedFields).toBeUndefined();
+    expect(md.uid).toBeUndefined();
+    expect(md.generation).toBeUndefined();
+  });
+
+  test("drops cnrm bookkeeping annotations but keeps authored ones", () => {
+    const cleaned = stripServerFields(liveBucket());
+    const annotations = (cleaned.metadata as Record<string, unknown>).annotations as Record<string, string>;
+    expect(annotations["cnrm.cloud.google.com/management-conflict-prevention-policy"]).toBeUndefined();
+    expect(annotations["cnrm.cloud.google.com/project-id"]).toBeUndefined();
+    expect(annotations.team).toBe("data");
+  });
+
+  test("keeps authored spec and labels; does not mutate input", () => {
+    const input = liveBucket();
+    const cleaned = stripServerFields(input);
+    expect(cleaned.spec).toEqual({ location: "US", storageClass: "STANDARD" });
+    expect(input.status).toBeDefined();
+  });
+});
+
+describe("GCP buildExportFromObjects (#117)", () => {
+  test("maps live CC objects to export IR, stripped by default", () => {
+    const ir = buildExportFromObjects([liveBucket(), livePubsub()]);
+    expect(ir.resources).toHaveLength(2);
+    const bucket = ir.resources.find((r) => r.logicalId === "my-bucket")!;
+    expect(bucket.type).toBe("GCP::Storage::Bucket");
+    expect((bucket.properties.metadata as Record<string, unknown>).uid).toBeUndefined();
+    expect(bucket.properties.location).toBe("US");
+  });
+
+  test("verbatim keeps server fields", () => {
+    const ir = buildExportFromObjects([liveBucket()], { verbatim: true });
+    const bucket = ir.resources[0];
+    expect((bucket.properties.metadata as Record<string, unknown>).uid).toBe("u-1");
+  });
+
+  test("selector by type narrows the export", () => {
+    const ir = buildExportFromObjects([liveBucket(), livePubsub()], {
+      selector: { type: "GCP::Pubsub::Topic" },
+    });
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["events"]);
+  });
+
+  test("selector by name narrows the export", () => {
+    const ir = buildExportFromObjects([liveBucket(), livePubsub()], {
+      selector: { name: "my-bucket" },
+    });
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["my-bucket"]);
+  });
+
+  test("export IR feeds GcpGenerator (templateGenerator) unchanged", () => {
+    const ir = buildExportFromObjects([liveBucket()]);
+    const files = new GcpGenerator().generate(ir);
+    expect(files.length).toBeGreaterThan(0);
+  });
+});

--- a/lexicons/gcp/src/import/live-export.ts
+++ b/lexicons/gcp/src/import/live-export.ts
@@ -1,0 +1,78 @@
+import type { ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
+import { GcpParser } from "./parser";
+
+/** Server-written metadata fields, stripped unless `verbatim`. */
+const SERVER_METADATA_FIELDS = [
+  "managedFields",
+  "uid",
+  "resourceVersion",
+  "generation",
+  "creationTimestamp",
+  "selfLink",
+  "ownerReferences",
+  "finalizers",
+];
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Strip `status` and server-written metadata to reach the declared shape of a
+ * Config Connector object. Config Connector writes back several
+ * `cnrm.cloud.google.com/*` annotations that are not authored config; those are
+ * dropped too. Returns a new object; the input is not mutated.
+ */
+export function stripServerFields(obj: Record<string, unknown>): Record<string, unknown> {
+  const clone = JSON.parse(JSON.stringify(obj)) as Record<string, unknown>;
+  delete clone.status;
+
+  if (isRecord(clone.metadata)) {
+    const md = clone.metadata;
+    for (const f of SERVER_METADATA_FIELDS) delete md[f];
+    if (isRecord(md.annotations)) {
+      for (const key of Object.keys(md.annotations)) {
+        // Config Connector's own bookkeeping annotations, plus the apply
+        // round-trip annotation — none are authored config.
+        if (
+          key.startsWith("cnrm.cloud.google.com/") ||
+          key === "kubectl.kubernetes.io/last-applied-configuration"
+        ) {
+          delete md.annotations[key];
+        }
+      }
+      if (Object.keys(md.annotations).length === 0) delete md.annotations;
+    }
+  }
+  return clone;
+}
+
+/**
+ * Build full-fidelity export IR from a list of live Config Connector objects
+ * (each live object is already its manifest). Reuses the import GcpParser by
+ * feeding cleaned objects as JSON documents. Pure: all I/O stays in the caller.
+ */
+export function buildExportFromObjects(
+  objects: unknown[],
+  opts: { verbatim?: boolean; selector?: ResourceSelector } = {},
+): ExportedTemplate {
+  const cleaned = objects
+    .filter(isRecord)
+    .map((o) => (opts.verbatim ? o : stripServerFields(o)));
+
+  const content = cleaned.map((o) => JSON.stringify(o, null, 2)).join("\n---\n");
+  const ir = new GcpParser().parse(content);
+
+  const selector = opts.selector;
+  if (!selector || (selector.type === undefined && selector.name === undefined)) {
+    return ir;
+  }
+  return {
+    ...ir,
+    resources: ir.resources.filter(
+      (r) =>
+        (selector.type === undefined || r.type === selector.type) &&
+        (selector.name === undefined || r.logicalId === selector.name),
+    ),
+  };
+}

--- a/lexicons/gcp/src/plugin.ts
+++ b/lexicons/gcp/src/plugin.ts
@@ -385,4 +385,9 @@ export const bucket = new StorageBucket({
     const { describeResources } = await import("./describe-resources");
     return describeResources(options);
   },
+
+  async exportResources(options) {
+    const { exportResources } = await import("./export-resources");
+    return exportResources(options);
+  },
 };


### PR DESCRIPTION
Implements live export for the GCP Config Connector lexicon so `chant import --from <gcp-env>` regenerates GCP resources as chant TypeScript.

## What

- `gcpPlugin.exportResources({ environment, selector?, owned?, verbatim? })` reads live Config Connector objects with kubectl — each live CC object is already its manifest. A `type` selector targets one kind (via `deriveGVK`); otherwise every `*.cnrm.cloud.google.com` resource kind is discovered with `kubectl api-resources -o name` and swept with `kubectl get <kind> -A -o json`. Missing kinds / RBAC denials are skipped, not fatal.
- `stripServerFields()` removes `status`, server-written metadata, and `cnrm.cloud.google.com/*` bookkeeping annotations to reach the declared shape. `verbatim: true` keeps them.
- `buildExportFromObjects()` (pure, `import/live-export.ts`) reuses the import `GcpParser` and honors `selector { type?, name? }`. Result feeds `GcpGenerator` unchanged.

## Tests

`import/live-export.test.ts` (8): strip semantics (status/server metadata/cnrm annotations removed, authored spec+labels kept, non-mutation), default-vs-verbatim, selector by type and by name, and round-trip via `GcpGenerator`.

## Docs

`lexicon-authoring/observation.mdx`: GCP row added to the live-export coverage table.

Part of #112. Closes #117.