### PR TITLE
refactor(temporal): rename Op activities stateSnapshot/stateDiff → lifecycle*

### DIFF
--- a/examples/gitlab-aws-alb-op/ops/alb-deploy.op.ts
+++ b/examples/gitlab-aws-alb-op/ops/alb-deploy.op.ts
@@ -10,7 +10,7 @@
  *   2. Deploy           — apply manifests sequentially (ordered by dependency)
  *   3. Verify           — wait for rollout, then snapshot state
  */
-import { Op, phase, build, kubectlApply, waitForStack, stateSnapshot } from "@intentius/chant-lexicon-temporal";
+import { Op, phase, build, kubectlApply, waitForStack, lifecycleSnapshot } from "@intentius/chant-lexicon-temporal";
 
 export default Op({
   name: "alb-deploy",
@@ -41,7 +41,7 @@ export default Op({
     phase("Verify", [
       waitForStack("alb-api", { namespace: "alb" }),
       waitForStack("alb-ui", { namespace: "alb" }),
-      stateSnapshot("staging"),
+      lifecycleSnapshot("staging"),
     ]),
   ],
 });

--- a/lexicons/temporal/src/composites/apply-op.ts
+++ b/lexicons/temporal/src/composites/apply-op.ts
@@ -79,7 +79,7 @@ export function ApplyOp(config: ApplyOpConfig): ApplyOpResources {
     phase("Plan", [
       {
         kind: "activity" as const,
-        fn: "stateDiff",
+        fn: "lifecycleDiff",
         args: { env: config.env, live: true },
         outcomeAttribute: { name: "Drift", from: "drifted" },
       },

--- a/lexicons/temporal/src/composites/composites.test.ts
+++ b/lexicons/temporal/src/composites/composites.test.ts
@@ -167,8 +167,8 @@ describe("WatchOp: configuration", () => {
     expect(phases.map((p) => p.name)).toEqual(["Snapshot", "Diff"]);
     const snapStep = (phases[0].steps as Array<Record<string, unknown>>)[0];
     const diffStep = (phases[1].steps as Array<Record<string, unknown>>)[0];
-    expect(snapStep.fn).toBe("stateSnapshot");
-    expect(diffStep.fn).toBe("stateDiff");
+    expect(snapStep.fn).toBe("lifecycleSnapshot");
+    expect(diffStep.fn).toBe("lifecycleDiff");
     expect(snapStep.args).toEqual({ env: "prod" });
     expect(diffStep.args).toEqual({ env: "prod", live: true });
     // Drift is surfaced as a workflow search attribute via outcomeAttribute (#41)
@@ -227,9 +227,9 @@ describe("WatchOp: serialization", () => {
     expect(wf).toContain('upsertSearchAttributes({"OpName":["prod-watch"],"Watch":["true"],"Env":["prod"]});');
     expect(wf).toContain('upsertSearchAttributes({ Phase: ["Snapshot"] });');
     expect(wf).toContain('upsertSearchAttributes({ Phase: ["Diff"] });');
-    expect(wf).toContain("stateSnapshot(");
+    expect(wf).toContain("lifecycleSnapshot(");
     // Diff result captured + Drift search attribute auto-emitted
-    expect(wf).toContain("const __r0 = await stateDiff(");
+    expect(wf).toContain("const __r0 = await lifecycleDiff(");
     expect(wf).toContain('upsertSearchAttributes({ "Drift": [String(__r0?.drifted)] });');
   });
 });

--- a/lexicons/temporal/src/composites/reconcile-op.ts
+++ b/lexicons/temporal/src/composites/reconcile-op.ts
@@ -78,11 +78,11 @@ export function ReconcileOp(config: ReconcileOpConfig): ReconcileOpResources {
       Env: config.env,
     },
     phases: [
-      phase("Snapshot", [activity("stateSnapshot", { env: config.env })]),
+      phase("Snapshot", [activity("lifecycleSnapshot", { env: config.env })]),
       phase("Plan", [
         {
           kind: "activity",
-          fn: "stateDiff",
+          fn: "lifecycleDiff",
           args: { env: config.env, live: true },
           outcomeAttribute: { name: "Drift", from: "drifted" },
         },

--- a/lexicons/temporal/src/composites/watch-op.ts
+++ b/lexicons/temporal/src/composites/watch-op.ts
@@ -5,7 +5,7 @@
  * Composes existing pieces:
  *   - The Op codegen (#7) emits a workflow that runs phases sequentially
  *   - The auto-emit search-attribute behavior (#28) tags each phase
- *   - The pre-built stateSnapshot + stateDiff activities (this commit)
+ *   - The pre-built lifecycleSnapshot + lifecycleDiff activities (this commit)
  *   - TemporalSchedule fires the workflow on a cron schedule
  *
  * @example
@@ -73,14 +73,14 @@ export function WatchOp(config: WatchOpConfig): WatchOpResources {
       Env: config.env,
     },
     phases: [
-      phase("Snapshot", [activity("stateSnapshot", { env: config.env })]),
+      phase("Snapshot", [activity("lifecycleSnapshot", { env: config.env })]),
       phase("Diff", [
-        // outcomeAttribute surfaces stateDiff's `drifted` boolean as a
+        // outcomeAttribute surfaces lifecycleDiff's `drifted` boolean as a
         // workflow-level Drift search attribute, making 'show me runs that
         // detected drift' a one-filter UI query.
         {
           kind: "activity",
-          fn: "stateDiff",
+          fn: "lifecycleDiff",
           args: { env: config.env, live },
           outcomeAttribute: { name: "Drift", from: "drifted" },
         },

--- a/lexicons/temporal/src/index.ts
+++ b/lexicons/temporal/src/index.ts
@@ -45,7 +45,7 @@ export {
   helmInstall,
   waitForStack,
   gitlabPipeline,
-  stateSnapshot,
+  lifecycleSnapshot,
   shell,
   teardown,
 } from "@intentius/chant/op";

--- a/lexicons/temporal/src/op/activities/index.ts
+++ b/lexicons/temporal/src/op/activities/index.ts
@@ -16,8 +16,8 @@ export type { GitlabPipelineArgs } from "./gitlab";
 export { shellCmd } from "./shell";
 export type { ShellCmdArgs } from "./shell";
 
-export { stateSnapshot, stateDiff } from "./state";
-export type { StateSnapshotArgs, StateDiffArgs, StateDiffResult } from "./state";
+export { lifecycleSnapshot, lifecycleDiff } from "./lifecycle";
+export type { LifecycleSnapshotArgs, LifecycleDiffArgs, LifecycleDiffResult } from "./lifecycle";
 
 export { chantTeardown } from "./teardown";
 export type { ChantTeardownArgs } from "./teardown";

--- a/lexicons/temporal/src/op/activities/lifecycle.ts
+++ b/lexicons/temporal/src/op/activities/lifecycle.ts
@@ -3,7 +3,7 @@ import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
 
-export interface StateSnapshotArgs {
+export interface LifecycleSnapshotArgs {
   /** Environment name (e.g. "dev", "staging", "prod"). */
   env: string;
 }
@@ -12,13 +12,13 @@ export interface StateSnapshotArgs {
  * Take a chant lifecycle snapshot for the given environment.
  * Uses fastIdempotent profile — 5m timeout, 3 retries.
  */
-export async function stateSnapshot(args: StateSnapshotArgs, signal?: AbortSignal): Promise<void> {
+export async function lifecycleSnapshot(args: LifecycleSnapshotArgs, signal?: AbortSignal): Promise<void> {
   const { stdout, stderr } = await execAsync(`chant lifecycle snapshot ${args.env}`, { signal });
   if (stdout) console.log(stdout);
   if (stderr) console.error(stderr);
 }
 
-export interface StateDiffArgs {
+export interface LifecycleDiffArgs {
   /** Environment name (e.g. "dev", "staging", "prod"). */
   env: string;
   /**
@@ -28,7 +28,7 @@ export interface StateDiffArgs {
   live?: boolean;
 }
 
-export interface StateDiffResult {
+export interface LifecycleDiffResult {
   /** Combined stdout + stderr from the chant command. */
   output: string;
   /** Process exit code (0 = success). */
@@ -69,7 +69,7 @@ function detectDrift(output: string): boolean {
  * cli/state.mdx. Pair with `outcomeAttribute: { name: "Drift", from: "drifted" }`
  * on a WatchOp activity step to surface drift as a workflow search attribute.
  */
-export async function stateDiff(args: StateDiffArgs, signal?: AbortSignal): Promise<StateDiffResult> {
+export async function lifecycleDiff(args: LifecycleDiffArgs, signal?: AbortSignal): Promise<LifecycleDiffResult> {
   const liveFlag = args.live ? " --live" : "";
   try {
     const { stdout, stderr } = await execAsync(`chant lifecycle diff ${args.env}${liveFlag}`, { signal });

--- a/lexicons/temporal/src/op/op-serializer.test.ts
+++ b/lexicons/temporal/src/op/op-serializer.test.ts
@@ -410,14 +410,14 @@ describe("serializeOps()", () => {
             {
               name: "Diff",
               steps: [
-                { kind: "activity", fn: "stateDiff", args: { env: "prod" }, outcomeAttribute: { name: "Drift", from: "drifted" } },
+                { kind: "activity", fn: "lifecycleDiff", args: { env: "prod" }, outcomeAttribute: { name: "Drift", from: "drifted" } },
               ],
             },
           ],
         }),
       ]);
       const wf = serializeOps(ops)["ops/watch/workflow.ts"];
-      expect(wf).toContain('const __r0 = await stateDiff({"env":"prod"});');
+      expect(wf).toContain('const __r0 = await lifecycleDiff({"env":"prod"});');
       expect(wf).toContain('upsertSearchAttributes({ "Drift": [String(__r0?.drifted)] });');
     });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,5 +62,5 @@ export * from "./mcp/types";
 export * from "./lifecycle/index";
 // Op builders — use explicit exports to avoid collision with the core `build` function
 export { Op, phase, activity, gate, kubectlApply, helmInstall, waitForStack,
-         gitlabPipeline, stateSnapshot, shell, teardown, OpResource } from "./op/index";
+         gitlabPipeline, lifecycleSnapshot, shell, teardown, OpResource } from "./op/index";
 export type { OpConfig, PhaseDefinition, StepDefinition, ActivityStep, GateStep } from "./op/index";

--- a/packages/core/src/op/activity-registry.test.ts
+++ b/packages/core/src/op/activity-registry.test.ts
@@ -13,7 +13,7 @@ describe("loadActivities", () => {
     expect(activities.has("shellCmd")).toBe(true);
     expect(activities.has("chantBuild")).toBe(true);
     expect(activities.has("kubectlApply")).toBe(true);
-    expect(activities.has("stateDiff")).toBe(true);
+    expect(activities.has("lifecycleDiff")).toBe(true);
     expect(typeof activities.get("shellCmd")).toBe("function");
   });
 

--- a/packages/core/src/op/builders.ts
+++ b/packages/core/src/op/builders.ts
@@ -84,8 +84,8 @@ export const gitlabPipeline = (name: string, opts?: Record<string, unknown>): Ac
   activity("gitlabPipeline", { name, ...opts }, "longInfra");
 
 /** Take a chant lifecycle snapshot for the given environment. */
-export const stateSnapshot = (env: string): ActivityStep =>
-  activity("stateSnapshot", { env });
+export const lifecycleSnapshot = (env: string): ActivityStep =>
+  activity("lifecycleSnapshot", { env });
 
 /** Run an arbitrary shell command. */
 export const shell = (cmd: string, opts?: { env?: Record<string, string> }): ActivityStep =>

--- a/packages/core/src/op/index.ts
+++ b/packages/core/src/op/index.ts
@@ -1,5 +1,5 @@
 export { Op, phase, activity, gate, build, kubectlApply, helmInstall, waitForStack,
-         gitlabPipeline, stateSnapshot, shell, teardown } from "./builders";
+         gitlabPipeline, lifecycleSnapshot, shell, teardown } from "./builders";
 export { OpResource } from "./resource";
 export type { OpConfig, PhaseDefinition, StepDefinition, ActivityStep, GateStep } from "./types";
 export { discoverOps } from "./discover";

--- a/packages/core/src/op/local-executor.test.ts
+++ b/packages/core/src/op/local-executor.test.ts
@@ -185,10 +185,10 @@ describe("runOpLocally — outcomeAttribute", () => {
     const diff: ActivityFn = async () => ({ output: "...", exitCode: 0, drifted: false });
     const config = op({
       phases: [{ name: "Check", steps: [
-        { kind: "activity", fn: "stateDiff", outcomeAttribute: { name: "Drift", from: "drifted" } },
+        { kind: "activity", fn: "lifecycleDiff", outcomeAttribute: { name: "Drift", from: "drifted" } },
       ] }],
     });
-    const result = await runOpLocally(config, new Map([["stateDiff", diff]]), PROFILES);
+    const result = await runOpLocally(config, new Map([["lifecycleDiff", diff]]), PROFILES);
     expect(result.records[0].outcome).toEqual({ name: "Drift", value: false });
   });
 });

--- a/packages/core/src/op/local-output.test.ts
+++ b/packages/core/src/op/local-output.test.ts
@@ -8,7 +8,7 @@ const RESULT: OpRunResult = {
   ok: true,
   records: [
     { phase: "Greet", fn: "shellCmd", args: { cmd: "echo hello from chant" }, status: "ok", durationMs: 42 },
-    { phase: "Check", fn: "stateDiff", args: { env: "prod" }, status: "ok", durationMs: 1200,
+    { phase: "Check", fn: "lifecycleDiff", args: { env: "prod" }, status: "ok", durationMs: 1200,
       outcome: { name: "Drift", value: false } },
   ],
 };
@@ -22,7 +22,7 @@ describe("renderHuman", () => {
     expect(out).toContain("✓ shellCmd(cmd=echo hello from chant)   42ms");
     expect(out).toContain("[phase] Check");
     expect(out).toContain("[outcome] Drift=false");
-    expect(out).toContain("✓ stateDiff(env=prod)   1.2s");
+    expect(out).toContain("✓ lifecycleDiff(env=prod)   1.2s");
     expect(out).toContain('Op "hello" completed in 0.1s');
   });
 

--- a/packages/core/src/op/op.test.ts
+++ b/packages/core/src/op/op.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from "vitest";
 import { Op, phase, activity, gate, build, kubectlApply, helmInstall,
-         waitForStack, gitlabPipeline, stateSnapshot, shell, teardown } from "./builders";
+         waitForStack, gitlabPipeline, lifecycleSnapshot, shell, teardown } from "./builders";
 import { DECLARABLE_MARKER, type Declarable } from "../declarable";
 
 // ── Op() ──────────────────────────────────────────────────────────────────────
@@ -177,9 +177,9 @@ describe("pre-built shortcuts", () => {
     expect(a.profile).toBe("longInfra");
   });
 
-  it("stateSnapshot() produces stateSnapshot activity with env arg", () => {
-    const a = stateSnapshot("prod");
-    expect(a.fn).toBe("stateSnapshot");
+  it("lifecycleSnapshot() produces lifecycleSnapshot activity with env arg", () => {
+    const a = lifecycleSnapshot("prod");
+    expect(a.fn).toBe("lifecycleSnapshot");
     expect(a.args?.env).toBe("prod");
     expect("profile" in a).toBe(false);
   });

--- a/packages/core/src/op/types.ts
+++ b/packages/core/src/op/types.ts
@@ -52,7 +52,7 @@ export interface ActivityStep {
    * The serializer captures the awaited result into a temporary, then emits
    * `upsertSearchAttributes({ <name>: [String(<from-path>)] })` immediately
    * after. Useful for filtering runs by outcome (e.g. `Drift: "true"/"false"`
-   * from a stateDiff activity).
+   * from a lifecycleDiff activity).
    *
    * `from` is a dot-path into the return value (e.g. `"drifted"` for
    * `{ drifted: boolean }`); when omitted, the whole return value is


### PR DESCRIPTION
Second of the lifecycle-rename series — moves the rename into the Op layer so activity names match the renamed CLI command they wrap.

## What
- Activity file `lexicons/temporal/src/op/activities/state.ts` → `lifecycle.ts`.
- `stateSnapshot`/`stateDiff` → `lifecycleSnapshot`/`lifecycleDiff` — function exports, the registered activity-name strings (`fn: "lifecycleSnapshot"`), and the `op/builders` shortcut.
- `StateSnapshotArgs`/`StateDiffArgs`/`StateDiffResult` → `Lifecycle*`.
- `WatchOp`/`ReconcileOp`/`ApplyOp` composites and the `gitlab-aws-alb-op` example reference the new names.

## Tests
Full suite green: **6033 passed / 5 skipped**, core typecheck clean. No `stateSnapshot`/`stateDiff` code references remain.

Next: PR3 (docs lifecycle reframing + slugs + BYOL), PR4 ("Contributing a Lifecycle" guide).