### PR TITLE
docs: accuracy fixes from state-model docs re-audit

### DIFF
--- a/docs/src/content/docs/guide/reconciling-state.mdx
+++ b/docs/src/content/docs/guide/reconciling-state.mdx
@@ -27,7 +27,7 @@ export const { op, schedule } = ReconcileOp({
 });
 ```
 
-Phases: snapshot → plan → regenerate ([live import](/chant/guide/live-import/)) → open PR. Run `chant run prod-reconcile` for a one-shot reconcile on the local executor; give it a `schedule` to run continuously on Temporal. The PR's diff *is* the regenerated TypeScript, so review is a normal code review.
+Phases: **Snapshot → Plan → Reconcile**, where the Reconcile phase's `reconcilePr` activity regenerates source ([live import](/chant/guide/live-import/)) and opens the PR in one step. Run `chant run prod-reconcile` for a one-shot reconcile on the local executor; give it a `schedule` to run continuously on Temporal. The PR's diff *is* the regenerated TypeScript, so review is a normal code review.
 
 Reconcile never mutates the cloud. It only changes source — the safest reconciliation direction, and a good first step past pure observation.
 

--- a/docs/src/content/docs/lexicons/overview.mdx
+++ b/docs/src/content/docs/lexicons/overview.mdx
@@ -28,7 +28,7 @@ Lexicons opt into the `chant state diff <env> --live` pipeline by implementing o
 | Lexicon | `describeResources()` | `listArtifacts()` | Ownership | Notes |
 |---|---|---|---|---|
 | AWS | ✅ |  | Tags | `aws cloudformation describe-stack-resources`; `--owned` available on live export (not on describe — tags absent there) |
-| Azure | ✅ |  | Tags | `az resource show` per declared entity; resource-group is the env name |
+| Azure | ✅ |  | — | `az resource show` per declared entity; resource-group is the env name. Stamps the ownership marker at synthesis, but the `--owned` query is not yet wired (no `exportResources`) |
 | GCP (Config Connector) | ✅ |  | Labels | `kubectl get <gvk>` against the GKE management cluster |
 | Kubernetes | ✅ |  | Labels | `kubectl get <kind>` per declared entity; ~20 common types |
 | Temporal | ✅ |  | — | Temporal client — namespaces, search attributes, schedules |
@@ -41,7 +41,7 @@ Lexicons opt into the `chant state diff <env> --live` pipeline by implementing o
 
 Lexicons that implement neither are warn-skipped — `--live` doesn't fail the whole command for them.
 
-The **Ownership** column shows which marker channel a lexicon queries for the `--owned` filter ([ownership marking](/chant/configuration/config-file/#ownership)). `—` means no durable marker channel: those targets log that ownership is unavailable and degrade to detect-only rather than silently filtering.
+The **Ownership** column shows the marker channel a lexicon queries for the `--owned` filter ([ownership marking](/chant/configuration/config-file/#ownership)). `—` means the `--owned` query isn't available for that lexicon — either it has no durable marker channel, or (Azure) it stamps the marker at synthesis but the query side isn't wired up yet. Where a lexicon is asked for owned resources but can't read a marker — e.g. AWS `describeResources`, which gets no tags from `describe-stack-resources` — it logs that ownership is unavailable and returns everything rather than silently filtering.
 
 ## Cross-lexicon migration
 


### PR DESCRIPTION
Re-audited the docs created for the #112 initiative against the shipped code. Every concrete claim — ownership marker keys, `exportResources`/`describeResources` signatures, native apply commands, CLI flags, composite configs, per-provider export commands, change-set actions — verified accurate, with two exceptions corrected here:

## 1. Azure ownership column overclaimed
`lexicons/overview.mdx` listed Azure under **Ownership = Tags**, but the column means "the marker channel a lexicon **queries** for `--owned`". Azure stamps the marker at synthesis (#119) but has **no `exportResources` and no `owned` filter on `describeResources`** — so `--owned` doesn't work for it. Changed Azure's cell to `—` and rewrote the column note to distinguish stamp-without-query (Azure) from no-marker-channel, and to scope the degradation-logging claim to AWS `describeResources` (the only place it actually warns).

## 2. ReconcileOp phase description
`guide/reconciling-state.mdx` implied four phases (snapshot → plan → regenerate → open PR). The composite has **three** — Snapshot → Plan → Reconcile — with the `reconcilePr` activity doing regenerate + PR in one step. Reworded to match (consistent with `guide/ops.mdx`).

Docs only.