### PR TITLE
feat(core): ownership-gated delete in ChangeSet

### DIFF
--- a/docs/src/content/docs/cli/state.mdx
+++ b/docs/src/content/docs/cli/state.mdx
@@ -87,7 +87,9 @@ chant state plan prod --json   # emit the ChangeSet as JSON
 | **adopt** | Live but undeclared, ownership not established — a candidate to pull back into source, never an auto-delete |
 | **noop** | Declared and live with no drift, or already reconciled |
 
-`create` and `update` are precise from declared-vs-live. `delete` is only ever proposed for a resource a live ownership marker confirms is chant's — until ownership data exists, an undeclared live resource is `adopt`, never `delete`. The classification reads ownership from the live marker, never from the snapshot, so the snapshot never becomes load-bearing.
+`create` and `update` are precise from declared-vs-live. `delete` is only ever proposed for an undeclared resource whose **live ownership marker** ([ownership marking](/chant/configuration/config-file/#ownership)) confirms it is chant's; a foreign orphan is `adopt`, and an orphan with no marker data is `adopt`, never `delete`. Pass `--owned` to restrict the query to chant-owned resources.
+
+The classification reads ownership from the live marker, **never from the snapshot**, so the snapshot never becomes load-bearing: the delete decision is identical whether or not a snapshot exists. The moment a mutation trusted the snapshot, the snapshot would have become an authoritative state file under a different name — which chant deliberately avoids.
 
 `state plan` is strictly read-only: it builds, queries, and classifies. It never mutates the cloud and never deploys — `chant build` stays pure.
 

--- a/lexicons/gcp/src/describe-resources.ts
+++ b/lexicons/gcp/src/describe-resources.ts
@@ -15,7 +15,7 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import type { ResourceMetadata } from "@intentius/chant/lexicon";
-import { hasOwnershipMarker } from "@intentius/chant/ownership";
+import { hasOwnershipMarker, classifyOwnership } from "@intentius/chant/ownership";
 
 const execAsync = promisify(exec);
 
@@ -109,6 +109,7 @@ export async function describeResources(options: {
         physicalId: obj.metadata?.uid,
         status: statusFromCC(obj),
         lastUpdated: obj.metadata?.creationTimestamp,
+        ownership: classifyOwnership(obj.metadata?.labels, "label"),
         attributes: pruneUndefined({
           namespace: obj.metadata?.namespace,
           labels: obj.metadata?.labels,

--- a/lexicons/k8s/src/describe-resources.ts
+++ b/lexicons/k8s/src/describe-resources.ts
@@ -15,7 +15,7 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import type { ResourceMetadata } from "@intentius/chant/lexicon";
-import { hasOwnershipMarker } from "@intentius/chant/ownership";
+import { hasOwnershipMarker, classifyOwnership } from "@intentius/chant/ownership";
 
 const execAsync = promisify(exec);
 
@@ -117,6 +117,7 @@ export async function describeResources(options: {
         physicalId: obj.metadata?.uid,
         status: statusFromKubectl(obj),
         lastUpdated: obj.metadata?.creationTimestamp,
+        ownership: classifyOwnership(obj.metadata?.labels, "label"),
         attributes: pruneUndefined({
           namespace: obj.metadata?.namespace,
           labels: obj.metadata?.labels,

--- a/packages/core/src/cli/handlers/state.ts
+++ b/packages/core/src/cli/handlers/state.ts
@@ -479,6 +479,7 @@ export async function runStatePlan(ctx: CommandContext): Promise<number> {
         buildOutput,
         entityNames: Array.from(declared),
         entities,
+        owned: args.owned,
       });
     } catch (err) {
       console.error(formatError({

--- a/packages/core/src/lexicon.ts
+++ b/packages/core/src/lexicon.ts
@@ -377,6 +377,13 @@ export interface ResourceMetadata {
   lastUpdated?: string;
   /** Cloud-assigned output properties */
   attributes?: Record<string, unknown>;
+  /**
+   * Live ownership verdict from the resource's marker (#119/#120), when the
+   * lexicon could determine it. `owned` = carries chant's marker; `foreign` =
+   * no marker. Absent = the lexicon has no marker channel here. The change set
+   * reads this — never the snapshot — to decide whether an orphan is a delete.
+   */
+  ownership?: "owned" | "foreign";
 }
 
 /**

--- a/packages/core/src/state/change-set.test.ts
+++ b/packages/core/src/state/change-set.test.ts
@@ -41,7 +41,7 @@ describe("buildChangeSet (#118)", () => {
     expect(cs.entries.find((x) => x.name === "queue")!.action).toBe("noop");
   });
 
-  test("live but undeclared → adopt, never delete (no ownership yet)", () => {
+  test("live but undeclared, no ownership data → adopt, never delete", () => {
     const cs = buildChangeSet("prod", {
       declared: new Set(),
       observedNow: { orphan: meta() },
@@ -50,6 +50,50 @@ describe("buildChangeSet (#118)", () => {
     const e = cs.entries.find((x) => x.name === "orphan")!;
     expect(e.action).toBe("adopt");
     expect(e.ownership).toBe("unknown");
+  });
+
+  test("owned orphan → delete (#121)", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(),
+      observedNow: { orphan: meta({ ownership: "owned" }) },
+      observedThen: undefined,
+    });
+    const e = cs.entries.find((x) => x.name === "orphan")!;
+    expect(e.action).toBe("delete");
+    expect(e.ownership).toBe("owned");
+  });
+
+  test("foreign orphan → adopt, never delete (#121)", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(),
+      observedNow: { orphan: meta({ ownership: "foreign" }) },
+      observedThen: undefined,
+    });
+    const e = cs.entries.find((x) => x.name === "orphan")!;
+    expect(e.action).toBe("adopt");
+    expect(e.ownership).toBe("foreign");
+  });
+
+  test("snapshot is never load-bearing: ownership/delete ignores observedThen", () => {
+    // The same live orphan, once with a rich snapshot and once with none.
+    // The delete decision must depend only on the LIVE ownership marker, so the
+    // result must be identical regardless of what the snapshot says.
+    const withSnapshot = buildChangeSet("prod", {
+      declared: new Set(),
+      observedNow: { orphan: meta({ ownership: "owned" }) },
+      observedThen: { orphan: meta({ ownership: "foreign", status: "STALE" }) },
+    });
+    const withoutSnapshot = buildChangeSet("prod", {
+      declared: new Set(),
+      observedNow: { orphan: meta({ ownership: "owned" }) },
+      observedThen: undefined,
+    });
+    const a = withSnapshot.entries.find((x) => x.name === "orphan")!;
+    const b = withoutSnapshot.entries.find((x) => x.name === "orphan")!;
+    expect(a.action).toBe("delete");
+    expect(a.ownership).toBe("owned");
+    expect(a.action).toBe(b.action);
+    expect(a.ownership).toBe(b.ownership);
   });
 
   test("never proposes a delete without ownership data", () => {

--- a/packages/core/src/state/change-set.ts
+++ b/packages/core/src/state/change-set.ts
@@ -91,6 +91,12 @@ export function buildChangeSet(env: string, input: DiffLiveInput): ChangeSet {
     const type = observedNow[name]?.type ?? observedThen[name]?.type;
     const evidence = { declared: isDeclared, inSnapshot, live };
 
+    // Ownership comes from the LIVE marker only (carried on observedNow), never
+    // from the snapshot. This is the invariant that keeps the snapshot from
+    // becoming load-bearing: a mutation decision (delete) is never made from a
+    // record chant has to host.
+    const ownership: Ownership = observedNow[name]?.ownership ?? "unknown";
+
     let action: ChangeAction;
     let deltas: AttributeChange[] | undefined;
 
@@ -106,14 +112,15 @@ export function buildChangeSet(env: string, input: DiffLiveInput): ChangeSet {
         action = "noop";
       }
     } else if (live) {
-      // Live but undeclared. Cannot become a delete without ownership — adopt.
-      action = "adopt";
+      // Live but undeclared. Only a chant-owned orphan is a safe delete; a
+      // foreign or unknown orphan can be adopted but never auto-deleted.
+      action = ownership === "owned" ? "delete" : "adopt";
     } else {
       // Only in the snapshot: already gone, nothing to reconcile.
       action = "noop";
     }
 
-    entries.push({ name, type, action, evidence, deltas, ownership: "unknown" });
+    entries.push({ name, type, action, evidence, deltas, ownership });
   }
 
   entries.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
Makes `delete` precise in the change set — and only for chant-owned orphans. Builds on #118 (ChangeSet) and #120 (live ownership classification).

## What

- `ResourceMetadata` gains `ownership?: "owned" | "foreign"`, populated by the live marker query. K8s and GCP `describeResources` classify it from the resource's labels; AWS leaves it unset (describe-stack-resources returns no tags).
- `buildChangeSet` reads ownership from `observedNow` (the **live marker**), never from the snapshot. An undeclared live resource becomes `delete` only when `ownership === "owned"`; `foreign` or `unknown` → `adopt`, never `delete`.
- `chant state plan` honors `--owned`.

## The invariant

A dedicated test asserts the delete decision is **identical with or without a snapshot** — proving nothing in the plan path reads the snapshot to decide a mutation. The moment a mutation trusts the snapshot, the snapshot becomes an authoritative state file under another name; this guards against that.

## Tests

`state/change-set.test.ts` (+4): owned orphan → delete, foreign orphan → adopt, snapshot-not-load-bearing invariant. The "never proposes a delete without ownership data" test still holds. Core typechecks clean.

## Docs

`cli/state.mdx`: `state plan` delete semantics + the no-load-bearing-snapshot guarantee, `--owned` flag.

Part of #112. Closes #121.