### PR TITLE
feat(azure): implement exportResources (live import)

### DIFF
--- a/lexicons/azure/src/export-resources.test.ts
+++ b/lexicons/azure/src/export-resources.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// execMock returns either a {stdout,stderr} result or an Error. We deliver it
+// via the callback on a microtask — never as a rejected promise — so a failure
+// case can't leave a dangling unhandled rejection that masks the assertion.
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    exec: (
+      cmd: string,
+      cb: (err: Error | null, out: { stdout: string; stderr: string }) => void,
+    ) => {
+      const r = execMock(cmd);
+      queueMicrotask(() =>
+        r instanceof Error
+          ? cb(r, { stdout: "", stderr: "" })
+          : cb(null, r as { stdout: string; stderr: string }),
+      );
+    },
+  };
+});
+
+const { exportResources } = await import("./export-resources");
+
+const liveTemplate = {
+  $schema:
+    "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  contentVersion: "1.0.0.0",
+  resources: [
+    {
+      type: "Microsoft.Storage/storageAccounts",
+      apiVersion: "2021-09-01",
+      name: "mystore",
+      location: "eastus",
+      properties: {},
+    },
+  ],
+};
+
+describe("azure exportResources I/O glue (#159 / #160)", () => {
+  beforeEach(() => execMock.mockReset());
+
+  test("runs `az group export` against the resource group and maps the body", async () => {
+    execMock.mockReturnValue({ stdout: JSON.stringify(liveTemplate), stderr: "" });
+    const ir = await exportResources({ environment: "prod-rg" });
+    expect(execMock).toHaveBeenCalledTimes(1);
+    const cmd = execMock.mock.calls[0][0] as string;
+    expect(cmd).toContain("az group export");
+    expect(cmd).toContain("--resource-group prod-rg");
+    expect(cmd).toContain("--output json");
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["mystore"]);
+  });
+
+  test("a failing az invocation throws with the stderr surfaced", async () => {
+    execMock.mockReturnValue(
+      Object.assign(new Error("exit 1"), { stderr: "ERROR: Please run 'az login'" }),
+    );
+    await expect(exportResources({ environment: "prod-rg" })).rejects.toThrow(
+      /Failed to export resource group "prod-rg".*az login/,
+    );
+  });
+
+  test("selector and owned flags are threaded through to the mapper", async () => {
+    const mixed = {
+      ...liveTemplate,
+      resources: [
+        {
+          type: "Microsoft.Storage/storageAccounts",
+          apiVersion: "2021-09-01",
+          name: "mine",
+          location: "eastus",
+          tags: { "chant-managed-by": "chant" },
+          properties: {},
+        },
+        {
+          type: "Microsoft.Storage/storageAccounts",
+          apiVersion: "2021-09-01",
+          name: "theirs",
+          location: "eastus",
+          properties: {},
+        },
+      ],
+    };
+    execMock.mockReturnValue({ stdout: JSON.stringify(mixed), stderr: "" });
+    const ir = await exportResources({ environment: "prod-rg", owned: true });
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["mine"]);
+  });
+});

--- a/lexicons/azure/src/export-resources.ts
+++ b/lexicons/azure/src/export-resources.ts
@@ -1,0 +1,38 @@
+/**
+ * Live export for the Azure lexicon — implements LexiconPlugin.exportResources()
+ * so `chant import --from <azure-env>` regenerates Azure resources as chant
+ * TypeScript.
+ *
+ * The environment argument is the Azure resource group. Export reads the live
+ * ARM template with `az group export` and maps it to the import IR. All I/O
+ * lives here; selector/ownership filtering and IR-building are pure in
+ * `./import/live-export`.
+ */
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import type { ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
+import { parseExportedTemplate } from "./import/live-export";
+
+const execAsync = promisify(exec);
+
+export async function exportResources(options: {
+  environment: string;
+  selector?: ResourceSelector;
+  owned?: boolean;
+}): Promise<ExportedTemplate> {
+  const cmd = [
+    "az", "group", "export",
+    "--resource-group", options.environment,
+    "--output", "json",
+  ].join(" ");
+
+  let stdout: string;
+  try {
+    ({ stdout } = await execAsync(cmd));
+  } catch (err) {
+    const stderr = (err as { stderr?: string }).stderr ?? (err as Error).message;
+    throw new Error(`Failed to export resource group "${options.environment}": ${stderr}`);
+  }
+
+  return parseExportedTemplate(stdout, options.selector, options.owned);
+}

--- a/lexicons/azure/src/import/live-export.test.ts
+++ b/lexicons/azure/src/import/live-export.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "vitest";
+import { parseExportedTemplate } from "./live-export";
+import { ArmGenerator } from "./generator";
+
+// Mimics what `az group export --output json` returns: an ARM template object.
+const liveTemplate = {
+  $schema:
+    "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  contentVersion: "1.0.0.0",
+  resources: [
+    {
+      type: "Microsoft.Storage/storageAccounts",
+      apiVersion: "2021-09-01",
+      name: "mystore",
+      location: "eastus",
+      properties: { accessTier: "Hot" },
+    },
+    {
+      type: "Microsoft.Network/virtualNetworks",
+      apiVersion: "2021-05-01",
+      name: "myvnet",
+      location: "eastus",
+      properties: {},
+    },
+  ],
+};
+
+describe("azure exportResources mapping (#159)", () => {
+  test("maps a live ARM template to export IR", () => {
+    const ir = parseExportedTemplate(liveTemplate);
+    expect(ir.resources.map((r) => r.logicalId).sort()).toEqual(["mystore", "myvnet"]);
+    const store = ir.resources.find((r) => r.logicalId === "mystore")!;
+    expect(store.type).toBe("Microsoft.Storage/storageAccounts");
+    expect(store.properties.accessTier).toBe("Hot");
+    expect(store.properties.location).toBe("eastus");
+  });
+
+  test("accepts a stringified template body", () => {
+    const ir = parseExportedTemplate(JSON.stringify(liveTemplate));
+    expect(ir.resources).toHaveLength(2);
+  });
+
+  test("selector by name narrows the export", () => {
+    const ir = parseExportedTemplate(liveTemplate, { name: "myvnet" });
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["myvnet"]);
+  });
+
+  test("selector by type narrows the export", () => {
+    const ir = parseExportedTemplate(liveTemplate, {
+      type: "Microsoft.Storage/storageAccounts",
+    });
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["mystore"]);
+  });
+
+  test("owned filter keeps only resources carrying the chant marker (#120)", () => {
+    const mixed = {
+      $schema: liveTemplate.$schema,
+      contentVersion: "1.0.0.0",
+      resources: [
+        {
+          type: "Microsoft.Storage/storageAccounts",
+          apiVersion: "2021-09-01",
+          name: "mine",
+          location: "eastus",
+          tags: { "chant-managed-by": "chant", "chant-stack": "billing" },
+          properties: {},
+        },
+        {
+          type: "Microsoft.Storage/storageAccounts",
+          apiVersion: "2021-09-01",
+          name: "theirs",
+          location: "eastus",
+          tags: { team: "other" },
+          properties: {},
+        },
+      ],
+    };
+    const ir = parseExportedTemplate(mixed, undefined, true);
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["mine"]);
+  });
+
+  test("no selector and not owned → full passthrough", () => {
+    const ir = parseExportedTemplate(liveTemplate, {}, false);
+    expect(ir.resources).toHaveLength(2);
+  });
+
+  test("export IR feeds ArmGenerator (templateGenerator) unchanged", () => {
+    const ir = parseExportedTemplate(liveTemplate);
+    const files = new ArmGenerator().generate(ir);
+    expect(files.length).toBeGreaterThan(0);
+    const all = files.map((f) => f.content).join("\n");
+    expect(all).toContain("mystore");
+  });
+});

--- a/lexicons/azure/src/import/live-export.ts
+++ b/lexicons/azure/src/import/live-export.ts
@@ -1,0 +1,43 @@
+import type { ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
+import { hasOwnershipMarker } from "@intentius/chant/ownership";
+import { ArmParser } from "./parser";
+
+/**
+ * Map a live ARM template (from `az group export`) to full-fidelity export IR.
+ *
+ * `az group export --output json` returns an ARM template — either as a JSON
+ * object or, via the CLI, a JSON string. `ArmParser` already turns the template
+ * into `TemplateIR` — the same IR the static-import path uses — so the result
+ * feeds `ArmGenerator` (templateGenerator) unchanged. Pure: all I/O stays in
+ * the caller (`../export-resources`).
+ *
+ * Mirrors AWS `parseStackTemplate`. The one shape difference: ARM tags are a
+ * `Record<string,string>` map (not the `{Key,Value}[]` array CloudFormation
+ * uses), so the ownership filter reads `properties.tags` directly without
+ * `tagArrayToMap`, against the `azure-tag` channel (`chant-managed-by`).
+ */
+export function parseExportedTemplate(
+  templateBody: unknown,
+  selector?: ResourceSelector,
+  owned?: boolean,
+): ExportedTemplate {
+  const content =
+    typeof templateBody === "string" ? templateBody : JSON.stringify(templateBody);
+  const ir = new ArmParser().parse(content);
+
+  const hasSelector = selector && (selector.type !== undefined || selector.name !== undefined);
+  if (!hasSelector && !owned) return ir;
+
+  return {
+    ...ir,
+    resources: ir.resources.filter((r) => {
+      if (selector?.type !== undefined && r.type !== selector.type) return false;
+      if (selector?.name !== undefined && r.logicalId !== selector.name) return false;
+      if (owned) {
+        const tags = (r.properties as { tags?: Record<string, unknown> }).tags;
+        if (!hasOwnershipMarker(tags, "azure-tag")) return false;
+      }
+      return true;
+    }),
+  };
+}

--- a/lexicons/azure/src/plugin.ts
+++ b/lexicons/azure/src/plugin.ts
@@ -457,4 +457,9 @@ export const tags = defaultTags([
     const { describeResources } = await import("./describe-resources");
     return describeResources(options);
   },
+
+  async exportResources(options) {
+    const { exportResources } = await import("./export-resources");
+    return exportResources(options);
+  },
 };


### PR DESCRIPTION
Closes #159.

## What
Azure becomes a full live-import peer to aws/gcp/k8s. `chant import --from <env>` now works against an Azure resource group.

## How
- `lexicons/azure/src/import/live-export.ts` — pure `parseExportedTemplate` (ARM template → `ExportedTemplate` IR via `ArmParser`), with selector (name/type) and `owned` filtering against the `azure-tag` ownership channel (`chant-managed-by`). Mirrors AWS `parseStackTemplate`; ARM tags are a map, so no `tagArrayToMap`.
- `lexicons/azure/src/export-resources.ts` — exec glue shelling `az group export --resource-group <env> --output json`, error path surfaces stderr.
- `lexicons/azure/src/plugin.ts` — delegates `exportResources`.

## Tests
- `import/live-export.test.ts` — mapping, stringified body, selector by name/type, `owned` filter, passthrough, feeds `ArmGenerator`.
- `export-resources.test.ts` — `az group export` argv, error→throw, selector/owned threaded through (also covers Azure's slice of #160).

## Verification
- `npx vitest run lexicons/azure packages/core/src/lifecycle` — 479 passing.
- `npx tsc --noEmit -p packages/core/tsconfig.json` — clean.
- `npm run --prefix lexicons/azure prepack` — clean (incl. `types-compile`).