### PR TITLE
feat(op): PR-generation activity for reconcile

### DIFF
--- a/docs/src/content/docs/guide/ops.mdx
+++ b/docs/src/content/docs/guide/ops.mdx
@@ -94,6 +94,8 @@ Pre-built step builders:
 | `stateSnapshot(env, opts?)` | `chant state snapshot` |
 | `teardown(path, opts?)` | Build + destroy |
 
+A reconcile activity is also available via `activity("reconcilePr", args)`: given the change-set entries that triggered it, it regenerates TypeScript with `chant import --from <env>` and opens a reviewable PR (modes: `pull-request`, `issue`, `report`). It never commits to the main branch. It is the building block for the reconcile workflow (cloud → code).
+
 Each step takes an optional `profile` that controls Temporal retry and timeout settings:
 
 | Profile | Suitable for |

--- a/lexicons/temporal/src/op/activities/index.ts
+++ b/lexicons/temporal/src/op/activities/index.ts
@@ -21,3 +21,6 @@ export type { StateSnapshotArgs, StateDiffArgs, StateDiffResult } from "./state"
 
 export { chantTeardown } from "./teardown";
 export type { ChantTeardownArgs } from "./teardown";
+
+export { reconcilePr } from "./reconcile";
+export type { ReconcilePrArgs, ReconcileResult, ReconcileMode, ReconcileEntry } from "./reconcile";

--- a/lexicons/temporal/src/op/activities/reconcile.test.ts
+++ b/lexicons/temporal/src/op/activities/reconcile.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "vitest";
+import { reconcilePr, reconcileSummary, reconcileBranchName } from "./reconcile";
+
+const entries = [
+  { name: "bucket", action: "adopt", type: "AWS::S3::Bucket" },
+  { name: "queue", action: "update", type: "AWS::SQS::Queue" },
+];
+
+describe("reconcileBranchName (#122)", () => {
+  test("deterministic, slugified per env", () => {
+    expect(reconcileBranchName("prod")).toBe("chant/reconcile-prod");
+    expect(reconcileBranchName("us-east/1")).toBe("chant/reconcile-us-east-1");
+  });
+});
+
+describe("reconcileSummary (#122)", () => {
+  test("summarizes which entries triggered the reconcile", () => {
+    const body = reconcileSummary("prod", entries);
+    expect(body).toContain("live environment `prod`");
+    expect(body).toContain("| bucket | adopt | AWS::S3::Bucket |");
+    expect(body).toContain("| queue | update | AWS::SQS::Queue |");
+  });
+
+  test("handles an empty entry set", () => {
+    expect(reconcileSummary("prod", [])).toContain("_(none)_");
+  });
+});
+
+describe("reconcilePr report mode (#122)", () => {
+  test("returns the summary without any git/network IO", async () => {
+    const result = await reconcilePr({ env: "prod", entries, mode: "report" });
+    expect(result.mode).toBe("report");
+    expect(result.prUrl).toBeUndefined();
+    expect(result.branch).toBeUndefined();
+    expect(result.summary).toContain("| bucket | adopt | AWS::S3::Bucket |");
+    expect(result.entries).toEqual(entries);
+  });
+});

--- a/lexicons/temporal/src/op/activities/reconcile.ts
+++ b/lexicons/temporal/src/op/activities/reconcile.ts
@@ -1,0 +1,132 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+/** What the reconcile activity does with the regenerated source. */
+export type ReconcileMode = "pull-request" | "issue" | "report";
+
+/** A change-set entry that triggered reconciliation. */
+export interface ReconcileEntry {
+  /** chant entity name. */
+  name: string;
+  /** create | update | delete | adopt | noop (from `chant state plan`). */
+  action: string;
+  /** Resource type, when known. */
+  type?: string;
+}
+
+export interface ReconcilePrArgs {
+  /** Environment to reconcile from (passed to `chant import --from`). */
+  env: string;
+  /** The change-set entries that triggered this reconcile. */
+  entries: ReconcileEntry[];
+  /** What to produce. Default: pull-request. */
+  mode?: ReconcileMode;
+  /** Output directory for regenerated source. Default: ./infra. */
+  output?: string;
+  /** Branch to open the PR from. Default: chant/reconcile-<env>. */
+  branch?: string;
+  /** Restrict live import to chant-owned resources. */
+  owned?: boolean;
+  /** PR / issue title. Default derived from env. */
+  title?: string;
+}
+
+export interface ReconcileResult {
+  mode: ReconcileMode;
+  /** Branch created (pull-request mode). */
+  branch?: string;
+  /** Opened PR URL (pull-request mode). */
+  prUrl?: string;
+  /** Opened issue URL (issue mode). */
+  issueUrl?: string;
+  /** The markdown summary used as the PR/issue body. */
+  summary: string;
+  /** The entries that triggered the reconcile. */
+  entries: ReconcileEntry[];
+}
+
+/** Default branch name for a reconcile PR. Deterministic — no timestamp. */
+export function reconcileBranchName(env: string): string {
+  const safe = env.replace(/[^a-zA-Z0-9._-]+/g, "-");
+  return `chant/reconcile-${safe}`;
+}
+
+/**
+ * Build the markdown body summarizing which change-set entries triggered the
+ * reconcile. Pure — used as the PR/issue body and returned in `report` mode.
+ */
+export function reconcileSummary(env: string, entries: ReconcileEntry[]): string {
+  const lines = [
+    `Reconcile from live environment \`${env}\`.`,
+    "",
+    "This PR regenerates chant TypeScript from live state to close the gap between the cloud and source. It was triggered by the following change-set entries:",
+    "",
+    "| Entry | Action | Type |",
+    "|---|---|---|",
+  ];
+  for (const e of entries) {
+    lines.push(`| ${e.name} | ${e.action} | ${e.type ?? ""} |`);
+  }
+  if (entries.length === 0) {
+    lines.push("| _(none)_ | | |");
+  }
+  lines.push("");
+  lines.push("Review the diff before merging — live import may surface values that need redaction.");
+  return lines.join("\n");
+}
+
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Reconcile activity: turn regenerated TypeScript into a reviewable artifact.
+ *
+ * - `report` — return the summary only; no git, no network.
+ * - `issue` — open a GitHub issue describing the drift (no code change).
+ * - `pull-request` — create a branch, regenerate source via
+ *   `chant import --from <env>`, commit, push, and open a PR whose diff is the
+ *   regenerated TypeScript. Never commits to the main branch.
+ *
+ * Requires `chant` and (for non-report modes) `gh`/`git` in the environment.
+ */
+export async function reconcilePr(args: ReconcilePrArgs, signal?: AbortSignal): Promise<ReconcileResult> {
+  const mode = args.mode ?? "pull-request";
+  const summary = reconcileSummary(args.env, args.entries);
+  const title = args.title ?? `Reconcile ${args.env}: ${args.entries.length} change(s) from live`;
+
+  if (mode === "report") {
+    return { mode, summary, entries: args.entries };
+  }
+
+  if (mode === "issue") {
+    const { stdout } = await execAsync(
+      `gh issue create --title ${shellQuote(title)} --body ${shellQuote(summary)}`,
+      { signal },
+    );
+    return { mode, summary, entries: args.entries, issueUrl: stdout.trim() };
+  }
+
+  // pull-request
+  const branch = args.branch ?? reconcileBranchName(args.env);
+  const output = args.output ?? "./infra";
+  const ownedFlag = args.owned ? " --owned" : "";
+
+  // Never touch the main branch: cut a fresh branch first.
+  await execAsync(`git checkout -b ${shellQuote(branch)}`, { signal });
+  await execAsync(
+    `chant import --from ${shellQuote(args.env)}${ownedFlag} --output ${shellQuote(output)} --force`,
+    { signal },
+  );
+  await execAsync(`git add ${shellQuote(output)}`, { signal });
+  await execAsync(`git commit -m ${shellQuote(title)}`, { signal });
+  await execAsync(`git push -u origin ${shellQuote(branch)}`, { signal });
+  const { stdout } = await execAsync(
+    `gh pr create --title ${shellQuote(title)} --body ${shellQuote(summary)} --head ${shellQuote(branch)}`,
+    { signal },
+  );
+
+  return { mode, branch, summary, entries: args.entries, prUrl: stdout.trim() };
+}


### PR DESCRIPTION
A reusable Op activity that turns regenerated TypeScript into a reviewable PR — the building block for the cloud→code reconcile workflow (#123).

## What

- `reconcilePr` activity (`lexicons/temporal/src/op/activities/reconcile.ts`): given the change-set entries that triggered it, regenerates source via `chant import --from <env>`, creates a branch, commits, pushes, and opens a PR whose diff is the regenerated TypeScript. **Never commits to the main branch** — it always cuts a fresh branch first.
- Modes: `pull-request` (default), `issue` (open a GitHub issue, no code change), `report` (return the summary only — no git/network).
- The PR/issue body summarizes which change-set entries triggered it (a markdown table of name / action / type).
- Pure `reconcileSummary()` and `reconcileBranchName()` (deterministic, no timestamp) factored out for testing.

## Tests

`reconcile.test.ts` (4): branch slugification, summary content (incl. empty set), and `report` mode returning the summary with zero IO.

## Docs

`guide/ops.mdx`: note on the reconcile activity and its modes.

Part of #112. Closes #122.