### PR TITLE
docs: concepts/state-models page (three-axis model + dial)

### DIFF
--- a/docs/src/content/docs/concepts/comparison.mdx
+++ b/docs/src/content/docs/concepts/comparison.mdx
@@ -11,6 +11,8 @@ chant **doesn't manage deployment or drift**. chant's core scope is synthesis: p
 
 This isn't a reaction to other tools' failures — it's an approach that was always available. Nobody built it because the industry was racing to own the full lifecycle. chant does one thing and stops.
 
+For the model behind the rows below — the three axes of state and where each tool sits — see [State Models](/chant/concepts/state-models/).
+
 **The agentic angle:** the operational layer — deploying, monitoring, remediating — is increasingly handled by agents and automation. chant handles the part that should be deterministic and auditable: turning typed declarations into spec-native output. The two layers are complementary.
 
 ## Nobody sells you a lifecycle

--- a/docs/src/content/docs/concepts/drift-detection.mdx
+++ b/docs/src/content/docs/concepts/drift-detection.mdx
@@ -5,7 +5,7 @@ description: Why chant's snapshots are observational, what the diff categories m
 
 import { Aside } from '@astrojs/starlight/components';
 
-Drift is the gap between what you declared in source and what's actually deployed. Most IaC tools track this through an authoritative state file — chant doesn't. This page explains the model, the diff vocabulary, and when (and when not) to invest in continuous drift detection.
+Drift is the gap between what you declared in source and what's actually deployed. Most IaC tools track this through an authoritative state file — chant doesn't. This page explains the model, the diff vocabulary, and when (and when not) to invest in continuous drift detection. For where this sits in the broader model — the dial from observe to reconcile to authoritative — see [State Models](/chant/concepts/state-models/).
 
 ## The observational snapshot model
 

--- a/docs/src/content/docs/concepts/governance.mdx
+++ b/docs/src/content/docs/concepts/governance.mdx
@@ -5,7 +5,7 @@ description: Why governance, not authoritative state, is what IaC depends on
 
 State is essential. That is not in dispute. But essential is not the same as authoritative. The properties teams depend on are governance properties, and most of them survive without an authoritative state file.
 
-This page explains where chant draws that line. For the tool-by-tool comparison see [How chant compares](/chant/concepts/comparison/). For the snapshot and diff mechanism see [Drift Detection](/chant/concepts/drift-detection/).
+This page explains where chant draws that line. For the model that places chant on the three axes of state — where truth lives, reconciliation direction, and who answers "is this mine?" — see [State Models](/chant/concepts/state-models/). For the tool-by-tool comparison see [How chant compares](/chant/concepts/comparison/). For the snapshot and diff mechanism see [Drift Detection](/chant/concepts/drift-detection/).
 
 ## What a state file actually costs
 

--- a/docs/src/content/docs/concepts/state-models.mdx
+++ b/docs/src/content/docs/concepts/state-models.mdx
@@ -1,0 +1,73 @@
+---
+title: State Models
+description: The three axes that describe any state model, and where chant sits on each — truth in the live system, reconciliation chosen per environment, ownership answered by live markers.
+---
+
+Every infrastructure tool takes a position on state, usually implicitly. This page makes the axes explicit so the rest of the docs can point here instead of re-deriving the argument. For the cost side of the trade — what a state file actually buys and charges — see [State and Governance](/chant/concepts/governance/).
+
+## Three axes
+
+Any state model is a point in a three-dimensional space.
+
+### 1. Where truth lives
+
+| Truth lives in… | Called | Examples |
+|---|---|---|
+| A state file | Authoritative | Terraform, Pulumi |
+| The live system | Observational | query the cloud, diff against a snapshot |
+| The source code | Source-as-truth | GitOps reconcilers |
+
+### 2. Reconciliation direction
+
+| Direction | Name | What it does |
+|---|---|---|
+| `code → cloud` | Apply | push declared source into the live system |
+| `cloud → code` | Sync | pull live reality back into source (open PRs) |
+| none | Observe | report drift, change nothing |
+
+### 3. Who answers "is this mine?"
+
+| Answered by | Mechanism |
+|---|---|
+| A trusted state file | the tool consults its own record |
+| A live ownership marker | a tag/label on the cloud resource |
+| Nobody | the tool escalates rather than guessing |
+
+This third axis is the one most tools collapse into the first: they answer "is this mine?" from the same state file they host. chant separates them on purpose.
+
+## Where chant sits
+
+- **Truth is the live system.** chant reads the cloud directly. The snapshot it stores is evidence for diffing, never a source of truth.
+- **Reconciliation direction is a per-environment choice.** A dev environment might only observe; staging might reconcile `cloud → code`; production might apply `code → cloud` behind a gate. Same project, different dial positions.
+- **Ownership is answered by live markers.** A chant-managed resource carries a [marker](/chant/configuration/config-file/#ownership) — a standard tag or label — that records the stack identity on the resource itself. "Is this mine?" is answered by reading that marker, never by a record chant has to lock.
+
+## The dial
+
+The three axes collapse, in practice, into one dial chosen per environment:
+
+```
+observe  →  reconcile  →  authoritative
+(report)    (cloud→code   (code→cloud
+             PRs)          apply)
+```
+
+- **observe** — `chant state diff --live` / `WatchOp`. Detect drift, change nothing.
+- **reconcile** — `ReconcileOp`. Open PRs that pull live reality back into source.
+- **authoritative** — `ApplyOp`. Push declared source into the cloud, deleting owned orphans.
+
+You turn the dial up per environment as trust and tooling allow. Nothing forces an environment past the position you chose for it.
+
+## The invariant that keeps it honest
+
+There is exactly one rule that prevents this model from quietly becoming the thing it avoids:
+
+> The projection reads ownership from the live marker, never from the snapshot.
+
+The moment a *mutation* trusts the snapshot — uses it to decide what to create, update, or delete — the snapshot becomes load-bearing, and you have rebuilt an authoritative state file under a different name, with all its costs. chant's change set ([`chant state plan`](/chant/cli/state/)) reads ownership only from the live resource. The snapshot can be deleted between runs with no change in behavior. That is the test, and chant holds to it by construction.
+
+## See also
+
+- [State and Governance](/chant/concepts/governance/) — what a state file costs, and why governance is the part that matters
+- [Drift Detection](/chant/concepts/drift-detection/) — the observe position, in depth
+- [How chant compares](/chant/concepts/comparison/) — these axes mapped across tools
+- [Ops](/chant/guide/ops/) — the reconcile (`ReconcileOp`) and apply (`ApplyOp`) workflows


### PR DESCRIPTION
New canonical concepts page for how chant thinks about state.

## What
- `concepts/state-models.mdx`: the three axes (where truth lives / reconciliation direction / who answers "is this mine?"), chant's position on each, the **observe → reconcile → authoritative** dial chosen per environment, and the load-bearing invariant (projection reads ownership from the live marker, never the snapshot).
- Cross-links added from `governance`, `drift-detection`, and `comparison` so one page owns the model.

Docs only. Sidebar entry lands in #129. All internal links verified against existing pages.

Part of #112. Closes #126.