### PR TITLE
feat(temporal): ReconcileOp composite (cloud→code PRs)

### DIFF
--- a/docs/src/content/docs/guide/ops.mdx
+++ b/docs/src/content/docs/guide/ops.mdx
@@ -234,6 +234,28 @@ The `WatchOp` composite pairs an Op with a `TemporalSchedule` so `chant state sn
 
 See **[Watching State](/chant/guide/watching-state/)** for the full walk-through: composite shape, generated workflow, Temporal UI filters (`Watch = "true"` / `Drift = "true"`), smoke-testing drift end-to-end, and how to triage each diff category. For the conceptual background on what drift means and why chant snapshots are observational, see [Drift Detection](/chant/concepts/drift-detection/).
 
+## Reconcile (cloud → code)
+
+The `ReconcileOp` composite takes the next step on the dial: when live drifts from declarations, open a PR that regenerates the affected TypeScript. Phases are **snapshot → plan → regenerate → open PR** — the plan is `chant state plan`, and the regenerate-and-PR step is the `reconcilePr` activity.
+
+```typescript
+import { ReconcileOp } from "@intentius/chant-lexicon-temporal";
+
+// one-shot on the local executor
+export const { op } = ReconcileOp({ name: "prod-reconcile", env: "prod" });
+
+// scheduled on Temporal, owned-only
+export const { op, schedule } = ReconcileOp({
+  name: "prod-reconcile",
+  env: "prod",
+  schedule: "0 * * * *",       // hourly
+  scope: { owned: true },
+  onDrift: "pull-request",      // or "issue" | "report"
+});
+```
+
+Run `chant run prod-reconcile` for a one-shot reconcile on the local executor; give it a `schedule` to run continuously on Temporal, where the cron and run history are the value (as with `WatchOp`). The primitives need no executor — only the scheduled, durable form requires Temporal.
+
 ## Op dependencies
 
 `depends` declares Ops that must succeed before this one starts. `chant build` validates all referenced names exist at build time.

--- a/lexicons/temporal/src/composites/composites.test.ts
+++ b/lexicons/temporal/src/composites/composites.test.ts
@@ -6,6 +6,7 @@ import { describe, test, expect } from "vitest";
 import { TemporalDevStack } from "./dev-stack";
 import { TemporalCloudStack } from "./cloud-stack";
 import { WatchOp } from "./watch-op";
+import { ReconcileOp } from "./reconcile-op";
 import { serializeOps } from "../op/serializer";
 import { DECLARABLE_MARKER } from "@intentius/chant/declarable";
 
@@ -229,5 +230,54 @@ describe("WatchOp: serialization", () => {
     // Diff result captured + Drift search attribute auto-emitted
     expect(wf).toContain("const __r0 = await stateDiff(");
     expect(wf).toContain('upsertSearchAttributes({ "Drift": [String(__r0?.drifted)] });');
+  });
+});
+
+// ── ReconcileOp ──────────────────────────────────────────────────────
+
+describe("ReconcileOp: shape", () => {
+  test("one-shot (no schedule) returns op only", () => {
+    const result = ReconcileOp({ name: "prod-reconcile", env: "prod" });
+    expect(result.op).toBeDefined();
+    expect(result.schedule).toBeUndefined();
+    expect(getEntityType(result.op)).toBe("Temporal::Op");
+    expect((result.op as Record<symbol, unknown>)[DECLARABLE_MARKER]).toBe(true);
+  });
+
+  test("with schedule returns op + schedule", () => {
+    const result = ReconcileOp({ name: "prod-reconcile", env: "prod", schedule: "0 * * * *" });
+    expect(result.op).toBeDefined();
+    expect(result.schedule).toBeDefined();
+    expect(getEntityType(result.schedule)).toBe("Temporal::Schedule");
+  });
+});
+
+describe("ReconcileOp: configuration", () => {
+  test("phases are Snapshot → Plan → Reconcile with the right activities", () => {
+    const { op } = ReconcileOp({ name: "p", env: "prod" });
+    const phases = (getProps(op).phases as Array<Record<string, unknown>>) ?? [];
+    expect(phases.map((p) => p.name)).toEqual(["Snapshot", "Plan", "Reconcile"]);
+    const reconcileStep = (phases[2].steps as Array<Record<string, unknown>>)[0];
+    expect(reconcileStep.fn).toBe("reconcilePr");
+    expect(reconcileStep.args).toEqual({ env: "prod", mode: "pull-request", owned: false });
+  });
+
+  test("scope.owned + onDrift flow into the reconcilePr step", () => {
+    const { op } = ReconcileOp({ name: "p", env: "prod", onDrift: "issue", scope: { owned: true } });
+    const phases = getProps(op).phases as Array<Record<string, unknown>>;
+    const reconcileStep = (phases[2].steps as Array<Record<string, unknown>>)[0];
+    expect(reconcileStep.args).toEqual({ env: "prod", mode: "issue", owned: true });
+  });
+
+  test("auto-emit search attrs include Reconcile + Env", () => {
+    const { op } = ReconcileOp({ name: "p", env: "prod" });
+    expect(getProps(op).searchAttributes).toEqual({ Reconcile: "true", Env: "prod" });
+  });
+
+  test("Plan phase surfaces Drift as a search attribute", () => {
+    const { op } = ReconcileOp({ name: "p", env: "prod" });
+    const phases = getProps(op).phases as Array<Record<string, unknown>>;
+    const diffStep = (phases[1].steps as Array<Record<string, unknown>>)[0];
+    expect(diffStep.outcomeAttribute).toEqual({ name: "Drift", from: "drifted" });
   });
 });

--- a/lexicons/temporal/src/composites/reconcile-op.ts
+++ b/lexicons/temporal/src/composites/reconcile-op.ts
@@ -1,0 +1,112 @@
+/**
+ * ReconcileOp composite — the cloud → code workflow as an Op.
+ *
+ * Keeps source tracking reality: when live drifts from declarations, open a PR
+ * that regenerates the affected TypeScript. Mirrors the {@link WatchOp} shape.
+ *
+ * Phases: snapshot → plan → regenerate (live import) → open PR. The
+ * regenerate-and-PR step is the `reconcilePr` activity (#122), which derives
+ * the change set from `chant state plan` and opens a reviewable PR.
+ *
+ * Runs on the local Op executor for a one-shot `chant run`; on Temporal when a
+ * `schedule` is given (the cron + run history are the value, as with WatchOp).
+ *
+ * @example
+ * ```typescript
+ * // one-shot, local executor
+ * export const { op } = ReconcileOp({ name: "prod-reconcile", env: "prod" });
+ *
+ * // scheduled on Temporal
+ * export const { op, schedule } = ReconcileOp({
+ *   name: "prod-reconcile",
+ *   env: "prod",
+ *   schedule: "0 * * * *",        // hourly
+ *   scope: { owned: true },
+ * });
+ * ```
+ *
+ * @see #112 — stateless-authoritative state model + live import
+ */
+
+import { Op, phase, activity, OpResource } from "@intentius/chant/op";
+import { TemporalSchedule } from "../resources";
+import type { ReconcileMode } from "../op/activities/reconcile";
+
+function kebabToCamel(s: string): string {
+  return s.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+export interface ReconcileOpConfig {
+  /** Op name (kebab-case). Used as workflow function name, task queue, schedule id base. */
+  name: string;
+  /** Environment to reconcile (e.g. "prod"). */
+  env: string;
+  /**
+   * Cron expression. When set, a TemporalSchedule fires the workflow; omit for
+   * one-shot `chant run` on the local executor.
+   */
+  schedule?: string;
+  /**
+   * What to produce on drift. Default: "pull-request".
+   * @default "pull-request"
+   */
+  onDrift?: ReconcileMode;
+  /** Restrict reconciliation to chant-owned resources. */
+  scope?: { owned?: boolean };
+  /** Override the task queue. Defaults to `name`. */
+  taskQueue?: string;
+}
+
+export interface ReconcileOpResources {
+  /** Op resource — generates the snapshot→plan→regenerate→PR workflow. */
+  op: InstanceType<typeof OpResource>;
+  /** Temporal schedule, present only when `schedule` was given. */
+  schedule?: InstanceType<typeof TemporalSchedule>;
+}
+
+export function ReconcileOp(config: ReconcileOpConfig): ReconcileOpResources {
+  const taskQueue = config.taskQueue ?? config.name;
+  const onDrift = config.onDrift ?? "pull-request";
+  const owned = config.scope?.owned ?? false;
+
+  const op = Op({
+    name: config.name,
+    overview: `Reconcile the ${config.env} environment into source (cloud → code)`,
+    taskQueue,
+    searchAttributes: {
+      Reconcile: "true",
+      Env: config.env,
+    },
+    phases: [
+      phase("Snapshot", [activity("stateSnapshot", { env: config.env })]),
+      phase("Plan", [
+        {
+          kind: "activity",
+          fn: "stateDiff",
+          args: { env: config.env, live: true },
+          outcomeAttribute: { name: "Drift", from: "drifted" },
+        },
+      ]),
+      phase("Reconcile", [
+        // reconcilePr derives the change set from `chant state plan`,
+        // regenerates via `chant import --from`, and opens a PR.
+        activity("reconcilePr", { env: config.env, mode: onDrift, owned }),
+      ]),
+    ],
+  });
+
+  if (!config.schedule) {
+    return { op };
+  }
+
+  const schedule = new TemporalSchedule({
+    scheduleId: `${config.name}-schedule`,
+    spec: { cronExpressions: [config.schedule] },
+    action: {
+      workflowType: kebabToCamel(config.name) + "Workflow",
+      taskQueue,
+    },
+  } as Record<string, unknown>);
+
+  return { op, schedule };
+}

--- a/lexicons/temporal/src/index.ts
+++ b/lexicons/temporal/src/index.ts
@@ -29,6 +29,8 @@ export { TemporalCloudStack } from "./composites/cloud-stack";
 export type { TemporalCloudStackConfig, TemporalCloudStackResources } from "./composites/cloud-stack";
 export { WatchOp } from "./composites/watch-op";
 export type { WatchOpConfig, WatchOpResources } from "./composites/watch-op";
+export { ReconcileOp } from "./composites/reconcile-op";
+export type { ReconcileOpConfig, ReconcileOpResources } from "./composites/reconcile-op";
 
 // Op builders (re-exported from core for single-import convenience)
 export {

--- a/lexicons/temporal/src/op/activities/reconcile.test.ts
+++ b/lexicons/temporal/src/op/activities/reconcile.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { reconcilePr, reconcileSummary, reconcileBranchName } from "./reconcile";
+import { reconcilePr, reconcileSummary, reconcileBranchName, entriesFromPlan } from "./reconcile";
 
 const entries = [
   { name: "bucket", action: "adopt", type: "AWS::S3::Bucket" },
@@ -23,6 +23,27 @@ describe("reconcileSummary (#122)", () => {
 
   test("handles an empty entry set", () => {
     expect(reconcileSummary("prod", [])).toContain("_(none)_");
+  });
+});
+
+describe("entriesFromPlan (#123)", () => {
+  test("maps a ChangeSet, dropping noop entries", () => {
+    const plan = JSON.stringify({
+      env: "prod",
+      entries: [
+        { name: "a", action: "create", type: "T1", evidence: {}, ownership: "unknown" },
+        { name: "b", action: "noop", type: "T2", evidence: {}, ownership: "unknown" },
+        { name: "c", action: "delete", type: "T3", evidence: {}, ownership: "owned" },
+      ],
+    });
+    expect(entriesFromPlan(plan)).toEqual([
+      { name: "a", action: "create", type: "T1" },
+      { name: "c", action: "delete", type: "T3" },
+    ]);
+  });
+
+  test("tolerates an empty / entry-less plan", () => {
+    expect(entriesFromPlan(JSON.stringify({ env: "prod" }))).toEqual([]);
   });
 });
 

--- a/lexicons/temporal/src/op/activities/reconcile.ts
+++ b/lexicons/temporal/src/op/activities/reconcile.ts
@@ -19,8 +19,12 @@ export interface ReconcileEntry {
 export interface ReconcilePrArgs {
   /** Environment to reconcile from (passed to `chant import --from`). */
   env: string;
-  /** The change-set entries that triggered this reconcile. */
-  entries: ReconcileEntry[];
+  /**
+   * The change-set entries that triggered this reconcile. Omit to derive them
+   * from `chant state plan <env> --json` at run time — the form used inside a
+   * workflow, where the entries aren't known until the activity runs.
+   */
+  entries?: ReconcileEntry[];
   /** What to produce. Default: pull-request. */
   mode?: ReconcileMode;
   /** Output directory for regenerated source. Default: ./infra. */
@@ -82,6 +86,33 @@ function shellQuote(s: string): string {
 }
 
 /**
+ * Map a `chant state plan --json` ChangeSet to reconcile entries, dropping
+ * `noop` entries (nothing to reconcile). Pure — exported for testing.
+ */
+export function entriesFromPlan(planJson: string): ReconcileEntry[] {
+  const cs = JSON.parse(planJson) as {
+    entries?: Array<{ name: string; action: string; type?: string }>;
+  };
+  return (cs.entries ?? [])
+    .filter((e) => e.action !== "noop")
+    .map((e) => ({ name: e.name, action: e.action, type: e.type }));
+}
+
+/** Derive reconcile entries from `chant state plan`. */
+async function derivePlanEntries(
+  env: string,
+  owned: boolean,
+  signal?: AbortSignal,
+): Promise<ReconcileEntry[]> {
+  const ownedFlag = owned ? " --owned" : "";
+  const { stdout } = await execAsync(
+    `chant state plan ${shellQuote(env)}${ownedFlag} --json`,
+    { signal },
+  );
+  return entriesFromPlan(stdout);
+}
+
+/**
  * Reconcile activity: turn regenerated TypeScript into a reviewable artifact.
  *
  * - `report` — return the summary only; no git, no network.
@@ -94,11 +125,13 @@ function shellQuote(s: string): string {
  */
 export async function reconcilePr(args: ReconcilePrArgs, signal?: AbortSignal): Promise<ReconcileResult> {
   const mode = args.mode ?? "pull-request";
-  const summary = reconcileSummary(args.env, args.entries);
-  const title = args.title ?? `Reconcile ${args.env}: ${args.entries.length} change(s) from live`;
+  const owned = args.owned ?? false;
+  const entries = args.entries ?? (await derivePlanEntries(args.env, owned, signal));
+  const summary = reconcileSummary(args.env, entries);
+  const title = args.title ?? `Reconcile ${args.env}: ${entries.length} change(s) from live`;
 
   if (mode === "report") {
-    return { mode, summary, entries: args.entries };
+    return { mode, summary, entries };
   }
 
   if (mode === "issue") {
@@ -106,13 +139,13 @@ export async function reconcilePr(args: ReconcilePrArgs, signal?: AbortSignal): 
       `gh issue create --title ${shellQuote(title)} --body ${shellQuote(summary)}`,
       { signal },
     );
-    return { mode, summary, entries: args.entries, issueUrl: stdout.trim() };
+    return { mode, summary, entries, issueUrl: stdout.trim() };
   }
 
   // pull-request
   const branch = args.branch ?? reconcileBranchName(args.env);
   const output = args.output ?? "./infra";
-  const ownedFlag = args.owned ? " --owned" : "";
+  const ownedFlag = owned ? " --owned" : "";
 
   // Never touch the main branch: cut a fresh branch first.
   await execAsync(`git checkout -b ${shellQuote(branch)}`, { signal });
@@ -128,5 +161,5 @@ export async function reconcilePr(args: ReconcilePrArgs, signal?: AbortSignal): 
     { signal },
   );
 
-  return { mode, branch, summary, entries: args.entries, prUrl: stdout.trim() };
+  return { mode, branch, summary, entries, prUrl: stdout.trim() };
 }


### PR DESCRIPTION
The `cloud → code` workflow as an Op composite — keep source tracking reality by opening PRs when live drifts from declarations. Mirrors the `WatchOp` shape.

## What

- `ReconcileOp({ name, env, schedule?, onDrift?, scope? })` returns an `Op` (plus a `TemporalSchedule` when `schedule` is set). Phases: **snapshot → plan → regenerate (live import) → open PR**.
- `scope: { owned: true }` restricts reconciliation to chant-owned resources; `onDrift` selects the `reconcilePr` mode (`pull-request` | `issue` | `report`).
- No `schedule` → `op` only, for one-shot `chant run` on the local executor. With a `schedule` → `op` + `TemporalSchedule` for continuous runs (cron + run history are the value, as with `WatchOp`).
- The `reconcilePr` activity (#122) now derives the change set from `chant state plan <env> --json` when `entries` aren't supplied — the in-workflow form, since Op steps pass static args. `entriesFromPlan()` maps a ChangeSet to reconcile entries, dropping `noop`.

## Tests

- `composites.test.ts` (+7): one-shot vs scheduled shape, phase wiring (`stateSnapshot`/`stateDiff`/`reconcilePr`), `scope.owned` + `onDrift` flow-through, `Reconcile`/`Env` + `Drift` search attributes.
- `reconcile.test.ts` (+2): `entriesFromPlan` maps and drops `noop`, tolerates entry-less plan.

## Docs

`guide/ops.mdx`: new "Reconcile (cloud → code)" section with one-shot and scheduled examples.

Part of #112. Closes #123.