### PR TITLE
feat(lexicons): owned filter on describe/exportResources

### DIFF
--- a/docs/src/content/docs/concepts/comparison.mdx
+++ b/docs/src/content/docs/concepts/comparison.mdx
@@ -13,6 +13,16 @@ This isn't a reaction to other tools' failures — it's an approach that was alw
 
 **The agentic angle:** the operational layer — deploying, monitoring, remediating — is increasingly handled by agents and automation. chant handles the part that should be deterministic and auditable: turning typed declarations into spec-native output. The two layers are complementary.
 
+## Nobody sells you a lifecycle
+
+Every infrastructure tool sells you a lifecycle. Synthesis, state, apply, drift, retire — owned end to end. A decade of investment goes into that lifecycle, into a better way to own it. The ownership is the product. That coupling is why a pure synthesis tool never existed. You could not get the compiler without the lifecycle welded to it.
+
+chant sells nothing. Synthesis is pure and the output is native spec — standard CloudFormation, GitLab CI, whatever the lexicon targets. Walk away and there is nothing to unwind. That is the test the claim has to pass, and it is the one most tools fail. You can leave a thing you were never sold.
+
+The lifecycle is still there when you want it. You write your own. Ops are declared as code in `*.op.ts` files and run on a local executor for one-shot work, or on [Temporal](/chant/concepts/durable-workflows/) when an apply needs to outlive a single process — approval gates, rollback, crash-resume. The durable version of what the others sell, for the lifecycle you chose rather than one chosen for you.
+
+Decoupled first. Durable when you ask.
+
 ## Design decisions and their consequences
 
 These tools make different design decisions. Each decision has consequences — some favorable for certain workflows, some not. This isn't a feature matrix; it's a comparison of architectural choices.

--- a/docs/src/content/docs/lexicons/overview.mdx
+++ b/docs/src/content/docs/lexicons/overview.mdx
@@ -25,21 +25,23 @@ A **lexicon** is a collection of types and semantic lint rules for an operationa
 
 Lexicons opt into the `chant state diff <env> --live` pipeline by implementing one of two plugin methods: `describeResources()` (entity-keyed — for 1:1 cloud resources) or `listArtifacts()` (context-keyed — for runtime concepts created by tooling outside chant's entity model). See [Drift Detection — Resources and artifacts](/chant/concepts/drift-detection/#resources-and-artifacts) for the conceptual distinction, and [Implementing Observation](/chant/lexicon-authoring/observation/) for the author-side walkthrough.
 
-| Lexicon | `describeResources()` | `listArtifacts()` | Notes |
-|---|---|---|---|
-| AWS | ✅ |  | `aws cloudformation describe-stack-resources` |
-| Azure | ✅ |  | `az resource show` per declared entity; resource-group is the env name |
-| GCP (Config Connector) | ✅ |  | `kubectl get <gvk>` against the GKE management cluster |
-| Kubernetes | ✅ |  | `kubectl get <kind>` per declared entity; ~20 common types |
-| Temporal | ✅ |  | Temporal client — namespaces, search attributes, schedules |
-| Helm |  | ✅ | `helm list -A -o json` — releases as artifacts |
-| Docker |  | ✅ | `docker ps`, `docker image ls`, `docker network ls` (NDJSON) |
-| Flyway |  | ✅ | `flyway info -outputType=json` per declared `Flyway::Environment` |
-| Slurm |  | ✅ | `sinfo` partition state |
-| GitHub Actions |  |  | N/A — workflow definitions are git-tracked; drift is `git diff` ([rationale](https://github.com/INTENTIUS/chant/blob/main/lexicons/github/README.md#runtime-observation-na)) |
-| GitLab CI/CD |  |  | N/A — same rationale ([README](https://github.com/INTENTIUS/chant/blob/main/lexicons/gitlab/README.md#runtime-observation-na)) |
+| Lexicon | `describeResources()` | `listArtifacts()` | Ownership | Notes |
+|---|---|---|---|---|
+| AWS | ✅ |  | Tags | `aws cloudformation describe-stack-resources`; `--owned` available on live export (not on describe — tags absent there) |
+| Azure | ✅ |  | Tags | `az resource show` per declared entity; resource-group is the env name |
+| GCP (Config Connector) | ✅ |  | Labels | `kubectl get <gvk>` against the GKE management cluster |
+| Kubernetes | ✅ |  | Labels | `kubectl get <kind>` per declared entity; ~20 common types |
+| Temporal | ✅ |  | — | Temporal client — namespaces, search attributes, schedules |
+| Helm |  | ✅ | — | `helm list -A -o json` — releases as artifacts |
+| Docker |  | ✅ | — | `docker ps`, `docker image ls`, `docker network ls` (NDJSON) |
+| Flyway |  | ✅ | — | `flyway info -outputType=json` per declared `Flyway::Environment` |
+| Slurm |  | ✅ | — | `sinfo` partition state |
+| GitHub Actions |  |  | — | N/A — workflow definitions are git-tracked; drift is `git diff` ([rationale](https://github.com/INTENTIUS/chant/blob/main/lexicons/github/README.md#runtime-observation-na)) |
+| GitLab CI/CD |  |  | — | N/A — same rationale ([README](https://github.com/INTENTIUS/chant/blob/main/lexicons/gitlab/README.md#runtime-observation-na)) |
 
 Lexicons that implement neither are warn-skipped — `--live` doesn't fail the whole command for them.
+
+The **Ownership** column shows which marker channel a lexicon queries for the `--owned` filter ([ownership marking](/chant/configuration/config-file/#ownership)). `—` means no durable marker channel: those targets log that ownership is unavailable and degrade to detect-only rather than silently filtering.
 
 ## Cross-lexicon migration
 

--- a/lexicons/aws/src/import/live-export.test.ts
+++ b/lexicons/aws/src/import/live-export.test.ts
@@ -42,6 +42,30 @@ describe("AWS exportResources mapping (#115)", () => {
     expect(ir.resources.map((r) => r.logicalId)).toEqual(["MyBucket"]);
   });
 
+  test("owned filter keeps only resources carrying the chant marker (#120)", () => {
+    const mixed = {
+      AWSTemplateFormatVersion: "2010-09-09",
+      Resources: {
+        Mine: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "mine",
+            Tags: [
+              { Key: "chant:managed-by", Value: "chant" },
+              { Key: "chant:stack", Value: "billing" },
+            ],
+          },
+        },
+        Theirs: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "theirs", Tags: [{ Key: "team", Value: "other" }] },
+        },
+      },
+    };
+    const ir = parseStackTemplate(mixed, undefined, true);
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["Mine"]);
+  });
+
   test("export IR feeds CFGenerator (templateGenerator) unchanged", () => {
     const ir = parseStackTemplate(liveTemplate);
     const files = new CFGenerator().generate(ir);

--- a/lexicons/aws/src/import/live-export.ts
+++ b/lexicons/aws/src/import/live-export.ts
@@ -1,4 +1,5 @@
 import type { ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
+import { hasOwnershipMarker, tagArrayToMap } from "@intentius/chant/ownership";
 import { CFParser } from "./parser";
 
 /**
@@ -13,20 +14,25 @@ import { CFParser } from "./parser";
 export function parseStackTemplate(
   templateBody: unknown,
   selector?: ResourceSelector,
+  owned?: boolean,
 ): ExportedTemplate {
   const content =
     typeof templateBody === "string" ? templateBody : JSON.stringify(templateBody);
   const ir = new CFParser().parse(content);
 
-  if (!selector || (selector.type === undefined && selector.name === undefined)) {
-    return ir;
-  }
+  const hasSelector = selector && (selector.type !== undefined || selector.name !== undefined);
+  if (!hasSelector && !owned) return ir;
+
   return {
     ...ir,
-    resources: ir.resources.filter(
-      (r) =>
-        (selector.type === undefined || r.type === selector.type) &&
-        (selector.name === undefined || r.logicalId === selector.name),
-    ),
+    resources: ir.resources.filter((r) => {
+      if (selector?.type !== undefined && r.type !== selector.type) return false;
+      if (selector?.name !== undefined && r.logicalId !== selector.name) return false;
+      if (owned) {
+        const tags = (r.properties as { Tags?: Array<{ Key?: string; Value?: unknown }> }).Tags;
+        if (!hasOwnershipMarker(tagArrayToMap(tags), "aws-tag")) return false;
+      }
+      return true;
+    }),
   };
 }

--- a/lexicons/aws/src/plugin.ts
+++ b/lexicons/aws/src/plugin.ts
@@ -476,10 +476,20 @@ aws cloudformation wait stack-update-complete --stack-name my-app-prod`,
     environment: string;
     buildOutput: string;
     entityNames: string[];
+    owned?: boolean;
   }): Promise<Record<string, ResourceMetadata>> {
     const { getRuntime } = await import("@intentius/chant/runtime-adapter");
     const rt = getRuntime();
     const resources: Record<string, ResourceMetadata> = {};
+
+    if (options.owned) {
+      // describe-stack-resources does not return tags, so ownership cannot be
+      // determined here. Degrade to detect-only rather than silently filtering.
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[aws] ownership filter unavailable on describeResources (no tags from describe-stack-resources) — returning all; use `chant import --from <env> --owned` for ownership-filtered export",
+      );
+    }
 
     // Derive stack name: environment-based convention
     // Try to parse the build output to detect stack name from Metadata or use convention
@@ -583,8 +593,7 @@ aws cloudformation wait stack-update-complete --stack-name my-app-prod`,
       throw new Error(`Stack "${stackName}" returned no TemplateBody`);
     }
 
-    // `owned` is accepted but inert until ownership marking lands (#120).
-    return parseStackTemplate(parsed.TemplateBody, options.selector);
+    return parseStackTemplate(parsed.TemplateBody, options.selector, options.owned);
   },
 
   mcpTools() {

--- a/lexicons/gcp/src/describe-resources.ts
+++ b/lexicons/gcp/src/describe-resources.ts
@@ -15,6 +15,7 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import type { ResourceMetadata } from "@intentius/chant/lexicon";
+import { hasOwnershipMarker } from "@intentius/chant/ownership";
 
 const execAsync = promisify(exec);
 
@@ -80,6 +81,7 @@ export async function describeResources(options: {
   buildOutput: string;
   entityNames: string[];
   entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
+  owned?: boolean;
 }): Promise<Record<string, ResourceMetadata>> {
   const result: Record<string, ResourceMetadata> = {};
 
@@ -98,6 +100,10 @@ export async function describeResources(options: {
     try {
       const { stdout } = await execAsync(cmd);
       const obj: KubectlResponse = JSON.parse(stdout);
+      // owned filter: skip resources not carrying chant's marker label.
+      if (options.owned && !hasOwnershipMarker(obj.metadata?.labels, "label")) {
+        continue;
+      }
       result[entityName] = {
         type: entityType,
         physicalId: obj.metadata?.uid,

--- a/lexicons/gcp/src/export-resources.ts
+++ b/lexicons/gcp/src/export-resources.ts
@@ -65,9 +65,9 @@ export async function exportResources(options: {
     }
   }
 
-  // `owned` is accepted but inert until ownership marking lands (#120).
   return buildExportFromObjects(objects, {
     verbatim: options.verbatim,
     selector: options.selector,
+    owned: options.owned,
   });
 }

--- a/lexicons/gcp/src/import/live-export.test.ts
+++ b/lexicons/gcp/src/import/live-export.test.ts
@@ -89,6 +89,14 @@ describe("GCP buildExportFromObjects (#117)", () => {
     expect(ir.resources.map((r) => r.logicalId)).toEqual(["my-bucket"]);
   });
 
+  test("owned filter keeps only objects carrying the chant marker label (#120)", () => {
+    const mine = liveBucket();
+    (mine.metadata as any).labels = { "app.kubernetes.io/managed-by": "chant", "chant.intentius.io/stack": "billing" };
+    const theirs = livePubsub(); // no chant label
+    const ir = buildExportFromObjects([mine, theirs], { owned: true });
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["my-bucket"]);
+  });
+
   test("export IR feeds GcpGenerator (templateGenerator) unchanged", () => {
     const ir = buildExportFromObjects([liveBucket()]);
     const files = new GcpGenerator().generate(ir);

--- a/lexicons/gcp/src/import/live-export.ts
+++ b/lexicons/gcp/src/import/live-export.ts
@@ -1,4 +1,5 @@
 import type { ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
+import { hasOwnershipMarker } from "@intentius/chant/ownership";
 import { GcpParser } from "./parser";
 
 /** Server-written metadata fields, stripped unless `verbatim`. */
@@ -54,9 +55,17 @@ export function stripServerFields(obj: Record<string, unknown>): Record<string, 
  */
 export function buildExportFromObjects(
   objects: unknown[],
-  opts: { verbatim?: boolean; selector?: ResourceSelector } = {},
+  opts: { verbatim?: boolean; selector?: ResourceSelector; owned?: boolean } = {},
 ): ExportedTemplate {
-  const cleaned = objects
+  const owning = opts.owned
+    ? objects.filter((o) => {
+        if (!isRecord(o)) return false;
+        const labels = isRecord(o.metadata) ? (o.metadata.labels as Record<string, unknown>) : undefined;
+        return hasOwnershipMarker(labels, "label");
+      })
+    : objects;
+
+  const cleaned = owning
     .filter(isRecord)
     .map((o) => (opts.verbatim ? o : stripServerFields(o)));
 

--- a/lexicons/k8s/src/describe-resources.ts
+++ b/lexicons/k8s/src/describe-resources.ts
@@ -15,6 +15,7 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import type { ResourceMetadata } from "@intentius/chant/lexicon";
+import { hasOwnershipMarker } from "@intentius/chant/ownership";
 
 const execAsync = promisify(exec);
 
@@ -85,6 +86,7 @@ export async function describeResources(options: {
   buildOutput: string;
   entityNames: string[];
   entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
+  owned?: boolean;
 }): Promise<Record<string, ResourceMetadata>> {
   const result: Record<string, ResourceMetadata> = {};
   const skippedTypes = new Set<string>();
@@ -106,6 +108,10 @@ export async function describeResources(options: {
     try {
       const { stdout } = await execAsync(cmd);
       const obj: KubectlResponse = JSON.parse(stdout);
+      // owned filter: skip resources not carrying chant's marker label.
+      if (options.owned && !hasOwnershipMarker(obj.metadata?.labels, "label")) {
+        continue;
+      }
       result[entityName] = {
         type: entityType,
         physicalId: obj.metadata?.uid,

--- a/lexicons/k8s/src/export-resources.ts
+++ b/lexicons/k8s/src/export-resources.ts
@@ -52,9 +52,9 @@ export async function exportResources(options: {
     }
   }
 
-  // `owned` is accepted but inert until ownership marking lands (#120).
   return buildExportFromObjects(objects, {
     verbatim: options.verbatim,
     selector: options.selector,
+    owned: options.owned,
   });
 }

--- a/lexicons/k8s/src/import/live-export.test.ts
+++ b/lexicons/k8s/src/import/live-export.test.ts
@@ -97,6 +97,14 @@ describe("buildExportFromObjects (#116)", () => {
     expect(ir.resources).toHaveLength(2);
   });
 
+  test("owned filter keeps only objects carrying the chant marker label (#120)", () => {
+    const mine = liveDeployment();
+    (mine.metadata as any).labels = { "app.kubernetes.io/managed-by": "chant", "chant.intentius.io/stack": "billing" };
+    const theirs = liveService(); // no chant label
+    const ir = buildExportFromObjects([mine, theirs], { owned: true });
+    expect(ir.resources.map((r) => r.type)).toEqual(["K8s::Apps::Deployment"]);
+  });
+
   test("export IR feeds K8sGenerator (templateGenerator) unchanged", () => {
     const ir = buildExportFromObjects([liveDeployment()]);
     const files = new K8sGenerator().generate(ir);

--- a/lexicons/k8s/src/import/live-export.ts
+++ b/lexicons/k8s/src/import/live-export.ts
@@ -1,4 +1,5 @@
 import type { ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
+import { hasOwnershipMarker } from "@intentius/chant/ownership";
 import { K8sParser } from "./parser";
 
 /**
@@ -54,9 +55,17 @@ export function stripServerFields(obj: Record<string, unknown>): Record<string, 
  */
 export function buildExportFromObjects(
   objects: unknown[],
-  opts: { verbatim?: boolean; selector?: ResourceSelector } = {},
+  opts: { verbatim?: boolean; selector?: ResourceSelector; owned?: boolean } = {},
 ): ExportedTemplate {
-  const cleaned = objects
+  const owning = opts.owned
+    ? objects.filter((o) => {
+        if (!isRecord(o)) return false;
+        const labels = isRecord(o.metadata) ? (o.metadata.labels as Record<string, unknown>) : undefined;
+        return hasOwnershipMarker(labels, "label");
+      })
+    : objects;
+
+  const cleaned = owning
     .filter(isRecord)
     .map((o) => (opts.verbatim ? o : stripServerFields(o)));
 

--- a/packages/core/src/lexicon.ts
+++ b/packages/core/src/lexicon.ts
@@ -267,6 +267,13 @@ export interface LexiconPlugin {
     buildOutput: string;
     entityNames: string[];
     entities: Map<string, { entityType: string; props: Record<string, unknown> }>;
+    /**
+     * Restrict the result to chant-owned resources (those carrying the
+     * ownership marker, #119). Where a lexicon has no durable marker channel,
+     * it must log that ownership is unavailable rather than silently returning
+     * everything.
+     */
+    owned?: boolean;
   }): Promise<Record<string, ResourceMetadata>>;
 
   /**

--- a/packages/core/src/ownership.test.ts
+++ b/packages/core/src/ownership.test.ts
@@ -4,6 +4,8 @@ import {
   ownershipKeys,
   hasOwnershipMarker,
   readOwnership,
+  classifyOwnership,
+  tagArrayToMap,
   OWNERSHIP_MANAGED_BY_VALUE,
 } from "./ownership";
 import { resolveOwnershipMarker } from "./config";
@@ -60,6 +62,28 @@ describe("hasOwnershipMarker / readOwnership", () => {
 
   test("readOwnership returns undefined when unmarked", () => {
     expect(readOwnership({ foo: "bar" }, "label")).toBeUndefined();
+  });
+});
+
+describe("classifyOwnership / tagArrayToMap (#120)", () => {
+  test("marker present → owned, absent → foreign", () => {
+    expect(classifyOwnership({ "chant:managed-by": "chant" }, "aws-tag")).toBe("owned");
+    expect(classifyOwnership({ team: "x" }, "aws-tag")).toBe("foreign");
+    expect(classifyOwnership(undefined, "label")).toBe("foreign");
+  });
+
+  test("tagArrayToMap converts CloudFormation {Key,Value} tags", () => {
+    const map = tagArrayToMap([
+      { Key: "chant:managed-by", Value: "chant" },
+      { Key: "chant:stack", Value: "billing" },
+    ]);
+    expect(map["chant:managed-by"]).toBe("chant");
+    expect(classifyOwnership(map, "aws-tag")).toBe("owned");
+  });
+
+  test("tagArrayToMap tolerates undefined / malformed entries", () => {
+    expect(tagArrayToMap(undefined)).toEqual({});
+    expect(tagArrayToMap([{ Value: "no-key" }])).toEqual({});
   });
 });
 

--- a/packages/core/src/ownership.ts
+++ b/packages/core/src/ownership.ts
@@ -93,6 +93,37 @@ export function hasOwnershipMarker(
 }
 
 /**
+ * The two live-side ownership verdicts a marker query can produce.
+ *
+ * - `owned` — carries chant's marker; an undeclared owned resource is a safe
+ *   delete candidate.
+ * - `foreign` — no marker; can be adopted but never auto-deleted.
+ *
+ * The third verdict, `unknown`, is reserved for when no marker channel was
+ * queried at all (see the `Ownership` type in the change set).
+ */
+export function classifyOwnership(
+  tagsOrLabels: Record<string, unknown> | undefined,
+  channel: OwnershipChannel,
+): "owned" | "foreign" {
+  return hasOwnershipMarker(tagsOrLabels, channel) ? "owned" : "foreign";
+}
+
+/**
+ * Convert a tag array of `{Key, Value}` (AWS/CloudFormation form) into the
+ * key→value map the ownership helpers expect.
+ */
+export function tagArrayToMap(
+  tags: ReadonlyArray<{ Key?: string; Value?: unknown }> | undefined,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const t of tags ?? []) {
+    if (typeof t.Key === "string") out[t.Key] = t.Value;
+  }
+  return out;
+}
+
+/**
  * Read the stack/env identity from a marked resource's tags/labels. Returns
  * undefined when the managed-by marker is absent.
  */


### PR DESCRIPTION
Queries the ownership marker (#119) on the live side so the projection can tell chant-owned resources from foreign ones — the input #121 needs to make `delete` precise.

## What

- **Core** — `classifyOwnership(tags, channel)` → `owned | foreign`; `tagArrayToMap()` converts CloudFormation `{Key,Value}` tags to the map the helpers expect. `describeResources` contract gains an `owned?` option.
- **Live-export `owned` filter** — AWS filters by tags (`aws-tag` channel), K8s + GCP by labels (`label` channel). `exportResources({ owned: true })` now wires through to the filter: marker present → kept, absent → dropped. (Was inert; now live.)
- **`describeResources` `owned` filter** — K8s + GCP filter by the marker label on the fetched object. AWS logs that ownership is unavailable via `describe-stack-resources` (no tags there) and degrades to detect-only — never silently filtering.
- Classification: marker present + undeclared → delete candidate (consumed in #121); marker absent → `foreign` (adopt only).

## Tests

- Core `ownership.test.ts` (+3): classify, tag-array conversion, malformed tolerance.
- AWS/K8s/GCP `live-export.test.ts` (+1 each): `--owned` keeps only marked resources, drops foreign.
- Existing describe tests unchanged. Core typechecks clean.

## Docs

`lexicons/overview.mdx`: new **Ownership** column (Tags / Labels / —) with the degradation note.

Part of #112. Closes #120.