### PR TITLE
feat(temporal): approval gates + compensation for destructive apply

### DIFF
--- a/docs/src/content/docs/guide/ops.mdx
+++ b/docs/src/content/docs/guide/ops.mdx
@@ -276,7 +276,17 @@ export const { op } = ApplyOp({
 });
 ```
 
-`delete` controls how apply treats resources no longer declared. Deletes ride the target's **native** delete path scoped to the ownership marker — `kubectl apply --prune --selector app.kubernetes.io/managed-by=chant`, the CloudFormation stack boundary, or ARM `--mode Complete`. Because the prune is marker-scoped, a foreign (unmarked) resource is never touched: deletes are owned-only by construction. An ungated apply may run on the local executor; `delete: "gated"` (or an explicit `gate`) inserts an approval phase before the destructive apply — that gate becomes durable on Temporal ([durable workflows](/chant/concepts/durable-workflows/)).
+`delete` controls how apply treats resources no longer declared. Deletes ride the target's **native** delete path scoped to the ownership marker — `kubectl apply --prune --selector app.kubernetes.io/managed-by=chant`, the CloudFormation stack boundary, or ARM `--mode Complete`. Because the prune is marker-scoped, a foreign (unmarked) resource is never touched: deletes are owned-only by construction.
+
+### Gates and compensation — where Temporal is load-bearing
+
+A destructive apply is exactly where durability matters, and where `ApplyOp` leans on Temporal:
+
+- **Approval gate** — `delete: "gated"` (or an explicit `gate`) inserts an Approve phase before the apply. On Temporal this is a durable wait-for-signal: it survives a worker crash and can hold for hours or days without keeping a process open. The local executor cannot.
+- **Compensation** — a destructive apply defaults to an `onFailure` Rollback phase (a `compensateApply` activity), so a partial failure unwinds instead of leaving the cloud half-applied. CloudFormation rolls back natively; for kubectl/ARM, pass `compensate: { command }` (e.g. `kubectl rollout undo …`) — without one, compensation warns rather than silently doing nothing. Set `compensate: false` to opt out.
+- **Crash-resume + audit** — the workflow resumes from the last completed step with no double-acting, and the workflow history is the audit trail.
+
+An ungated, additive apply needs none of this and runs on the local executor. See [Durable Workflows](/chant/concepts/durable-workflows/) for why infra apply wants durable execution — and why it stays optional.
 
 ## Op dependencies
 

--- a/lexicons/temporal/src/composites/apply-op.ts
+++ b/lexicons/temporal/src/composites/apply-op.ts
@@ -51,6 +51,13 @@ export interface ApplyOpConfig {
    * set explicitly. Omit `signalName` to default to `approve-<name>`.
    */
   gate?: { signalName?: string; timeout?: string; description?: string };
+  /**
+   * Saga-style rollback on partial apply failure, run as an `onFailure` phase.
+   * Defaults on whenever the apply is destructive (`delete !== "never"`). Pass
+   * `{ command }` to supply a rollback command for targets without a native one
+   * (kubectl, ARM); `false` to disable.
+   */
+  compensate?: boolean | { command?: string };
   /** Override the task queue. Defaults to `name`. */
   taskQueue?: string;
 }
@@ -97,6 +104,13 @@ export function ApplyOp(config: ApplyOpConfig): ApplyOpResources {
     ]),
   );
 
+  // Compensation defaults on for destructive applies — a partial failure should
+  // unwind rather than leave the cloud half-applied.
+  const compensateDefault = deleteMode !== "never";
+  const compensateEnabled = config.compensate === undefined ? compensateDefault : config.compensate !== false;
+  const compensateCommand =
+    typeof config.compensate === "object" ? config.compensate.command : undefined;
+
   const op = Op({
     name: config.name,
     overview: `Apply declared source to the ${config.env} environment (code → cloud)`,
@@ -106,6 +120,19 @@ export function ApplyOp(config: ApplyOpConfig): ApplyOpResources {
       Env: config.env,
     },
     phases,
+    ...(compensateEnabled
+      ? {
+          onFailure: [
+            phase("Rollback", [
+              activity("compensateApply", {
+                target,
+                env: config.env,
+                ...(compensateCommand ? { command: compensateCommand } : {}),
+              }),
+            ]),
+          ],
+        }
+      : {}),
   });
 
   return { op };

--- a/lexicons/temporal/src/composites/composites.test.ts
+++ b/lexicons/temporal/src/composites/composites.test.ts
@@ -337,3 +337,36 @@ describe("ApplyOp: gating + deletes", () => {
     expect(getProps(op).searchAttributes).toEqual({ Apply: "true", Env: "prod" });
   });
 });
+
+describe("ApplyOp: compensation (#125)", () => {
+  test("destructive apply adds an onFailure Rollback phase by default", () => {
+    const { op } = ApplyOp({ name: "p", env: "prod", delete: "owned-only" });
+    const onFailure = getProps(op).onFailure as Array<Record<string, unknown>> | undefined;
+    expect(onFailure?.map((p) => p.name)).toEqual(["Rollback"]);
+    const step = (onFailure![0].steps as Array<Record<string, unknown>>)[0];
+    expect(step.fn).toBe("compensateApply");
+    expect(step.args).toEqual({ target: "kubectl", env: "prod" });
+  });
+
+  test("additive apply has no compensation by default", () => {
+    const { op } = ApplyOp({ name: "p", env: "prod", delete: "never" });
+    expect(getProps(op).onFailure).toBeUndefined();
+  });
+
+  test("compensate: false disables rollback even when destructive", () => {
+    const { op } = ApplyOp({ name: "p", env: "prod", delete: "owned-only", compensate: false });
+    expect(getProps(op).onFailure).toBeUndefined();
+  });
+
+  test("compensate.command supplies a rollback for targets without a native one", () => {
+    const { op } = ApplyOp({
+      name: "p",
+      env: "prod",
+      target: "kubectl",
+      compensate: { command: "kubectl rollout undo deployment/web" },
+    });
+    const onFailure = getProps(op).onFailure as Array<Record<string, unknown>>;
+    const step = (onFailure[0].steps as Array<Record<string, unknown>>)[0];
+    expect((step.args as Record<string, unknown>).command).toBe("kubectl rollout undo deployment/web");
+  });
+});

--- a/lexicons/temporal/src/op/activities/apply.test.ts
+++ b/lexicons/temporal/src/op/activities/apply.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { applyCommand } from "./apply";
+import { applyCommand, rollbackCommand } from "./apply";
 
 describe("applyCommand (#124)", () => {
   test("kubectl never → plain apply, no prune", () => {
@@ -37,5 +37,18 @@ describe("applyCommand (#124)", () => {
     // unscoped delete command, so a foreign (unmarked) resource is never pruned.
     const cmd = applyCommand("kubectl", "prod", "dist", "owned-only");
     expect(cmd).toContain("managed-by=chant");
+  });
+});
+
+describe("rollbackCommand (#125)", () => {
+  test("cloudformation has a native rollback", () => {
+    expect(rollbackCommand("cloudformation", "prod")).toBe(
+      "aws cloudformation rollback-stack --stack-name prod",
+    );
+  });
+
+  test("kubectl / arm have no native single-command rollback", () => {
+    expect(rollbackCommand("kubectl", "prod")).toBeUndefined();
+    expect(rollbackCommand("arm", "rg")).toBeUndefined();
   });
 });

--- a/lexicons/temporal/src/op/activities/apply.ts
+++ b/lexicons/temporal/src/op/activities/apply.ts
@@ -79,3 +79,50 @@ export async function nativeApply(args: NativeApplyArgs, signal?: AbortSignal): 
   if (stderr) console.error(stderr);
   return { command };
 }
+
+/**
+ * The native rollback command for a target, or undefined when the target has
+ * no single-command rollback. Pure — exported for testing.
+ *
+ * Only CloudFormation has a native "return to last known good state" command.
+ * For kubectl/ARM the caller must supply a rollback command; otherwise the
+ * compensation degrades to a logged warning rather than silently doing nothing.
+ */
+export function rollbackCommand(target: ApplyTarget, env: string): string | undefined {
+  switch (target) {
+    case "cloudformation":
+      return `aws cloudformation rollback-stack --stack-name ${env}`;
+    case "kubectl":
+    case "arm":
+      return undefined;
+  }
+}
+
+export interface CompensateApplyArgs {
+  /** Native mechanism that was applied. */
+  target: ApplyTarget;
+  /** Environment — CFN stack name / ARM resource group. */
+  env: string;
+  /** Explicit rollback command, used in preference to the native default. */
+  command?: string;
+}
+
+/**
+ * Compensation step (saga rollback) for a partial apply failure. Runs the
+ * explicit `command` if given, else the target's native rollback. Where no
+ * automatic rollback exists, it warns rather than silently no-op'ing — partial
+ * state should never look reverted when it isn't.
+ */
+export async function compensateApply(args: CompensateApplyArgs, signal?: AbortSignal): Promise<{ command?: string }> {
+  const command = args.command ?? rollbackCommand(args.target, args.env);
+  if (!command) {
+    console.warn(
+      `[apply] no automatic rollback for target "${args.target}" — partial apply to ${args.env} was NOT reverted; supply compensate.command to enable rollback`,
+    );
+    return {};
+  }
+  const { stdout, stderr } = await execAsync(command, { signal });
+  if (stdout) console.log(stdout);
+  if (stderr) console.error(stderr);
+  return { command };
+}

--- a/lexicons/temporal/src/op/activities/index.ts
+++ b/lexicons/temporal/src/op/activities/index.ts
@@ -25,5 +25,5 @@ export type { ChantTeardownArgs } from "./teardown";
 export { reconcilePr } from "./reconcile";
 export type { ReconcilePrArgs, ReconcileResult, ReconcileMode, ReconcileEntry } from "./reconcile";
 
-export { nativeApply } from "./apply";
-export type { NativeApplyArgs, ApplyTarget, DeleteMode } from "./apply";
+export { nativeApply, compensateApply } from "./apply";
+export type { NativeApplyArgs, CompensateApplyArgs, ApplyTarget, DeleteMode } from "./apply";


### PR DESCRIPTION
The durability-critical half of apply: human approval gates and rollback. This is where Temporal is load-bearing — the local executor cannot hold a multi-hour approval wait or survive a crash mid-apply. Builds on #124.

## What

- **Compensation** — a destructive `ApplyOp` (`delete !== "never"`) defaults to an `onFailure` Rollback phase running a `compensateApply` activity (saga-style rollback), so a partial failure unwinds instead of leaving the cloud half-applied. `compensate: false` opts out; `compensate: { command }` supplies a rollback for targets without a native one.
- **`compensateApply` activity** — delegates to native rollback (`aws cloudformation rollback-stack`); for kubectl/ARM there is no native single-command rollback, so it runs the supplied `command`, or **warns** rather than silently no-op'ing (partial state should never look reverted when it isn't). `rollbackCommand()` is pure and tested.
- **Approval gate** (from #124) is the durable wait-for-signal; on Temporal it survives a worker crash and can hold for days. **Crash-resume** with no double-acting and the **workflow history as audit trail** are inherent to the Temporal Op codegen.

## Tests

- `apply.test.ts` (+2): `rollbackCommand` — CloudFormation native, kubectl/ARM undefined.
- `composites.test.ts` (+4): destructive apply adds `onFailure` Rollback by default; additive apply has none; `compensate: false` disables; `compensate.command` flows through.

## Docs

`guide/ops.mdx`: "Gates and compensation — where Temporal is load-bearing" subsection (durable wait, saga rollback, crash-resume + audit), with the local-executor-for-additive note.

Part of #112. Closes #125.