### PR TITLE
ci: bump GitHub Actions off Node 20 to Node 24 runtimes

### DIFF
--- a/.github/workflows/chant.yml
+++ b/.github/workflows/chant.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -21,7 +21,7 @@ jobs:
         run: npm install
 
       - name: Cache lexicon schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.chant
           key: lexicon-schemas-${{ hashFiles('lexicons/*/src/**/fetch.ts', 'lexicons/*/src/**/versions.ts') }}
@@ -67,8 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -77,7 +77,7 @@ jobs:
         run: npm install
 
       - name: Cache lexicon schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.chant
           key: lexicon-schemas-${{ hashFiles('lexicons/*/src/**/fetch.ts', 'lexicons/*/src/**/versions.ts') }}
@@ -105,8 +105,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -115,7 +115,7 @@ jobs:
         run: npm install
 
       - name: Cache lexicon schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.chant
           key: lexicon-schemas-${{ hashFiles('lexicons/*/src/**/fetch.ts', 'lexicons/*/src/**/versions.ts') }}
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: npm smoke tests (docker build)
         run: docker build -f test/Dockerfile.smoke-npm -t chant-smoke-npm .

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -19,8 +19,8 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -30,7 +30,7 @@ jobs:
         run: sudo apt-get install -y graphviz
 
       - name: Cache lexicon schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.chant
           key: lexicon-schemas-${{ hashFiles('lexicons/*/src/**/fetch.ts', 'lexicons/*/src/**/versions.ts') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt-get install -y graphviz
 
       - name: Cache lexicon schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.chant
           key: lexicon-schemas-${{ hashFiles('lexicons/*/src/**/fetch.ts', 'lexicons/*/src/**/versions.ts') }}
@@ -48,4 +48,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/ext-vscode.yml
+++ b/.github/workflows/ext-vscode.yml
@@ -15,8 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
       - run: npm install
@@ -25,7 +25,7 @@ jobs:
         working-directory: editors/vscode
       - run: npx @vscode/vsce package --no-dependencies
         working-directory: editors/vscode
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: chant-vscode-${{ github.sha }}
           path: editors/vscode/*.vsix
@@ -35,8 +35,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/ext-vscode-v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
       - run: npm install
@@ -56,8 +56,8 @@ jobs:
   #   if: startsWith(github.ref, 'refs/tags/ext-vscode-v')
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-node@v4
+  #     - uses: actions/checkout@v6
+  #     - uses: actions/setup-node@v6
   #       with:
   #         node-version: "24"
   #     - run: npm install

--- a/.github/workflows/ext-zed.yml
+++ b/.github/workflows/ext-zed.yml
@@ -14,13 +14,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasip1
       - run: cargo build --release --target wasm32-wasip1
         working-directory: editors/zed
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: chant-zed-${{ github.sha }}
           path: editors/zed/target/wasm32-wasip1/release/*.wasm
@@ -32,14 +32,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: chant-zed-${{ github.sha }}
           path: wasm
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: wasm/*.wasm

--- a/.github/workflows/publish-lexicon.yml
+++ b/.github/workflows/publish-lexicon.yml
@@ -11,8 +11,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -29,7 +29,7 @@ jobs:
           echo "name=$name" >> $GITHUB_OUTPUT
 
       - name: Cache lexicon schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.chant
           key: lexicon-schemas-${{ hashFiles('lexicons/*/src/**/fetch.ts', 'lexicons/*/src/**/versions.ts') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
       - run: npm install
 
       - name: Cache lexicon schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.chant
           key: lexicon-schemas-${{ hashFiles('lexicons/*/src/**/fetch.ts', 'lexicons/*/src/**/versions.ts') }}
@@ -45,8 +45,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'


### PR DESCRIPTION
Closes the loop on the Node 20 deprecation warning surfaced during the #112 initiative. GitHub forces Node 20 actions to Node 24 on **2026-06-16** and removes Node 20 from runners on **2026-09-16**.

## What

Every pinned action was checked against its `action.yml` `using:` field. Those whose pinned major ran on `node20` are bumped to the major that runs on `node24`:

| Action | Was | Now | Runtime |
|---|---|---|---|
| actions/checkout | v4 | **v6** | node24 |
| actions/setup-node | v4 | **v6** | node24 |
| actions/cache | v4 | **v5** | node24 |
| actions/deploy-pages | v4 | **v5** | node24 |
| actions/upload-artifact | v4 | **v7** | node24 |
| actions/download-artifact | v4 | **v8** | node24 |
| softprops/action-gh-release | v2 | **v3** | node24 |

## Left unchanged (already fine)

- `github/codeql-action/upload-sarif@v4` — already node24
- `actions/upload-pages-artifact@v3`, `dtolnay/rust-toolchain@stable`, `lycheeverse/lychee-action@v2` — composite/docker, no node20 runtime

Version-string-only changes across the 7 workflow files. The always-on workflows (`chant`, `docs-check`) exercise checkout/setup-node/cache on this PR; the deprecation annotation should no longer appear.