### PR TITLE
docs: revise governance + comparison (retire 'no plan' concession)

### DIFF
--- a/docs/src/content/docs/concepts/comparison.mdx
+++ b/docs/src/content/docs/concepts/comparison.mdx
@@ -35,7 +35,8 @@ These tools make different design decisions. Each decision has consequences — 
 | **Spec fidelity** | Provider-mapped | Abstracted (L2/L3) | Provider-mapped | Spec-true |
 | **Output** | State + API calls | CloudFormation | State + API calls | Native spec output |
 | **Lifecycle scope** | Full | Full (via CloudFormation) | Full | Synthesis + opt-in observability |
-| **State model** | Authoritative | Authoritative (via CloudFormation) | Authoritative | Non-authoritative (observational) |
+| **State model** | Authoritative | Authoritative (via CloudFormation) | Authoritative | No authoritative state file; precise change set via live projection + cloud-side ownership |
+| **Reconciliation** | `code → cloud` | `code → cloud` | `code → cloud` | none / `code → cloud` / `cloud → code` (chosen per environment) |
 | **Determinism** | Mostly | No (code executes) | No (code executes) | Yes (for lint-conforming source) |
 | **Walk-away cost** | High (state, HCL) | Medium (CloudFormation remains) | High (state, SDK) | Zero (output is native) |
 | **Semantic validation** | None built-in | None built-in | None built-in | Built-in (lexicon rules) |
@@ -72,7 +73,7 @@ The most consequential design difference after execution model is the state mode
 
 **CDK** inherits CloudFormation's authoritative state model, which AWS manages as a service. Less operational burden, but the same architectural commitment: state is truth.
 
-**chant** is designed with an observational state model — snapshots record what was observed at a point in time, not what must be true now. This architectural choice gives up precision (no automatic plan/apply) but gains safety and simplicity:
+**chant** is designed with an observational state model — snapshots record what was observed at a point in time, not what must be true now. It does not give up the precise change set, though: chant computes a create/update/delete plan against the live system using [cloud-side ownership markers](/chant/configuration/config-file/#ownership) rather than a hosted state file. What it drops is the *authoritative file*, and with it the costs:
 
 - **No locking** — a stale snapshot is inconvenient, not dangerous
 - **No sensitive data** — scrubbing is a design requirement, not a best-effort guideline
@@ -80,8 +81,8 @@ The most consequential design difference after execution model is the state mode
 - **Minimal overhead** — state is designed to live in git alongside source code
 
 **Trade-offs:**
-- Non-authoritative state means agents must verify against live APIs before acting, and gaps escalate to human review rather than being resolved automatically
-- Git-based state gives versioning, portability, and offline access, but no locking, no encryption at rest, and no access control separation from source code
+- Ownership is answered by a live marker on the resource, so the projection must query live APIs; a resource with no marker is `foreign` and escalates to human review rather than being auto-deleted
+- Git-based snapshots give versioning, portability, and offline access, but no locking, no encryption at rest, and no access control separation from source code
 
 ## What each tool optimizes for
 

--- a/docs/src/content/docs/concepts/governance.mdx
+++ b/docs/src/content/docs/concepts/governance.mdx
@@ -20,7 +20,7 @@ These are the costs of hosting an authoritative state file yourself. They are pr
 | Self-hosted (Terraform, Pulumi) | You run the backend | Full control, plus the lock, the backups, and the corruption risk |
 | Third-party SaaS | A vendor operates a state database for you | Operational burden gone, replaced by a vendor dependency and your state and secrets living in their system |
 | Platform-managed (CloudFormation, CDK) | The cloud hosts state as part of the service | No file to operate, in exchange for cloud lock-in and all-or-nothing applies |
-| Observational (chant) | No one, because state is a snapshot rather than a source of truth | No file to host or trust, in exchange for no automatic plan and apply |
+| Observational (chant) | No one, because state is a snapshot rather than a source of truth | No file to host or trust; the precise change set comes from live projection + cloud-side ownership instead |
 
 Every model except the last keeps authoritative state and only changes who operates it. The third-party tier is worth a closer look. It is usually a queryable database, sometimes the real-time graph people picture state evolving into. A faster, better-indexed source of truth is still a source of truth. It still has to be correct and current.
 
@@ -35,7 +35,7 @@ Separate the requirement from the mechanism. The properties a team cannot give u
 
 Authoritative state is one mechanism that provides these. It is not the only one. When state is called essential, the essential thing is usually the governance, and authoritative state is the tool that happened to deliver it.
 
-The observational model keeps the governance and drops the authority. Snapshots and diffs live in git, which gives audit and review. Linting runs on the static artifact before apply, which gives pre-apply validation. What is given up is automatic plan and apply, because without authoritative state chant cannot compute a precise change set the way Terraform does.
+The observational model keeps the governance and drops the authority. Snapshots and diffs live in git, which gives audit and review. Linting runs on the static artifact before apply, which gives pre-apply validation. And the change set is not given up: [`chant state plan`](/chant/cli/state/) computes a precise create/update/delete set against the live system, using [ownership markers](/chant/configuration/config-file/#ownership) that live on the cloud resource rather than in a hosted state file. The plan survives without the file — the marker, not a record chant has to lock, is what makes `delete` precise. This makes the thesis stronger, not weaker: the file was never the essential part, and now even the one capability it seemed to monopolize comes from projection instead. See [State Models](/chant/concepts/state-models/) for the full model.
 
 ## A diff, not a plan
 


### PR DESCRIPTION
Two pages said chant cannot compute a precise change set. Once `chant state plan` exists, that's no longer true.

## What
- **governance.mdx**: replaced "without authoritative state chant cannot compute a precise change set the way Terraform does" with the projection story — precise create/update/delete against live, using ownership markers on the cloud resource rather than a hosted file. Updated the spectrum table row. The existing thesis ("the file was never the essential part") gets stronger.
- **comparison.mdx**: rewrote the **State model** row to "no authoritative state file; precise change set via live projection + cloud-side ownership", added a **Reconciliation** row (none / code→cloud / cloud→code, per environment), and updated the prose + trade-offs to match shipped behavior.

No page now claims chant cannot produce a change set. Docs only.

Part of #112. Closes #127.