### PR TITLE
docs: tone audit — chant state framing + Temporal's role

### DIFF
--- a/docs/src/content/docs/concepts/deployment-paths.mdx
+++ b/docs/src/content/docs/concepts/deployment-paths.mdx
@@ -8,6 +8,8 @@ import Diagram from '../../../components/Diagram.astro';
 
 chant covers the synthesis step — TypeScript in, validated artifacts out — and offers two optional layers beyond that. Knowing which layer fits your situation avoids unnecessary setup.
 
+If you never use the operational layers, chant is a pure synthesis compiler — no executor, no state file, nothing to run. The orchestration layer is Temporal-native when you want durability and zero-dependency when you don't: the local executor runs Ops in-process, and only gated or destructive applies need a Temporal cluster.
+
 <Diagram name="deployment-paths" alt="Decision tree: existing deploy pipeline → synthesis only; need observability/gates → Ops or Raw Temporal" caption="Choosing your deployment model" />
 
 ## Synthesis Only

--- a/docs/src/content/docs/guide/local-vs-temporal.mdx
+++ b/docs/src/content/docs/guide/local-vs-temporal.mdx
@@ -13,6 +13,11 @@ sequencing.
 Temporal cluster. There is no config to inspect and no implicit switch — one
 flag selects the runtime.
 
+Temporal-native when you want durability, zero-dependency when you don't. The
+local executor is the on-ramp; the synthesis primitives need no executor at all.
+Reach for Temporal only when an Op must survive a crash, hold a multi-hour
+approval, or roll back a partial failure — never as a baseline requirement.
+
 ## Capability comparison
 
 | | Local mode | Temporal mode |

--- a/docs/src/content/docs/guide/ops.mdx
+++ b/docs/src/content/docs/guide/ops.mdx
@@ -18,6 +18,8 @@ Deciding whether Ops is the right deployment model for your project? See [Choosi
 
 `chant run <name>` runs an Op **locally by default** — in-process, with no Temporal server. `chant build` compiles each `*.op.ts` into generated Temporal worker code for when you run with `--temporal`, which spawns the worker and submits the workflow. See [Local vs Temporal](/chant/guide/local-vs-temporal/) for the trade-off.
 
+Temporal-native when you want durability, zero-dependency when you don't: the local executor is the on-ramp, and the synthesis primitives below it need no executor at all. Reach for Temporal when an Op must survive a crash, hold a long approval, or roll back a partial failure.
+
 <Aside type="note" title="Prerequisites">
 Requires `@intentius/chant-lexicon-temporal` (the package). Local mode needs nothing running. `--temporal` additionally requires a reachable Temporal server (or [Temporal Cloud](https://cloud.temporal.io) — free tier available); see [Worker Profiles](/chant/lexicons/temporal/worker-profiles/) for connection configuration.
 </Aside>


### PR DESCRIPTION
Final cross-page pass after the other docs updates in this initiative landed.

## Axis 1 — chant and state
Audited every state mention: all frame it as **"no authoritative state file, precise change set anyway"**. No page drifts into "chant has state now" (the "state management" hits all refer to other tools or the de-risking framing). "Walk-away cost is zero" and the "pure synthesis compiler if you never use the operational layers" reassurance both stay true and visible.

## Axis 2 — Temporal's role
Added the de-risking clause — **"Temporal-native when you want durability, zero-dependency when you don't"** — to the remaining Temporal-forward pages that lacked it: `guide/ops`, `guide/local-vs-temporal`, `concepts/deployment-paths`. Restated the pure-synthesis-compiler / executor-free-primitives framing so foregrounding Temporal never reads as "heavy orchestration platform". Only gated/destructive Ops are Temporal-bound.

## Result
A reader sampling any three pages comes away with: a pure synthesis core, opt-in observational/reconcile state with no state file, and Temporal as optional but powerful. Docs only.

Part of #112. Closes #131.