### PR TITLE
feat(core): ownership marker contract + serializer stamping

### DIFF
--- a/docs/src/content/docs/configuration/config-file.mdx
+++ b/docs/src/content/docs/configuration/config-file.mdx
@@ -23,6 +23,28 @@ chant uses a `chant.config.ts` file at the project root for configuration.
 
 An array of lexicon names the project uses.
 
+### `ownership`
+
+Opt-in cloud-side ownership marking. When `stack` is set, the serializer stamps a chant ownership marker carrying this stack (and optional `env`) identity onto every supported resource at synthesis time:
+
+```typescript
+ownership: {
+  stack: "billing",   // stamped onto every resource (enables marking)
+  env: "prod",        // optional environment identity
+  // enabled: false,  // set to disable without removing the block
+}
+```
+
+The marker is the record that later lets `delete` be precise without an authoritative state file — ownership lives on the cloud resource, not in a file chant has to host or lock. It is stamped into each target's native metadata channel:
+
+| Channel | Targets | Keys |
+|---|---|---|
+| Labels | Kubernetes, GCP (Config Connector) | `app.kubernetes.io/managed-by=chant`, `chant.intentius.io/stack`, `chant.intentius.io/env` |
+| Tags | AWS | `chant:managed-by=chant`, `chant:stack`, `chant:env` |
+| Tags | Azure | `chant-managed-by=chant`, `chant-stack`, `chant-env` |
+
+The marker carries **stack identity**, not just `managed=true`, so one stack never mistakes another's resources for its own. Ownership means "carries chant's marker", not "carries only chant's marker" — co-stamping with other tools (ArgoCD, Terraform) is fine, and explicit per-resource tags/labels win on key collisions. Walk-away cost stays zero: these are standard tags/labels, nothing proprietary.
+
 ### `lint.extends`
 
 An array of preset configuration paths to inherit from:

--- a/lexicons/aws/src/serializer-ownership.test.ts
+++ b/lexicons/aws/src/serializer-ownership.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "vitest";
+import { awsSerializer } from "./serializer";
+import { DECLARABLE_MARKER, type Declarable } from "@intentius/chant/declarable";
+import { AttrRef } from "@intentius/chant/attrref";
+
+class MockBucket implements Declarable {
+  readonly [DECLARABLE_MARKER] = true as const;
+  readonly lexicon = "aws";
+  readonly entityType = "AWS::S3::Bucket";
+  readonly arn: AttrRef;
+  readonly props: Record<string, unknown>;
+  constructor(props: Record<string, unknown> = {}) {
+    this.props = props;
+    this.arn = new AttrRef(this, "Arn");
+  }
+}
+
+describe("awsSerializer ownership stamping (#119)", () => {
+  test("stamps the ownership marker as tags when context.ownership is set", () => {
+    const entities = new Map<string, Declarable>([["MyBucket", new MockBucket({ BucketName: "b" })]]);
+    const out = awsSerializer.serialize(entities, [], { ownership: { stack: "billing", env: "prod" } });
+    const template = JSON.parse(out as string);
+    const tags = template.Resources.MyBucket.Properties.Tags as Array<{ Key: string; Value: string }>;
+    const byKey = Object.fromEntries(tags.map((t) => [t.Key, t.Value]));
+    expect(byKey["chant:managed-by"]).toBe("chant");
+    expect(byKey["chant:stack"]).toBe("billing");
+    expect(byKey["chant:env"]).toBe("prod");
+  });
+
+  test("no ownership context → no chant tags injected", () => {
+    const entities = new Map<string, Declarable>([["MyBucket", new MockBucket({ BucketName: "b" })]]);
+    const out = awsSerializer.serialize(entities, []);
+    const template = JSON.parse(out as string);
+    const tags = (template.Resources.MyBucket.Properties?.Tags ?? []) as Array<{ Key: string }>;
+    expect(tags.some((t) => t.Key.startsWith("chant:"))).toBe(false);
+  });
+});

--- a/lexicons/aws/src/serializer.ts
+++ b/lexicons/aws/src/serializer.ts
@@ -1,6 +1,7 @@
 import type { Declarable, CoreParameter } from "@intentius/chant/declarable";
 import { isPropertyDeclarable } from "@intentius/chant/declarable";
-import type { Serializer, SerializerResult } from "@intentius/chant/serializer";
+import type { Serializer, SerializerResult, SerializeContext } from "@intentius/chant/serializer";
+import { ownershipEntries, type OwnershipMarker } from "@intentius/chant/ownership";
 import type { LexiconOutput } from "@intentius/chant/lexicon-output";
 import { walkValue, type SerializerVisitor } from "@intentius/chant/serializer-walker";
 import { isChildProject, type ChildProjectInstance } from "@intentius/chant/child-project";
@@ -131,6 +132,7 @@ function serializeToTemplate(
   outputs?: LexiconOutput[],
   extraParameters?: Record<string, CFParameter>,
   extraOutputs?: Record<string, CFOutput>,
+  ownership?: OwnershipMarker,
 ): CFTemplate {
   const template: CFTemplate = {
     AWSTemplateFormatVersion: "2010-09-09",
@@ -148,8 +150,15 @@ function serializeToTemplate(
     entityNames.set(entity, name);
   }
 
-  // Collect default tags
+  // Collect default tags. The ownership marker is stamped as tags, seeded
+  // first so user default tags (and explicit per-resource tags) take precedence
+  // on key collisions.
   const defaultTagEntries: TagEntry[] = [];
+  if (ownership) {
+    for (const [Key, Value] of Object.entries(ownershipEntries("aws-tag", ownership))) {
+      defaultTagEntries.push({ Key, Value });
+    }
+  }
   for (const [, entity] of entities) {
     if (isDefaultTags(entity)) {
       defaultTagEntries.push(...entity.tags);
@@ -323,7 +332,9 @@ export const awsSerializer: Serializer = {
   name: "aws",
   rulePrefix: "WAW",
 
-  serialize(entities: Map<string, Declarable>, outputs?: LexiconOutput[]): string | SerializerResult {
+  serialize(entities: Map<string, Declarable>, outputs?: LexiconOutput[], context?: SerializeContext): string | SerializerResult {
+    const ownership = context?.ownership;
+
     // Check if any entities are child projects (nested stacks)
     const childProjects = new Map<string, ChildProjectInstance>();
     let hasChildProjects = false;
@@ -337,7 +348,7 @@ export const awsSerializer: Serializer = {
 
     // No nested stacks — use the simple path
     if (!hasChildProjects) {
-      const template = serializeToTemplate(entities, outputs);
+      const template = serializeToTemplate(entities, outputs, undefined, undefined, ownership);
       return JSON.stringify(template, null, 2);
     }
 
@@ -377,7 +388,7 @@ export const awsSerializer: Serializer = {
     }
 
     // Serialize the parent template (ChildProjectInstance entities become CF::Stack resources)
-    const parentTemplate = serializeToTemplate(entities, outputs, parentParams);
+    const parentTemplate = serializeToTemplate(entities, outputs, parentParams, undefined, ownership);
     const primary = JSON.stringify(parentTemplate, null, 2);
 
     return {

--- a/lexicons/azure/src/serializer-ownership.test.ts
+++ b/lexicons/azure/src/serializer-ownership.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "vitest";
+import { azureSerializer } from "./serializer";
+import { DECLARABLE_MARKER } from "@intentius/chant/declarable";
+
+function makeEntity(entityType: string, props: Record<string, unknown> = {}): any {
+  return { [DECLARABLE_MARKER]: true, lexicon: "azure", entityType, kind: "resource", props };
+}
+
+describe("azureSerializer ownership stamping (#119)", () => {
+  test("stamps the ownership marker as tags when context.ownership is set", () => {
+    const entities = new Map<string, any>([
+      ["myStorage", makeEntity("Microsoft.Storage/storageAccounts", { name: "mystore", location: "eastus" })],
+    ]);
+    const out = azureSerializer.serialize(entities, [], { ownership: { stack: "billing", env: "prod" } });
+    const template = JSON.parse(out as string);
+    const tags = template.resources[0].tags as Record<string, string>;
+    expect(tags["chant-managed-by"]).toBe("chant");
+    expect(tags["chant-stack"]).toBe("billing");
+    expect(tags["chant-env"]).toBe("prod");
+    // Azure forbids '/' in tag keys — the marker must not use the label form.
+    expect(Object.keys(tags).some((k) => k.includes("/"))).toBe(false);
+  });
+
+  test("no ownership context → no chant tags", () => {
+    const entities = new Map<string, any>([
+      ["myStorage", makeEntity("Microsoft.Storage/storageAccounts", { name: "mystore", location: "eastus" })],
+    ]);
+    const out = azureSerializer.serialize(entities, []);
+    const template = JSON.parse(out as string);
+    const tags = (template.resources[0].tags ?? {}) as Record<string, string>;
+    expect(Object.keys(tags).some((k) => k.startsWith("chant-"))).toBe(false);
+  });
+});

--- a/lexicons/azure/src/serializer.ts
+++ b/lexicons/azure/src/serializer.ts
@@ -12,7 +12,8 @@
 
 import type { Declarable, CoreParameter } from "@intentius/chant/declarable";
 import { isPropertyDeclarable } from "@intentius/chant/declarable";
-import type { Serializer, SerializerResult } from "@intentius/chant/serializer";
+import type { Serializer, SerializerResult, SerializeContext } from "@intentius/chant/serializer";
+import { ownershipEntries, type OwnershipMarker } from "@intentius/chant/ownership";
 import type { LexiconOutput } from "@intentius/chant/lexicon-output";
 import { walkValue, type SerializerVisitor } from "@intentius/chant/serializer-walker";
 import { isChildProject, type ChildProjectInstance } from "@intentius/chant/child-project";
@@ -172,6 +173,7 @@ function toArmValue(value: unknown, entityNames: Map<Declarable, string>): unkno
 function serializeToTemplate(
   entities: Map<string, Declarable>,
   outputs?: LexiconOutput[],
+  ownership?: OwnershipMarker,
 ): ArmTemplate {
   const template: ArmTemplate = {
     $schema: "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -185,8 +187,14 @@ function serializeToTemplate(
     entityNames.set(entity, name);
   }
 
-  // Collect default tags
+  // Collect default tags. The ownership marker is stamped as tags, seeded
+  // first so user default tags (and explicit per-resource tags) win.
   const defaultTagEntries: TagEntry[] = [];
+  if (ownership) {
+    for (const [key, value] of Object.entries(ownershipEntries("azure-tag", ownership))) {
+      defaultTagEntries.push({ key, value });
+    }
+  }
   for (const [, entity] of entities) {
     if (isDefaultTags(entity)) {
       defaultTagEntries.push(...entity.tags);
@@ -410,7 +418,7 @@ export const azureSerializer: Serializer = {
   name: "azure",
   rulePrefix: "AZR",
 
-  serialize(entities: Map<string, Declarable>, outputs?: LexiconOutput[]): string | SerializerResult {
+  serialize(entities: Map<string, Declarable>, outputs?: LexiconOutput[], context?: SerializeContext): string | SerializerResult {
     // Check for child projects (linked templates)
     let hasChildProjects = false;
     const allFiles: Record<string, string> = {};
@@ -439,7 +447,7 @@ export const azureSerializer: Serializer = {
       }
     }
 
-    const template = serializeToTemplate(entities, outputs);
+    const template = serializeToTemplate(entities, outputs, context?.ownership);
     const primary = JSON.stringify(template, null, 2);
 
     if (!hasChildProjects) {

--- a/lexicons/gcp/src/serializer-ownership.test.ts
+++ b/lexicons/gcp/src/serializer-ownership.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "vitest";
+import { gcpSerializer } from "./serializer";
+import { DECLARABLE_MARKER } from "@intentius/chant/declarable";
+
+function mockResource(entityType: string, props: Record<string, unknown>): any {
+  return { [DECLARABLE_MARKER]: true, lexicon: "gcp", entityType, kind: "resource", props };
+}
+
+describe("gcpSerializer ownership stamping (#119)", () => {
+  test("stamps the ownership marker as labels when context.ownership is set", () => {
+    const entities = new Map<string, any>([
+      ["myBucket", mockResource("GCP::Storage::Bucket", { metadata: { name: "my-bucket" }, location: "US" })],
+    ]);
+    const yaml = gcpSerializer.serialize(entities, [], { ownership: { stack: "billing", env: "prod" } });
+    expect(yaml).toContain("app.kubernetes.io/managed-by: chant");
+    expect(yaml).toContain("chant.intentius.io/stack: billing");
+    expect(yaml).toContain("chant.intentius.io/env: prod");
+  });
+
+  test("no ownership context → no chant labels", () => {
+    const entities = new Map<string, any>([
+      ["myBucket", mockResource("GCP::Storage::Bucket", { metadata: { name: "my-bucket" }, location: "US" })],
+    ]);
+    const yaml = gcpSerializer.serialize(entities, []);
+    expect(yaml).not.toContain("managed-by: chant");
+    expect(yaml).not.toContain("chant.intentius.io/stack");
+  });
+});

--- a/lexicons/gcp/src/serializer.ts
+++ b/lexicons/gcp/src/serializer.ts
@@ -8,7 +8,8 @@
 import { createRequire } from "module";
 import type { Declarable } from "@intentius/chant/declarable";
 import { isPropertyDeclarable } from "@intentius/chant/declarable";
-import type { Serializer, SerializerResult } from "@intentius/chant/serializer";
+import type { Serializer, SerializerResult, SerializeContext } from "@intentius/chant/serializer";
+import { ownershipEntries } from "@intentius/chant/ownership";
 import type { LexiconOutput } from "@intentius/chant/lexicon-output";
 import { walkValue, type SerializerVisitor } from "@intentius/chant/serializer-walker";
 import { emitYAML } from "@intentius/chant/yaml";
@@ -116,15 +117,18 @@ export const gcpSerializer: Serializer = {
   name: "gcp",
   rulePrefix: "WGC",
 
-  serialize(entities: Map<string, Declarable>, _outputs?: LexiconOutput[]): string {
+  serialize(entities: Map<string, Declarable>, _outputs?: LexiconOutput[], context?: SerializeContext): string {
     // Build reverse map: entity → name
     const entityNames = new Map<Declarable, string>();
     for (const [name, entity] of entities) {
       entityNames.set(entity, name);
     }
 
-    // Collect default labels and annotations
-    let defaultLabelEntries: Record<string, unknown> = {};
+    // Collect default labels and annotations. Ownership markers are stamped as
+    // labels (Config Connector resources carry them in metadata.labels).
+    let defaultLabelEntries: Record<string, unknown> = context?.ownership
+      ? { ...ownershipEntries("label", context.ownership) }
+      : {};
     let defaultAnnotationEntries: Record<string, unknown> = {};
 
     for (const [, entity] of entities) {

--- a/lexicons/k8s/src/serializer-ownership.test.ts
+++ b/lexicons/k8s/src/serializer-ownership.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "vitest";
+import { k8sSerializer } from "./serializer";
+import { DECLARABLE_MARKER } from "@intentius/chant/declarable";
+
+function mockResource(entityType: string, props: Record<string, unknown>): any {
+  return { [DECLARABLE_MARKER]: true, lexicon: "k8s", entityType, kind: "resource", props };
+}
+
+describe("k8sSerializer ownership stamping (#119)", () => {
+  test("stamps the ownership marker as labels when context.ownership is set", () => {
+    const entities = new Map<string, any>([
+      ["web", mockResource("K8s::Apps::Deployment", { metadata: { name: "web" }, spec: { replicas: 1 } })],
+    ]);
+    const yaml = k8sSerializer.serialize(entities, [], { ownership: { stack: "billing", env: "prod" } });
+    expect(yaml).toContain("app.kubernetes.io/managed-by: chant");
+    expect(yaml).toContain("chant.intentius.io/stack: billing");
+    expect(yaml).toContain("chant.intentius.io/env: prod");
+  });
+
+  test("explicit resource labels still win over the stamped marker", () => {
+    const entities = new Map<string, any>([
+      [
+        "web",
+        mockResource("K8s::Apps::Deployment", {
+          metadata: { name: "web", labels: { "app.kubernetes.io/managed-by": "argocd" } },
+          spec: { replicas: 1 },
+        }),
+      ],
+    ]);
+    const yaml = k8sSerializer.serialize(entities, [], { ownership: { stack: "billing" } });
+    expect(yaml).toContain("app.kubernetes.io/managed-by: argocd");
+    // stack identity still stamped (no explicit override)
+    expect(yaml).toContain("chant.intentius.io/stack: billing");
+  });
+
+  test("no ownership context → no chant labels", () => {
+    const entities = new Map<string, any>([
+      ["web", mockResource("K8s::Apps::Deployment", { metadata: { name: "web" }, spec: { replicas: 1 } })],
+    ]);
+    const yaml = k8sSerializer.serialize(entities, []);
+    expect(yaml).not.toContain("app.kubernetes.io/managed-by: chant");
+    expect(yaml).not.toContain("chant.intentius.io/stack");
+  });
+});

--- a/lexicons/k8s/src/serializer.ts
+++ b/lexicons/k8s/src/serializer.ts
@@ -8,7 +8,8 @@
 import { createRequire } from "module";
 import type { Declarable } from "@intentius/chant/declarable";
 import { isPropertyDeclarable } from "@intentius/chant/declarable";
-import type { Serializer, SerializerResult } from "@intentius/chant/serializer";
+import type { Serializer, SerializerResult, SerializeContext } from "@intentius/chant/serializer";
+import { ownershipEntries } from "@intentius/chant/ownership";
 import type { LexiconOutput } from "@intentius/chant/lexicon-output";
 import { walkValue, type SerializerVisitor } from "@intentius/chant/serializer-walker";
 import { emitYAML } from "@intentius/chant/yaml";
@@ -153,15 +154,19 @@ export const k8sSerializer: Serializer = {
   name: "k8s",
   rulePrefix: "WK8",
 
-  serialize(entities: Map<string, Declarable>, _outputs?: LexiconOutput[]): string {
+  serialize(entities: Map<string, Declarable>, _outputs?: LexiconOutput[], context?: SerializeContext): string {
     // Build reverse map: entity → name
     const entityNames = new Map<Declarable, string>();
     for (const [name, entity] of entities) {
       entityNames.set(entity, name);
     }
 
-    // Collect default labels and annotations
-    let defaultLabelEntries: Record<string, unknown> = {};
+    // Collect default labels and annotations. Ownership markers are stamped as
+    // labels, so they seed defaultLabelEntries and flow through the same merge
+    // (explicit resource labels still win).
+    let defaultLabelEntries: Record<string, unknown> = context?.ownership
+      ? { ...ownershipEntries("label", context.ownership) }
+      : {};
     let defaultAnnotationEntries: Record<string, unknown> = {};
 
     for (const [, entity] of entities) {

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -1,5 +1,6 @@
 import type { Declarable } from "./declarable";
 import type { Serializer, SerializerResult } from "./serializer";
+import type { OwnershipMarker } from "./ownership";
 import type { DiscoveryError, BuildError } from "./errors";
 import { BuildError as BuildErrorClass } from "./errors";
 import { LexiconOutput, isLexiconOutput } from "./lexicon-output";
@@ -24,6 +25,17 @@ export interface BuildManifest {
 /**
  * Result of the build process
  */
+/**
+ * Optional inputs to the build pipeline.
+ */
+export interface BuildOptions {
+  /**
+   * When set, serializers stamp this ownership marker into each resource's
+   * native metadata channel. Resolved from project config by the caller.
+   */
+  ownership?: OwnershipMarker;
+}
+
 export interface BuildResult {
   /** Map of lexicon name to serialized output (string or multi-file result) */
   outputs: Map<string, string | SerializerResult>;
@@ -310,6 +322,7 @@ export async function build(
   path: string,
   serializers: Serializer[],
   parentBuildStack?: Set<string>,
+  options?: BuildOptions,
 ): Promise<BuildResult> {
   const warnings: string[] = [];
   const errors: Array<DiscoveryError | BuildError> = [];
@@ -363,7 +376,7 @@ export async function build(
         );
         continue;
       }
-      const childResult = await build(childPath, serializers, buildStack);
+      const childResult = await build(childPath, serializers, buildStack, options);
       entity.buildResult = childResult;
       if (childResult.errors.length > 0) {
         for (const err of childResult.errors) {
@@ -429,7 +442,10 @@ export async function build(
         ...(outputsByLexicon.get(lexiconName) ?? []),
         ...unassignedOutputs,
       ];
-      outputs.set(lexiconName, serializer.serialize(lexiconEntities, lexiconLexiconOutputs));
+      outputs.set(
+        lexiconName,
+        serializer.serialize(lexiconEntities, lexiconLexiconOutputs, { ownership: options?.ownership }),
+      );
     } else {
       warnings.push(`No serializer found for lexicon "${lexiconName}"`);
     }

--- a/packages/core/src/cli/commands/build.ts
+++ b/packages/core/src/cli/commands/build.ts
@@ -1,4 +1,5 @@
 import { build } from "../../build";
+import { loadChantConfig, resolveOwnershipMarker } from "../../config";
 import type { Serializer, SerializerResult } from "../../serializer";
 import type { LexiconPlugin } from "../../lexicon";
 import { runPostSynthChecks } from "../../lint/post-synth";
@@ -53,8 +54,15 @@ export async function buildCommand(options: BuildOptions): Promise<BuildResult> 
   // Resolve the path
   const infraPath = resolve(options.path);
 
+  // Resolve opt-in ownership marking from project config (search the infra dir
+  // and its parent, where chant.config.* usually lives).
+  const { config } = await loadChantConfig(infraPath).then((r) =>
+    r.configPath ? r : loadChantConfig(dirname(infraPath)),
+  );
+  const ownership = resolveOwnershipMarker(config);
+
   // Run the build
-  const result = await build(infraPath, options.serializers);
+  const result = await build(infraPath, options.serializers, undefined, { ownership });
 
   // Format errors
   for (const error of result.errors) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 import { join } from "path";
 import { z } from "zod";
 import type { LintConfig } from "./lint/config";
+import type { OwnershipMarker } from "./ownership";
 
 /**
  * Zod schema for ChantConfig validation.
@@ -10,6 +11,11 @@ export const ChantConfigSchema = z.object({
   lexicons: z.array(z.string().min(1)).optional(),
   environments: z.array(z.string().min(1)).optional(),
   lint: z.record(z.string(), z.unknown()).optional(),
+  ownership: z.object({
+    stack: z.string().min(1).optional(),
+    env: z.string().min(1).optional(),
+    enabled: z.boolean().optional(),
+  }).optional(),
 }).passthrough();
 
 /**
@@ -26,6 +32,21 @@ export interface ChantConfig {
 
   /** Lint configuration (rules, extends, overrides, plugins) */
   lint?: LintConfig;
+
+  /**
+   * Opt-in cloud-side ownership marking. When `stack` is set (and `enabled`
+   * is not false), the serializer stamps a chant ownership marker carrying
+   * this stack/env identity onto every supported resource. See {@link
+   * resolveOwnershipMarker}.
+   */
+  ownership?: {
+    /** Stack identity stamped onto resources (required to enable stamping). */
+    stack?: string;
+    /** Optional environment identity. */
+    env?: string;
+    /** Set false to disable stamping even when `stack` is present. */
+    enabled?: boolean;
+  };
 }
 
 /**
@@ -69,6 +90,16 @@ export async function loadChantConfig(dir: string): Promise<ResolvedConfig> {
   }
 
   return { config: DEFAULT_CHANT_CONFIG };
+}
+
+/**
+ * Resolve the ownership marker to stamp from project config, or undefined when
+ * ownership marking is off (no `stack`, or `enabled: false`).
+ */
+export function resolveOwnershipMarker(config: ChantConfig): OwnershipMarker | undefined {
+  const o = config.ownership;
+  if (!o || !o.stack || o.enabled === false) return undefined;
+  return { stack: o.stack, env: o.env };
 }
 
 /**

--- a/packages/core/src/ownership.test.ts
+++ b/packages/core/src/ownership.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+import {
+  ownershipEntries,
+  ownershipKeys,
+  hasOwnershipMarker,
+  readOwnership,
+  OWNERSHIP_MANAGED_BY_VALUE,
+} from "./ownership";
+import { resolveOwnershipMarker } from "./config";
+
+describe("ownershipEntries (#119)", () => {
+  test("label channel carries managed-by + stack + env", () => {
+    const e = ownershipEntries("label", { stack: "billing", env: "prod" });
+    expect(e["app.kubernetes.io/managed-by"]).toBe("chant");
+    expect(e["chant.intentius.io/stack"]).toBe("billing");
+    expect(e["chant.intentius.io/env"]).toBe("prod");
+  });
+
+  test("aws-tag channel uses colon keys", () => {
+    const e = ownershipEntries("aws-tag", { stack: "billing" });
+    expect(e["chant:managed-by"]).toBe("chant");
+    expect(e["chant:stack"]).toBe("billing");
+    expect(e["chant:env"]).toBeUndefined(); // env omitted when not set
+  });
+
+  test("azure-tag channel uses hyphen keys (no slash, which Azure forbids)", () => {
+    const e = ownershipEntries("azure-tag", { stack: "billing", env: "stg" });
+    expect(e["chant-managed-by"]).toBe("chant");
+    expect(e["chant-stack"]).toBe("billing");
+    expect(e["chant-env"]).toBe("stg");
+    expect(Object.keys(e).some((k) => k.includes("/"))).toBe(false);
+  });
+
+  test("carries stack identity, not just managed=true", () => {
+    const a = ownershipEntries("label", { stack: "stack-a" });
+    const b = ownershipEntries("label", { stack: "stack-b" });
+    expect(a[ownershipKeys("label").stack]).not.toBe(b[ownershipKeys("label").stack]);
+  });
+});
+
+describe("hasOwnershipMarker / readOwnership", () => {
+  test("detects chant's marker even when co-stamped with other tools", () => {
+    const tags = {
+      "chant:managed-by": OWNERSHIP_MANAGED_BY_VALUE,
+      "chant:stack": "billing",
+      "team": "payments", // foreign co-stamp
+    };
+    expect(hasOwnershipMarker(tags, "aws-tag")).toBe(true);
+  });
+
+  test("absent marker → not owned", () => {
+    expect(hasOwnershipMarker({ team: "payments" }, "aws-tag")).toBe(false);
+    expect(hasOwnershipMarker(undefined, "label")).toBe(false);
+  });
+
+  test("readOwnership recovers stack/env from a marked resource", () => {
+    const labels = ownershipEntries("label", { stack: "billing", env: "prod" });
+    expect(readOwnership(labels, "label")).toEqual({ stack: "billing", env: "prod" });
+  });
+
+  test("readOwnership returns undefined when unmarked", () => {
+    expect(readOwnership({ foo: "bar" }, "label")).toBeUndefined();
+  });
+});
+
+describe("resolveOwnershipMarker (config opt-in)", () => {
+  test("enabled when stack is set", () => {
+    expect(resolveOwnershipMarker({ ownership: { stack: "billing", env: "prod" } })).toEqual({
+      stack: "billing",
+      env: "prod",
+    });
+  });
+
+  test("off when no ownership config", () => {
+    expect(resolveOwnershipMarker({})).toBeUndefined();
+  });
+
+  test("off when stack missing", () => {
+    expect(resolveOwnershipMarker({ ownership: { env: "prod" } })).toBeUndefined();
+  });
+
+  test("off when explicitly disabled", () => {
+    expect(resolveOwnershipMarker({ ownership: { stack: "billing", enabled: false } })).toBeUndefined();
+  });
+});

--- a/packages/core/src/ownership.ts
+++ b/packages/core/src/ownership.ts
@@ -1,0 +1,111 @@
+/**
+ * Ownership marker contract.
+ *
+ * chant stamps managed resources with a provider-native marker at synthesis
+ * time. This is what later lets `delete` be precise without an authoritative
+ * state file — the ownership record lives on the cloud resource, not in a file
+ * chant has to host or lock. The marker is standard tags/labels, so walk-away
+ * cost stays zero: nothing proprietary lands in the output.
+ *
+ * The marker carries stack identity, not just `managed=true`, so one stack
+ * never mistakes another stack's resources for its own. Ownership means
+ * "carries chant's marker", not "carries only chant's marker" — co-stamping
+ * with other tools is fine.
+ */
+
+/** The value of the managed-by marker for every channel. */
+export const OWNERSHIP_MANAGED_BY_VALUE = "chant";
+
+/**
+ * Stack (and optional environment) identity stamped onto a resource. Computed
+ * from project config and threaded into each serializer.
+ */
+export interface OwnershipMarker {
+  /** Distinguishes one chant stack's resources from another's. */
+  stack: string;
+  /** Optional environment identity. */
+  env?: string;
+}
+
+/**
+ * The native metadata channel a target stamps into. Tag-key syntax differs:
+ * Kubernetes/GCP labels allow a `prefix/name` form; AWS tag keys allow `:`;
+ * Azure tag keys forbid `/`, so they use a hyphenated form.
+ */
+export type OwnershipChannel = "label" | "aws-tag" | "azure-tag";
+
+interface ChannelKeys {
+  readonly managedBy: string;
+  readonly stack: string;
+  readonly env: string;
+}
+
+const CHANNEL_KEYS: Record<OwnershipChannel, ChannelKeys> = {
+  label: {
+    managedBy: "app.kubernetes.io/managed-by",
+    stack: "chant.intentius.io/stack",
+    env: "chant.intentius.io/env",
+  },
+  "aws-tag": {
+    managedBy: "chant:managed-by",
+    stack: "chant:stack",
+    env: "chant:env",
+  },
+  "azure-tag": {
+    managedBy: "chant-managed-by",
+    stack: "chant-stack",
+    env: "chant-env",
+  },
+};
+
+/** The marker key names used in a given channel. */
+export function ownershipKeys(channel: OwnershipChannel): ChannelKeys {
+  return CHANNEL_KEYS[channel];
+}
+
+/**
+ * The key/value entries to stamp for a channel: the managed-by marker, the
+ * stack identity, and the env identity when present.
+ */
+export function ownershipEntries(
+  channel: OwnershipChannel,
+  marker: OwnershipMarker,
+): Record<string, string> {
+  const keys = CHANNEL_KEYS[channel];
+  const entries: Record<string, string> = {
+    [keys.managedBy]: OWNERSHIP_MANAGED_BY_VALUE,
+    [keys.stack]: marker.stack,
+  };
+  if (marker.env) entries[keys.env] = marker.env;
+  return entries;
+}
+
+/**
+ * Ownership test: does this resource carry chant's managed-by marker? Other
+ * tools may co-stamp; only the managed-by marker is required to count as owned.
+ */
+export function hasOwnershipMarker(
+  tagsOrLabels: Record<string, unknown> | undefined,
+  channel: OwnershipChannel,
+): boolean {
+  if (!tagsOrLabels) return false;
+  return tagsOrLabels[CHANNEL_KEYS[channel].managedBy] === OWNERSHIP_MANAGED_BY_VALUE;
+}
+
+/**
+ * Read the stack/env identity from a marked resource's tags/labels. Returns
+ * undefined when the managed-by marker is absent.
+ */
+export function readOwnership(
+  tagsOrLabels: Record<string, unknown> | undefined,
+  channel: OwnershipChannel,
+): OwnershipMarker | undefined {
+  if (!hasOwnershipMarker(tagsOrLabels, channel)) return undefined;
+  const keys = CHANNEL_KEYS[channel];
+  const stack = tagsOrLabels![keys.stack];
+  const env = tagsOrLabels![keys.env];
+  return {
+    stack: typeof stack === "string" ? stack : "",
+    env: typeof env === "string" ? env : undefined,
+  };
+}

--- a/packages/core/src/serializer.ts
+++ b/packages/core/src/serializer.ts
@@ -1,5 +1,18 @@
 import type { Declarable } from "./declarable";
 import type { LexiconOutput } from "./lexicon-output";
+import type { OwnershipMarker } from "./ownership";
+
+/**
+ * Build-time context passed to a serializer. Optional — serializers that don't
+ * need it ignore the parameter.
+ */
+export interface SerializeContext {
+  /**
+   * When set, the serializer stamps this ownership marker into the target's
+   * native metadata channel (AWS/Azure tags, K8s/GCP labels).
+   */
+  ownership?: OwnershipMarker;
+}
 
 /**
  * Result of serialization that may include additional files (e.g. nested stack templates).
@@ -29,8 +42,13 @@ export interface Serializer {
    * Serializes the entities to a string representation
    * @param entities - Map of entity name to Declarable entity
    * @param outputs - Optional array of LexiconOutputs produced by this lexicon
+   * @param context - Optional build-time context (e.g. ownership marker)
    */
-  serialize(entities: Map<string, Declarable>, outputs?: LexiconOutput[]): string | SerializerResult;
+  serialize(
+    entities: Map<string, Declarable>,
+    outputs?: LexiconOutput[],
+    context?: SerializeContext,
+  ): string | SerializerResult;
 
   /**
    * Serialize a cross-lexicon reference to a foreign output.


### PR DESCRIPTION
Stamps chant-managed resources with a provider-native ownership marker at synthesis time — the record that later (#120/#121) lets `delete` be precise without an authoritative state file. The marker lives on the cloud resource, not in a file chant has to host or lock.

## What

- **Core `ownership.ts`** — the contract: per-channel marker keys and helpers (`ownershipEntries`, `hasOwnershipMarker`, `readOwnership`). The marker carries **stack identity** (and optional env), not just `managed=true`, so one stack never claims another's resources. Ownership = "carries chant's marker"; co-stamping with other tools is fine.
- **Channels**: K8s/GCP labels (`app.kubernetes.io/managed-by`, `chant.intentius.io/stack|env`), AWS tags (`chant:managed-by|stack|env`), Azure tags (`chant-managed-by|stack|env` — Azure forbids `/` in tag keys).
- **Opt-in** via `chant.config` `ownership: { stack, env?, enabled? }`. `resolveOwnershipMarker()` resolves it; `build()` threads it through `serialize(entities, outputs, { ownership })` (new optional `SerializeContext`).
- **Stamping** wired into the AWS, K8s, GCP, and Azure serializers via their existing default-tag/label injection — explicit per-resource tags/labels still win.

## Walk-away cost

Zero — markers are standard tags/labels, nothing proprietary in the output.

## Tests

- `packages/core/src/ownership.test.ts` (12): per-channel keys, co-stamp detection, read-back, config opt-in resolution.
- `serializer-ownership.test.ts` for AWS, K8s, GCP, Azure (9 total): a synthesized resource carries the marker + stack identity; explicit labels win; no context → no marker; Azure keys have no `/`.
- Existing build/serializer suites unchanged (117 + lexicon serializer tests pass). Core typechecks clean.

Part of #112. Closes #119.