### PR TITLE
test(lexicons): cover exportResources I/O glue (aws, gcp, k8s)

### DIFF
--- a/lexicons/aws/src/import/live-export-io.test.ts
+++ b/lexicons/aws/src/import/live-export-io.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// AWS exportResources reaches the cloud through the runtime adapter's spawn
+// (not node:child_process), so the I/O seam is the runtime-adapter module.
+const spawnMock = vi.fn();
+vi.mock("@intentius/chant/runtime-adapter", () => ({
+  getRuntime: () => ({ spawn: spawnMock }),
+}));
+
+import { awsPlugin } from "../plugin";
+
+const liveTemplate = {
+  AWSTemplateFormatVersion: "2010-09-09",
+  Resources: {
+    MyBucket: {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "my-bucket" },
+    },
+  },
+};
+
+describe("aws exportResources I/O glue (#160)", () => {
+  beforeEach(() => spawnMock.mockReset());
+
+  test("spawns `cloudformation get-template` for the env stack and maps the body", async () => {
+    spawnMock.mockResolvedValue({
+      stdout: JSON.stringify({ TemplateBody: liveTemplate }),
+      stderr: "",
+      exitCode: 0,
+    });
+    const ir = await awsPlugin.exportResources!({ environment: "prod" });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const argv = spawnMock.mock.calls[0][0] as string[];
+    expect(argv).toEqual(
+      expect.arrayContaining([
+        "aws", "cloudformation", "get-template",
+        "--stack-name", "prod",
+        "--output", "json",
+      ]),
+    );
+    expect(ir.resources.map((r) => r.logicalId)).toEqual(["MyBucket"]);
+  });
+
+  test("a non-zero exit throws with the stderr surfaced", async () => {
+    spawnMock.mockResolvedValue({
+      stdout: "",
+      stderr: "Stack with id ghost does not exist",
+      exitCode: 254,
+    });
+    await expect(awsPlugin.exportResources!({ environment: "ghost" })).rejects.toThrow(
+      /Failed to get template for stack "ghost".*does not exist/,
+    );
+  });
+
+  test("a stack with no TemplateBody throws", async () => {
+    spawnMock.mockResolvedValue({ stdout: JSON.stringify({}), stderr: "", exitCode: 0 });
+    await expect(awsPlugin.exportResources!({ environment: "prod" })).rejects.toThrow(
+      /no TemplateBody/,
+    );
+  });
+});

--- a/lexicons/gcp/src/export-resources-io.test.ts
+++ b/lexicons/gcp/src/export-resources-io.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// Deliver exec results synchronously (value, or Error for the failure path) so
+// a skipped kind can't leave a dangling unhandled rejection.
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    exec: (
+      cmd: string,
+      cb: (err: Error | null, out: { stdout: string; stderr: string }) => void,
+    ) => {
+      const r = execMock(cmd);
+      queueMicrotask(() =>
+        r instanceof Error
+          ? cb(r, { stdout: "", stderr: "" })
+          : cb(null, r as { stdout: string; stderr: string }),
+      );
+    },
+  };
+});
+
+const { exportResources } = await import("./export-resources");
+
+const liveBucket = {
+  apiVersion: "storage.cnrm.cloud.google.com/v1beta1",
+  kind: "StorageBucket",
+  metadata: { name: "my-bucket", namespace: "default", uid: "u-1" },
+  spec: { location: "US", storageClass: "STANDARD" },
+};
+
+describe("gcp exportResources I/O glue (#160)", () => {
+  beforeEach(() => execMock.mockReset());
+
+  test("discovers cnrm kinds, sweeps each with `kubectl get`, maps to IR", async () => {
+    execMock.mockImplementation((cmd?: string) => {
+      if (cmd?.includes("api-resources")) {
+        return {
+          stdout:
+            "storagebuckets.storage.cnrm.cloud.google.com\n" +
+            "pubsubtopics.pubsub.cnrm.cloud.google.com\n" +
+            "pods\n",
+          stderr: "",
+        };
+      }
+      if (cmd?.includes("storagebuckets.storage.cnrm")) {
+        return { stdout: JSON.stringify({ items: [liveBucket] }), stderr: "" };
+      }
+      return { stdout: JSON.stringify({ items: [] }), stderr: "" };
+    });
+
+    const ir = await exportResources({ environment: "prod" });
+    const cmds = execMock.mock.calls.map((c) => c[0] as string);
+    expect(cmds.some((c) => c === "kubectl api-resources -o name")).toBe(true);
+    expect(
+      cmds.some((c) => c === "kubectl get storagebuckets.storage.cnrm.cloud.google.com -A -o json"),
+    ).toBe(true);
+    // The non-cnrm "pods" line must be filtered out of the sweep.
+    expect(cmds.some((c) => c.includes("kubectl get pods"))).toBe(false);
+    expect(ir.resources.map((r) => r.logicalId)).toContain("my-bucket");
+  });
+
+  test("a kind that errors (absent / RBAC) is skipped; export still succeeds", async () => {
+    execMock.mockImplementation((cmd?: string) => {
+      if (cmd?.includes("api-resources")) {
+        return { stdout: "computenetworks.compute.cnrm.cloud.google.com\n", stderr: "" };
+      }
+      return new Error("Error from server (Forbidden)");
+    });
+    const ir = await exportResources({ environment: "prod" });
+    expect(ir.resources).toEqual([]);
+  });
+
+  test("no cnrm kinds discovered → empty export, no get calls", async () => {
+    execMock.mockImplementation(() => ({ stdout: "pods\nservices\n", stderr: "" }));
+    const ir = await exportResources({ environment: "prod" });
+    expect(ir.resources).toEqual([]);
+    expect(execMock.mock.calls.filter((c) => (c[0] as string).includes("get")).length).toBe(0);
+  });
+});

--- a/lexicons/k8s/src/export-resources-io.test.ts
+++ b/lexicons/k8s/src/export-resources-io.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// Synchronous delivery (value, or Error for skipped kinds) avoids dangling
+// unhandled rejections when a kind is missing / RBAC-denied.
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    exec: (
+      cmd: string,
+      cb: (err: Error | null, out: { stdout: string; stderr: string }) => void,
+    ) => {
+      const r = execMock(cmd);
+      queueMicrotask(() =>
+        r instanceof Error
+          ? cb(r, { stdout: "", stderr: "" })
+          : cb(null, r as { stdout: string; stderr: string }),
+      );
+    },
+  };
+});
+
+const { exportResources } = await import("./export-resources");
+
+const liveDeployment = {
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  metadata: { name: "web", namespace: "default", uid: "d-1" },
+  spec: { replicas: 3, selector: { matchLabels: { app: "web" } } },
+};
+
+const emptyList = { stdout: JSON.stringify({ items: [] }), stderr: "" };
+
+describe("k8s exportResources I/O glue (#160)", () => {
+  beforeEach(() => execMock.mockReset());
+
+  test("sweeps known kinds via `kubectl get <kind> -A -o json` and maps to IR", async () => {
+    execMock.mockImplementation((cmd?: string) =>
+      cmd?.includes("get deployment.apps")
+        ? { stdout: JSON.stringify({ items: [liveDeployment] }), stderr: "" }
+        : emptyList,
+    );
+    const ir = await exportResources({ environment: "prod" });
+    const cmds = execMock.mock.calls.map((c) => c[0] as string).filter(Boolean);
+    expect(cmds.every((c) => c.startsWith("kubectl get ") && c.endsWith("-A -o json"))).toBe(true);
+    expect(cmds).toContain("kubectl get deployment.apps -A -o json");
+    expect(ir.resources.map((r) => r.type)).toContain("K8s::Apps::Deployment");
+  });
+
+  test("a kind that errors is skipped; the rest of the sweep still maps", async () => {
+    execMock.mockImplementation((cmd?: string) => {
+      if (cmd?.includes("get secret ")) return new Error("Error from server (Forbidden)");
+      if (cmd?.includes("get deployment.apps")) {
+        return { stdout: JSON.stringify({ items: [liveDeployment] }), stderr: "" };
+      }
+      return emptyList;
+    });
+    const ir = await exportResources({ environment: "prod" });
+    expect(ir.resources.map((r) => r.type)).toContain("K8s::Apps::Deployment");
+  });
+
+  test("a type selector narrows the sweep to a single kubectl get", async () => {
+    execMock.mockImplementation(() => ({
+      stdout: JSON.stringify({ items: [liveDeployment] }),
+      stderr: "",
+    }));
+    await exportResources({ environment: "prod", selector: { type: "K8s::Apps::Deployment" } });
+    expect(execMock.mock.calls.length).toBe(1);
+    expect(execMock.mock.calls[0][0]).toBe("kubectl get deployment.apps -A -o json");
+  });
+});


### PR DESCRIPTION
Closes #160.

## What
Every `exportResources` shell-out path now has an executing test. Previously only the pure transforms (after the bytes return) were covered; command construction, exit-code handling, and absent-kind skipping were dark.

## Coverage (two mock seams)
- **aws** (`import/live-export-io.test.ts`) — mocks `@intentius/chant/runtime-adapter` `spawn`: `cloudformation get-template` argv + stack name, non-zero exit → throws with stderr, missing `TemplateBody` → throws.
- **gcp** (`export-resources-io.test.ts`) — mocks `node:child_process` exec: cnrm-kind discovery, per-kind `kubectl get` sweep, error-skip (RBAC/absent), empty-discovery short-circuit.
- **k8s** (`export-resources-io.test.ts`) — mocks exec: kind sweep with correct `kubectl get <kind> -A -o json`, error-skip, type-selector narrowing to one call.

Mocks deliver exec results synchronously (value or `Error`) so a skipped kind can't leave a dangling unhandled rejection.

## Verification
- `npx vitest run lexicons/aws/src/import lexicons/gcp/src lexicons/k8s/src` — 1119 passing.
- `npx tsc --noEmit -p packages/core/tsconfig.json` + eslint — clean.

(Azure's glue was covered in #166.)