### PR TITLE
docs: drift-detection update + live-import & reconciling-state guides + authoring

### DIFF
--- a/docs/src/content/docs/concepts/drift-detection.mdx
+++ b/docs/src/content/docs/concepts/drift-detection.mdx
@@ -55,6 +55,13 @@ The diff engine compares three axes: what's declared in source now, what was obs
 
 Drifted entries include attribute-level deltas so you can see *what* changed, not just *that* something changed.
 
+#### Resolving an `orphan`
+
+An orphan is a resource in the cloud that source doesn't know about. Detection is the first position on the [dial](/chant/concepts/state-models/#the-dial); resolving it is the next. There are two moves:
+
+- **Adopt it into source.** Regenerate the resource as chant TypeScript with [live import](/chant/guide/live-import/): `chant import --from <env> --name <orphan>`. The orphan stops being a surprise and starts being declared — the [`ReconcileOp`](/chant/guide/reconciling-state/) workflow automates this as a PR.
+- **Delete it.** Only ever for a *chant-owned* orphan — one carrying the [ownership marker](/chant/configuration/config-file/#ownership). A foreign orphan (no marker) is never auto-deleted; it escalates to adopt-or-review. `chant state plan` classifies which is which, and `ApplyOp` deletes only the owned ones.
+
 ### Artifacts (two-way diff)
 
 There's no "declared" axis, so the engine just compares now-vs-then:

--- a/docs/src/content/docs/guide/live-import.mdx
+++ b/docs/src/content/docs/guide/live-import.mdx
@@ -1,0 +1,62 @@
+---
+title: Live Import
+description: Generate chant TypeScript from a running cloud or cluster with chant import --from — the cloud→code direction, and the way to adopt an orphaned resource back into source.
+---
+
+`chant import <template-file>` reads a template from disk. `chant import --from <env>` reads the **live** cloud or cluster instead, regenerating chant TypeScript from what is actually running. This is the `cloud → code` direction — the way to adopt infrastructure you didn't author, or pull an orphan back into source.
+
+## How it works
+
+```bash
+chant import --from prod --output src/
+```
+
+1. Resolve the environment the way [`chant state diff --live`](/chant/cli/state/) does.
+2. Call each project lexicon's `exportResources()` capability for full-fidelity config.
+3. Generate TypeScript with the same by-category organization as file import.
+
+Unlike `state`, which only ever reads scrubbed metadata, live import emits the resource's **full input config** — so it may surface secrets. The command prints a warning; review generated files before committing.
+
+## Selectors
+
+| Flag | Effect |
+|---|---|
+| `--type <ResourceType>` | only resources of this type |
+| `--name <name>` | only the resource with this name |
+| `-d, --lexicon <name>` | restrict to one lexicon (e.g. `aws`, `k8s`) |
+| `--owned` | only chant-owned resources (carrying the [ownership marker](/chant/configuration/config-file/#ownership)) |
+| `--verbatim` | keep server-defaulted fields instead of stripping to declared shape |
+
+## Per-provider fidelity
+
+Each lexicon reads live config its own way and strips it to the shape you would have authored:
+
+| Lexicon | Source | Stripped by default |
+|---|---|---|
+| AWS | `cloudformation get-template --template-stage Original` | nothing — the original template is already declared shape |
+| Kubernetes | `kubectl get <kinds> -A -o json` | `status`, `managedFields`, server metadata, server annotations |
+| GCP (Config Connector) | `kubectl get <*.cnrm.cloud.google.com> -A -o json` | `status`, server metadata, `cnrm.cloud.google.com/*` annotations |
+
+`--verbatim` keeps the stripped fields when you need an exact copy rather than a clean authoring starting point.
+
+## The adopt-an-orphan loop
+
+When [drift detection](/chant/concepts/drift-detection/) reports an `orphan` — something in the cloud that source doesn't declare — live import is how you adopt it:
+
+```bash
+# 1. see what's orphaned
+chant state plan prod
+
+# 2. regenerate the orphan as chant TypeScript
+chant import --from prod --name my-bucket --output src/
+
+# 3. review, commit — the orphan is now declared
+```
+
+To automate this across many resources as a reviewable PR, use the [`ReconcileOp`](/chant/guide/reconciling-state/) workflow, which runs exactly this loop and opens the PR for you.
+
+## See also
+
+- [Reconciling State](/chant/guide/reconciling-state/) — the reconcile and apply workflows
+- [State Models](/chant/concepts/state-models/) — where live import sits on the dial
+- [`chant import`](/chant/cli/import/) — the full CLI reference

--- a/docs/src/content/docs/guide/reconciling-state.mdx
+++ b/docs/src/content/docs/guide/reconciling-state.mdx
@@ -1,0 +1,75 @@
+---
+title: Reconciling State
+description: The two reconciliation directions — reconcile (cloud→code) and apply (code→cloud) — the dial as per-environment configuration, and when to pick each.
+---
+
+Drift detection tells you the cloud and your source disagree. Reconciliation closes the gap. There are two directions, and chant exposes each as an Op composite. Which one you reach for — and whether you reach for either — is the [dial](/chant/concepts/state-models/#the-dial), chosen per environment.
+
+```
+observe  →  reconcile  →  authoritative
+(report)    (cloud→code   (code→cloud
+             PRs)          apply)
+```
+
+## Reconcile — `cloud → code`
+
+When the live system is ahead of source — someone created or changed a resource by hand — pull reality *back into source* so declarations track it. [`ReconcileOp`](/chant/guide/ops/#reconcile-cloud--code) does this by opening a PR:
+
+```typescript
+import { ReconcileOp } from "@intentius/chant-lexicon-temporal";
+
+export const { op, schedule } = ReconcileOp({
+  name: "prod-reconcile",
+  env: "prod",
+  schedule: "0 * * * *",      // hourly, on Temporal
+  scope: { owned: true },     // only chant-owned resources
+  onDrift: "pull-request",    // or "issue" | "report"
+});
+```
+
+Phases: snapshot → plan → regenerate ([live import](/chant/guide/live-import/)) → open PR. Run `chant run prod-reconcile` for a one-shot reconcile on the local executor; give it a `schedule` to run continuously on Temporal. The PR's diff *is* the regenerated TypeScript, so review is a normal code review.
+
+Reconcile never mutates the cloud. It only changes source — the safest reconciliation direction, and a good first step past pure observation.
+
+## Apply — `code → cloud`
+
+When source is the intended truth and the cloud should follow, [`ApplyOp`](/chant/guide/ops/#apply-code--cloud) pushes declared source into the live system via the target's native mechanism — `kubectl apply`, CloudFormation `deploy`, or an ARM deployment:
+
+```typescript
+import { ApplyOp } from "@intentius/chant-lexicon-temporal";
+
+export const { op } = ApplyOp({
+  name: "prod-apply",
+  env: "prod",
+  target: "kubectl",
+  delete: "gated",   // "never" | "owned-only" | "gated"
+  gate: { signalName: "approve-apply" },
+});
+```
+
+Authority stays with the platform — chant hosts no state file. Deletes ride the native delete path scoped to the ownership marker, so they only ever touch **chant-owned** orphans. A destructive apply gets an approval gate and saga-style rollback; see [Gates and compensation](/chant/guide/ops/#gates-and-compensation--where-temporal-is-load-bearing) for why that half is Temporal-bound.
+
+## The dial as configuration
+
+The same project can sit at different positions per environment:
+
+| Environment | Position | What runs |
+|---|---|---|
+| `dev` | observe | `chant state diff --live` in CI; no reconciliation |
+| `staging` | reconcile | `ReconcileOp` opens PRs when staging drifts |
+| `prod` | authoritative | `ApplyOp` with `delete: "gated"` behind approval |
+
+Nothing forces an environment past the position you chose for it. Turn the dial up as trust and tooling allow.
+
+## When to pick each
+
+- **Observe** when the cloud is changed by other tools you don't want to fight, and you just need visibility.
+- **Reconcile** when source should track reality and humans should review each adoption — the default for shared or partially-managed environments.
+- **Apply** when source is authoritative and you want the cloud reconciled to it, with deletes limited to what chant owns. Gate it in production.
+
+## See also
+
+- [State Models](/chant/concepts/state-models/) — the three axes and the dial
+- [Live Import](/chant/guide/live-import/) — the cloud→code regeneration the reconcile workflow uses
+- [Ops](/chant/guide/ops/) — `ReconcileOp` and `ApplyOp` in depth
+- [Durable Workflows](/chant/concepts/durable-workflows/) — why gated apply wants Temporal

--- a/docs/src/content/docs/lexicon-authoring/completeness-checklist.mdx
+++ b/docs/src/content/docs/lexicon-authoring/completeness-checklist.mdx
@@ -63,6 +63,8 @@ Informational — tracks depth of testing and feature coverage.
 | `import/parser.test.ts` exists | Import parser tested |
 | `import/generator.test.ts` exists | Import generator tested |
 | `import/roundtrip.test.ts` exists | Import round-trip tested |
+| `exportResources()` implemented | Live export for `chant import --from` ([Implementing Live Export](/chant/lexicon-authoring/live-export/)) |
+| Ownership marker + `owned` filter | Stamps the ownership marker and queries it on describe/export (degrades to detect-only where no marker channel exists) |
 | `typecheck.test.ts` exists | Type-level verification |
 | `roundtrip.test.ts` exists | Serialize/deserialize round-trip |
 | At least 5 composites | Rich composition library |

--- a/docs/src/content/docs/lexicon-authoring/live-export.mdx
+++ b/docs/src/content/docs/lexicon-authoring/live-export.mdx
@@ -1,0 +1,85 @@
+---
+title: Implementing Live Export
+description: How to implement exportResources() and the ownership marker so your lexicon participates in chant import --from and ownership-gated reconciliation.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Two opt-in capabilities let a lexicon participate in the `cloud → code` direction: **live export** (regenerate TypeScript from live config) and the **ownership marker** (tell chant-owned resources from foreign ones). They pair with [observation](/chant/lexicon-authoring/observation/) (the `cloud → report` direction) but are deliberately separate from it.
+
+## `exportResources()`
+
+`describeResources()` returns scrubbed *output* metadata for diffing — you cannot regenerate a resource from it. `exportResources()` returns the full *input* config, suitable for regeneration:
+
+```typescript
+exportResources?(options: {
+  environment: string;
+  selector?: ResourceSelector;   // { type?, name? }
+  owned?: boolean;               // restrict to chant-owned resources
+  verbatim?: boolean;            // keep server-defaulted fields
+}): Promise<ExportedTemplate>;
+```
+
+The result is the existing import IR (`TemplateIR`), branded as `ExportedTemplate`, so it feeds your lexicon's `templateGenerator()` unchanged. The brand keeps a full-fidelity export — which may carry secrets — from flowing into the `state` code paths, which consume scrubbed metadata through the `ObservationLexicon` view.
+
+<Aside type="caution">
+Keep the scrubbing boundary single-purpose. `describeResources()` scrubs for diffing; `exportResources()` returns full config for regeneration. Never overload one method for both — the secret-exposure surface stays in one place.
+</Aside>
+
+### Pattern
+
+Keep all I/O in the activity and the mapping pure, as the shipping lexicons do:
+
+1. Read live objects (`aws cloudformation get-template`, `kubectl get -o json`, …).
+2. **Strip to declared shape** by default — remove server-written fields (`status`, K8s `managedFields`, server metadata, provider bookkeeping annotations). Keep them when `verbatim` is set.
+3. Map to `TemplateIR` by reusing your import parser.
+4. Apply the `selector` (and the `owned` filter, below).
+
+Reference implementations: `lexicons/aws/src/import/live-export.ts`, `lexicons/k8s/src/import/live-export.ts`, `lexicons/gcp/src/import/live-export.ts`.
+
+## The ownership marker
+
+Ownership is what later lets `delete` be precise without a hosted state file. The marker is stamped at synthesis time into the target's native metadata channel:
+
+| Channel | Targets | Keys |
+|---|---|---|
+| Labels | Kubernetes, GCP | `app.kubernetes.io/managed-by=chant`, `chant.intentius.io/stack`, `chant.intentius.io/env` |
+| Tags | AWS | `chant:managed-by=chant`, `chant:stack`, `chant:env` |
+| Tags | Azure | `chant-managed-by=chant`, `chant-stack`, `chant-env` |
+
+Stamp it from your serializer by reading `context.ownership` and merging into your tag/label channel — reuse the core helper:
+
+```typescript
+import { ownershipEntries } from "@intentius/chant/ownership";
+
+serialize(entities, outputs, context) {
+  const ownership = context?.ownership;
+  const labels = ownership ? ownershipEntries("label", ownership) : {};
+  // merge `labels` into each resource's metadata.labels (explicit labels win)
+}
+```
+
+### Querying it for `owned`
+
+Implement the `owned` filter on both `describeResources` and `exportResources` by reading the marker back:
+
+```typescript
+import { hasOwnershipMarker, classifyOwnership } from "@intentius/chant/ownership";
+
+// export: drop objects without the marker
+if (owned && !hasOwnershipMarker(labels, "label")) continue;
+
+// describe: classify so the change set can gate delete
+metadata.ownership = classifyOwnership(labels, "label");
+```
+
+<Aside type="note">
+Where a target has **no durable marker channel**, log that ownership is unavailable and degrade to detect-only — never silently return everything. (AWS `describeResources` does this: `describe-stack-resources` returns no tags, so it warns and skips the filter.)
+</Aside>
+
+## See also
+
+- [Implementing Observation](/chant/lexicon-authoring/observation/) — the `describeResources()` / `listArtifacts()` side
+- [Completeness Checklist](/chant/lexicon-authoring/completeness-checklist/) — where these capabilities sit
+- [Live Import](/chant/guide/live-import/) — the user-facing `chant import --from`
+- [State Models](/chant/concepts/state-models/) — why ownership lives on the resource


### PR DESCRIPTION
User- and author-facing guides for the new primitives and workflows.

## What
- **`concepts/drift-detection.mdx`**: frames detection as the first dial position and reconcile as the next; adds an **Resolving an `orphan`** subsection (adopt via live import, or delete — only owned orphans).
- **New `guide/live-import.mdx`**: `chant import --from`, selectors, per-provider fidelity (AWS/K8s/GCP), and the adopt-an-orphan loop.
- **New `guide/reconciling-state.mdx`**: the reconcile (`cloud→code`) and apply (`code→cloud`) workflows, the dial as per-environment configuration, and when to pick each.
- **New `lexicon-authoring/live-export.mdx`**: implementing `exportResources()` and the ownership marker, with the degrade-to-detect-only rule; added both to the completeness checklist.

Docs only. Sidebar nav lands in #129. All internal page links verified.

Part of #112. Closes #128.