### PR TITLE
fix(temporal): run onFailure compensation only on failure, in reverse

### DIFF
--- a/lexicons/temporal/src/op/op-serializer.test.ts
+++ b/lexicons/temporal/src/op/op-serializer.test.ts
@@ -227,6 +227,50 @@ describe("serializeOps()", () => {
       expect(wf).toContain("onFailure compensation");
       expect(wf).toContain("// Phase: Rollback");
     });
+
+    it("runs onFailure compensation ONLY on failure: main phases are wrapped in try/catch (#168)", () => {
+      const ops = new Map([
+        makeOp({
+          name: "deploy", overview: "o",
+          phases: [{ name: "Apply", steps: [{ kind: "activity", fn: "helmInstall", args: { name: "r", chart: "c" } }] }],
+          onFailure: [{ name: "Rollback", steps: [{ kind: "activity", fn: "helmInstall", args: { name: "r", chart: "c" } }] }],
+        }),
+      ]);
+      const wf = serializeOps(ops)["ops/deploy/workflow.ts"];
+      // Main phase guarded; compensation lives in the catch and re-throws the original error.
+      expect(wf).toContain("try {");
+      expect(wf).toContain("} catch (__opErr) {");
+      expect(wf).toContain("throw __opErr;");
+      // The compensation Phase upsert must appear after the catch opens, never before.
+      expect(wf.indexOf("catch (__opErr)")).toBeLessThan(wf.indexOf('Phase: ["Rollback"]'));
+    });
+
+    it("has no try/catch when there is no onFailure (#168)", () => {
+      const ops = new Map([
+        makeOp({
+          name: "plain", overview: "o",
+          phases: [{ name: "Apply", steps: [{ kind: "activity", fn: "helmInstall", args: { name: "r", chart: "c" } }] }],
+        }),
+      ]);
+      const wf = serializeOps(ops)["ops/plain/workflow.ts"];
+      expect(wf).not.toContain("catch (__opErr)");
+    });
+
+    it("runs onFailure phases in reverse order, matching the local executor (#168)", () => {
+      const ops = new Map([
+        makeOp({
+          name: "deploy", overview: "o",
+          phases: [{ name: "Apply", steps: [] }],
+          onFailure: [
+            { name: "Rollback", steps: [] },
+            { name: "Notify", steps: [] },
+          ],
+        }),
+      ]);
+      const wf = serializeOps(ops)["ops/deploy/workflow.ts"];
+      // Declared order Rollback→Notify, so compensation emits Notify before Rollback.
+      expect(wf.indexOf('Phase: ["Notify"]')).toBeLessThan(wf.indexOf('Phase: ["Rollback"]'));
+    });
   });
 
   // ── activities.ts ───────────────────────────────────────────────────────────

--- a/lexicons/temporal/src/op/serializer.ts
+++ b/lexicons/temporal/src/op/serializer.ts
@@ -213,11 +213,23 @@ function generateWorkflow(config: OpConfig): string {
     }
   };
 
-  renderPhases(config.phases);
-
   if (config.onFailure && config.onFailure.length > 0) {
-    lines.push("  // onFailure compensation (executed on terminal failure only)");
-    renderPhases(config.onFailure);
+    // Compensation must run ONLY on terminal failure, in reverse phase order,
+    // and must never mask the original error — matching the local executor
+    // (packages/core/src/op/local-executor.ts). Wrap the main phases in
+    // try/catch; run onFailure phases reversed in the catch (best-effort), then
+    // re-throw the original failure.
+    lines.push("  try {");
+    renderPhases(config.phases);
+    lines.push("  } catch (__opErr) {");
+    lines.push("    // onFailure compensation (reverse phase order, terminal failure only)");
+    lines.push("    try {");
+    renderPhases([...config.onFailure].reverse());
+    lines.push("    } catch { /* best-effort compensation — never mask the original error */ }");
+    lines.push("    throw __opErr;");
+    lines.push("  }");
+  } else {
+    renderPhases(config.phases);
   }
 
   lines.push("}");


### PR DESCRIPTION
Closes #168. Found during the lifecycle audit (#161 prep).

## Bug
`serializer.ts` `generateWorkflow` appended `onFailure` phases after the main phases with the comment "executed on terminal failure only" — but emitted **no try/catch**. Generated Temporal workflows therefore ran "compensation" on **every** run, in **forward** order, contradicting both the comment and the local executor (`local-executor.ts`), which runs `onFailure` **in reverse**, **only** on terminal failure. The old test only asserted the comment string, so it never caught this.

## Fix
Wrap the main phases in `try { … } catch (__opErr) { <onFailure reversed, best-effort>; throw __opErr; }`:
- compensation runs only on failure
- reverse phase order (matches local executor)
- best-effort inner try/catch so a failing compensation can't mask the original error
- original failure is always re-thrown

## Tests
New string assertions: try/catch guard present with `onFailure`, `throw __opErr`, compensation emitted after the catch opens, reverse order (Notify before Rollback), and **no** try/catch when there's no `onFailure`.

## Verification
- `npx vitest run lexicons/temporal` — 187 passing.
- `npx tsc --noEmit -p packages/core/tsconfig.json` + eslint — clean.
- Eyeballed generated output: balanced braces, gate inside the guarded try, compensation reversed.

Runtime verification under a real worker remains tracked by #161 (deferred — needs the @temporalio SDK).