### PR TITLE
feat(cli): chant import --from <env> (live import driver)

### DIFF
--- a/docs/src/content/docs/cli/import.mdx
+++ b/docs/src/content/docs/cli/import.mdx
@@ -7,11 +7,14 @@ description: Import infrastructure templates and generate TypeScript files
 
 ```
 chant import <template-file> [flags]
+chant import --from <env> [flags]
 ```
 
 ## Description
 
 `chant import` reads an existing infrastructure template (e.g. a CloudFormation JSON template), detects which lexicon handles it, and generates TypeScript resource definitions. This lets you adopt chant incrementally by importing your current infrastructure rather than rewriting it from scratch.
+
+With `--from <env>` it reads the **live** cloud/cluster instead of a file: it resolves the environment, calls each project lexicon's `exportResources()` for full-fidelity config, and generates TypeScript from that. This is the cloud→code direction — the way to adopt an orphaned resource back into source.
 
 The import process:
 
@@ -25,20 +28,36 @@ The import process:
 
 | Flag | Description |
 |------|-------------|
+| `--from <env>` | Import from a live environment instead of a template file |
+| `-d, --lexicon <name>` | With `--from`, restrict to one lexicon (e.g. `aws`, `k8s`) |
+| `--type <ResourceType>` | With `--from`, export only resources of this type |
+| `--name <name>` | With `--from`, export only the resource with this name |
+| `--owned` | With `--from`, restrict to chant-owned resources (inert until ownership marking lands) |
+| `--verbatim` | With `--from`, keep server-defaulted fields instead of stripping to declared shape |
 | `-o, --output <dir>` | Output directory (default: `./infra/`) |
 | `--force` | Overwrite existing files |
+
+:::caution
+Live import may emit sensitive values (keys, tokens, passwords) into generated source — unlike `state`, which only reads scrubbed metadata. The command prints a warning; review generated files before committing.
+:::
 
 ## Usage
 
 ```bash
-# Import a template
+# Import a template file
 chant import template.json
 
 # Import to a specific directory
 chant import template.json --output src/
 
-# Overwrite existing files
-chant import template.json --force
+# Import live infrastructure from an environment
+chant import --from prod
+
+# Adopt a single orphaned resource back into source
+chant import --from prod --name my-bucket --output src/
+
+# Keep server-defaulted fields
+chant import --from prod --verbatim
 ```
 
 ## Exit Codes

--- a/packages/core/src/cli/commands/import-live.test.ts
+++ b/packages/core/src/cli/commands/import-live.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { liveImportFromPlugins } from "./import";
+import { mkdir, rm, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { LexiconPlugin, ExportedTemplate, ResourceSelector } from "../../lexicon";
+import type { TypeScriptGenerator } from "../../import/generator";
+import type { TemplateIR } from "../../import/parser";
+
+const generator: TypeScriptGenerator = {
+  generate(ir: TemplateIR) {
+    return [
+      {
+        path: "main.ts",
+        content: ir.resources
+          .map((r) => `export const ${r.logicalId} = ${JSON.stringify(r.properties)};`)
+          .join("\n"),
+      },
+    ];
+  },
+};
+
+function fakeExporter(name: string, ir: ExportedTemplate): LexiconPlugin {
+  return {
+    name,
+    serializer: {} as never,
+    generate: async () => {},
+    validate: async () => {},
+    coverage: async () => {},
+    package: async () => {},
+    templateGenerator: () => generator,
+    async exportResources(opts: { selector?: ResourceSelector }): Promise<ExportedTemplate> {
+      if (!opts.selector) return ir;
+      return {
+        ...ir,
+        resources: ir.resources.filter(
+          (r) =>
+            (opts.selector!.type === undefined || r.type === opts.selector!.type) &&
+            (opts.selector!.name === undefined || r.logicalId === opts.selector!.name),
+        ),
+      };
+    },
+  };
+}
+
+const sampleIR: ExportedTemplate = {
+  resources: [
+    { logicalId: "bucket", type: "Fake::Bucket", properties: { versioning: true } },
+    { logicalId: "queue", type: "Fake::Queue", properties: { fifo: false } },
+  ],
+  parameters: [],
+};
+
+describe("liveImportFromPlugins (#114)", () => {
+  let outputDir: string;
+
+  beforeEach(async () => {
+    outputDir = join(tmpdir(), `chant-live-import-${Date.now()}-${Math.random()}`);
+    await mkdir(outputDir, { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(outputDir, { recursive: true, force: true });
+  });
+
+  test("regenerates resources from a live exporter", async () => {
+    const result = await liveImportFromPlugins([fakeExporter("fake", sampleIR)], {
+      environment: "prod",
+      output: outputDir,
+      force: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.lexicon).toBe("fake");
+    const content = await readFile(join(outputDir, result.generatedFiles[0]), "utf-8");
+    expect(content).toContain("bucket");
+    expect(content).toContain("queue");
+  });
+
+  test("--name selector narrows the regenerated source", async () => {
+    const result = await liveImportFromPlugins([fakeExporter("fake", sampleIR)], {
+      environment: "prod",
+      output: outputDir,
+      force: true,
+      selector: { name: "queue" },
+    });
+    const content = await readFile(join(outputDir, result.generatedFiles[0]), "utf-8");
+    expect(content).toContain("queue");
+    expect(content).not.toContain("bucket");
+  });
+
+  test("errors when no lexicon supports live export", async () => {
+    const nonExporter: LexiconPlugin = {
+      name: "noexport",
+      serializer: {} as never,
+      generate: async () => {},
+      validate: async () => {},
+      coverage: async () => {},
+      package: async () => {},
+    };
+    const result = await liveImportFromPlugins([nonExporter], {
+      environment: "prod",
+      output: outputDir,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("live export");
+  });
+
+  test("--lexicon narrows to the named exporter", async () => {
+    const result = await liveImportFromPlugins(
+      [fakeExporter("a", sampleIR), fakeExporter("b", sampleIR)],
+      { environment: "prod", output: outputDir, force: true, lexicon: "b" },
+    );
+    expect(result.success).toBe(true);
+    expect(result.lexicon).toBe("b");
+  });
+
+  test("errors when the environment exports nothing", async () => {
+    const empty = fakeExporter("fake", { resources: [], parameters: [] });
+    const result = await liveImportFromPlugins([empty], {
+      environment: "prod",
+      output: outputDir,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No resources exported");
+  });
+});

--- a/packages/core/src/cli/commands/import.ts
+++ b/packages/core/src/cli/commands/import.ts
@@ -1,10 +1,10 @@
 import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "fs";
 import { join, resolve, basename, dirname } from "path";
 import { formatSuccess, formatWarning, formatError } from "../format";
-import type { TemplateIR, ResourceIR, TemplateParser } from "../../import/parser";
+import type { TemplateIR, ResourceIR, ParameterIR, TemplateParser } from "../../import/parser";
 import type { GeneratedFile, TypeScriptGenerator } from "../../import/generator";
 import { loadPlugins, resolveProjectLexicons } from "../plugins";
-import type { LexiconPlugin } from "../../lexicon";
+import type { LexiconPlugin, ResourceSelector } from "../../lexicon";
 
 /**
  * Import command options
@@ -307,6 +307,156 @@ export async function importCommand(options: ImportOptions): Promise<ImportResul
     generatedFiles,
     warnings,
     lexicon,
+  };
+}
+
+/**
+ * Live import options — read from a running cloud/cluster instead of a file.
+ */
+export interface LiveImportOptions {
+  /** Environment to resolve (passed to each lexicon's exportResources). */
+  environment: string;
+  /** Restrict to one lexicon by name (e.g. "aws", "k8s"). */
+  lexicon?: string;
+  /** Output directory (defaults to ./infra/). */
+  output?: string;
+  /** Force overwrite existing files. */
+  force?: boolean;
+  /** Selector forwarded to the lexicon. */
+  selector?: ResourceSelector;
+  /** Restrict to chant-owned resources (inert until ownership marking lands). */
+  owned?: boolean;
+  /** Keep server-defaulted fields instead of stripping to declared shape. */
+  verbatim?: boolean;
+}
+
+/**
+ * Merge several template IRs into one. Resources and parameters concatenate;
+ * later metadata wins on key collisions.
+ */
+function mergeIR(parts: TemplateIR[]): TemplateIR {
+  const resources: ResourceIR[] = [];
+  const parameters: ParameterIR[] = [];
+  let metadata: Record<string, unknown> | undefined;
+  for (const part of parts) {
+    resources.push(...part.resources);
+    parameters.push(...part.parameters);
+    if (part.metadata) metadata = { ...(metadata ?? {}), ...part.metadata };
+  }
+  return { resources, parameters, metadata };
+}
+
+/**
+ * Import directly from a live environment: ask each lexicon's exportResources
+ * for full-fidelity IR, then generate chant TypeScript from it.
+ *
+ * Unlike file import, the live config may contain secrets — the caller prints a
+ * warning. Reuses the same by-category output organization as file import.
+ */
+export async function importFromLive(options: LiveImportOptions): Promise<ImportResult> {
+  const projectDir = resolve(options.output ? dirname(options.output) : ".");
+
+  // Resolve project lexicons, then hand off to the testable core.
+  let plugins: LexiconPlugin[];
+  try {
+    const lexiconNames = await resolveProjectLexicons(projectDir);
+    plugins = await loadPlugins(lexiconNames);
+  } catch {
+    plugins = [];
+  }
+
+  return liveImportFromPlugins(plugins, options);
+}
+
+/**
+ * Live-import core: given resolved plugins, export and generate. Split from
+ * plugin resolution so it can be tested with fake exporters (no cloud calls).
+ */
+export async function liveImportFromPlugins(
+  plugins: LexiconPlugin[],
+  options: LiveImportOptions,
+): Promise<ImportResult> {
+  const outputDir = resolve(options.output ?? "./infra/");
+  const warnings: string[] = [];
+
+  let exporters = plugins.filter((p) => p.exportResources && p.templateGenerator);
+  if (options.lexicon) {
+    exporters = exporters.filter((p) => p.name === options.lexicon);
+  }
+
+  if (exporters.length === 0) {
+    return {
+      success: false,
+      generatedFiles: [],
+      warnings: [],
+      error: options.lexicon
+        ? `Lexicon "${options.lexicon}" does not support live export, or is not in this project.`
+        : "No project lexicon supports live export (exportResources).",
+    };
+  }
+
+  // Collect IR from every exporter, tagging which lexicon produced output.
+  const irParts: TemplateIR[] = [];
+  let generatorLexicon: LexiconPlugin | undefined;
+  for (const plugin of exporters) {
+    let ir: TemplateIR;
+    try {
+      ir = await plugin.exportResources!({
+        environment: options.environment,
+        selector: options.selector,
+        owned: options.owned,
+        verbatim: options.verbatim,
+      });
+    } catch (err) {
+      warnings.push(`${plugin.name}: live export failed — ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
+    if (ir.resources.length === 0) continue;
+    irParts.push(ir);
+    generatorLexicon ??= plugin;
+  }
+
+  if (irParts.length === 0 || !generatorLexicon) {
+    return {
+      success: false,
+      generatedFiles: [],
+      warnings,
+      error: `No resources exported from environment "${options.environment}".`,
+    };
+  }
+
+  if (exporters.length > 1 && irParts.length > 1) {
+    warnings.push("Multiple lexicons exported resources; generated with the first. Use --lexicon to target one.");
+  }
+
+  const ir = mergeIR(irParts);
+  const generator = generatorLexicon.templateGenerator!();
+
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+
+  const files = generateOrganizedFiles(ir, generator);
+  const generatedFiles: string[] = [];
+  for (const file of files) {
+    const filePath = join(outputDir, file.path);
+    const dirPath = join(outputDir, file.path.split("/").slice(0, -1).join("/"));
+    if (dirPath && !existsSync(dirPath)) {
+      mkdirSync(dirPath, { recursive: true });
+    }
+    if (existsSync(filePath) && !options.force) {
+      warnings.push(`File ${file.path} already exists, skipping`);
+      continue;
+    }
+    writeFileSync(filePath, file.content);
+    generatedFiles.push(file.path);
+  }
+
+  return {
+    success: true,
+    generatedFiles,
+    warnings,
+    lexicon: generatorLexicon.name,
   };
 }
 

--- a/packages/core/src/cli/handlers/misc.ts
+++ b/packages/core/src/cli/handlers/misc.ts
@@ -1,6 +1,7 @@
 import { listCommand, printListResult } from "../commands/list";
-import { importCommand, printImportResult } from "../commands/import";
-import { formatError, formatSuccess } from "../format";
+import { importCommand, importFromLive, printImportResult } from "../commands/import";
+import type { ResourceSelector } from "../../lexicon";
+import { formatError, formatSuccess, formatWarning } from "../format";
 import type { CommandContext } from "../registry";
 
 export async function runList(ctx: CommandContext): Promise<number> {
@@ -21,6 +22,34 @@ export async function runList(ctx: CommandContext): Promise<number> {
 }
 
 export async function runImport(ctx: CommandContext): Promise<number> {
+  const { args } = ctx;
+
+  // `--from <env>` switches import from a template file to a live source.
+  if (args.migrateFrom) {
+    const selector: ResourceSelector | undefined =
+      args.selectType || args.selectName
+        ? { type: args.selectType, name: args.selectName }
+        : undefined;
+
+    // Live config may carry secrets into generated source — warn before writing.
+    console.error(formatWarning({
+      message: "Live import may emit sensitive values (keys, tokens, passwords) into generated source. Review before committing.",
+    }));
+
+    const result = await importFromLive({
+      environment: args.migrateFrom,
+      lexicon: args.lexicon,
+      output: args.output,
+      force: args.force,
+      selector,
+      owned: args.owned,
+      verbatim: args.verbatim,
+    });
+
+    printImportResult(result);
+    return result.success ? 0 : 1;
+  }
+
   const result = await importCommand({
     templatePath: ctx.args.path,
     output: ctx.args.output,

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -88,7 +88,17 @@ export function parseArgs(args: string[]): ParsedArgs {
     } else if (arg === "--live") {
       result.live = true;
     } else if (arg === "--from") {
+      // Shared by `migrate --from <lexicon>` and `import --from <env>`; the
+      // two commands never run together, so one field carries both.
       result.migrateFrom = args[++i];
+    } else if (arg === "--type") {
+      result.selectType = args[++i];
+    } else if (arg === "--name") {
+      result.selectName = args[++i];
+    } else if (arg === "--owned") {
+      result.owned = true;
+    } else if (arg === "--verbatim") {
+      result.verbatim = true;
     } else if (arg === "--to") {
       result.migrateTo = args[++i];
     } else if (arg === "--emit") {
@@ -211,6 +221,7 @@ Examples:
   chant build ./infra/ --format yaml
   chant build ./infra/ --watch
   chant import template.json --output ./infra/
+  chant import --from prod --name my-bucket --output src/
   chant lint ./infra/
   chant lint ./infra/ --format sarif
   chant lint ./infra/ --watch

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -43,6 +43,14 @@ export interface ParsedArgs {
   reportFile?: string;
   /** `chant init --skill <name>` filter (added in #95 commit) */
   skill?: string;
+  /** `chant import --type <ResourceType>` selector */
+  selectType?: string;
+  /** `chant import --name <name>` selector */
+  selectName?: string;
+  /** `chant import --owned` — restrict live import to chant-owned resources */
+  owned?: boolean;
+  /** `chant import --verbatim` — keep server-defaulted fields in live import */
+  verbatim?: boolean;
 }
 
 /**


### PR DESCRIPTION
Adds a live source to `chant import` so it can read the running cloud/cluster instead of a template file — the cloud→code adoption path built on #113–#117.

## What

- `chant import --from <env>` resolves project lexicons, calls each one's `exportResources()`, merges the IR, and generates TypeScript via the existing by-category output organization (`generateOrganizedFiles`).
- Selectors `--type <ResourceType>` / `--name <name>` forward to the lexicon; `--lexicon <name>` restricts to one exporter.
- `--owned` wires the flag now (inert until ownership marking lands, #120).
- `--verbatim` keeps server-defaulted fields; default strips to declared shape.
- Prints a secrets warning before writing — unlike `state`, live import may emit sensitive values into generated source.
- `--from` shares the parsed field with `migrate --from` (the commands never co-run).

## Design

`liveImportFromPlugins(plugins, options)` is split from `importFromLive(options)` so the export+generate core is testable with fake exporters — no cloud calls.

## Tests

`commands/import-live.test.ts` (5): regenerate from a live exporter, `--name` selector, `--lexicon` narrowing, no-exporter error, empty-environment error. All 373 CLI tests pass.

## Docs

`cli/import.mdx`: `--from` synopsis, flag table, secrets caution, and the adopt-an-orphan example. Help text updated in `main.ts`.

Part of #112. Closes #114.