### PR TITLE
test(lexicons): cross-lexicon lifecycle integration (aws, gcp, k8s, azure)

### DIFF
--- a/lexicons/aws/src/lifecycle-integration.test.ts
+++ b/lexicons/aws/src/lifecycle-integration.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Cross-lexicon lifecycle integration (#163) — AWS row.
+ *
+ * Drives the REAL awsPlugin through core's live-import driver
+ * (`liveImportFromPlugins`) and the changeset path (`buildChangeSet`), with the
+ * cloud edge (the runtime adapter's spawn) mocked. Proves the seam between core
+ * and a real lexicon — not a `createMockPlugin` fixture.
+ */
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const spawnMock = vi.fn();
+vi.mock("@intentius/chant/runtime-adapter", () => ({
+  getRuntime: () => ({ spawn: spawnMock }),
+}));
+
+const { awsPlugin } = await import("./plugin");
+const { liveImportFromPlugins } = await import("@intentius/chant/cli/commands/import");
+const { buildChangeSet } = await import("@intentius/chant/lifecycle/change-set");
+
+const liveTemplate = {
+  AWSTemplateFormatVersion: "2010-09-09",
+  Resources: {
+    MyBucket: { Type: "AWS::S3::Bucket", Properties: { BucketName: "my-bucket" } },
+  },
+};
+
+const ok = (stdout: string) => ({ stdout, stderr: "", exitCode: 0 });
+
+describe("aws lifecycle integration (#163)", () => {
+  beforeEach(() => spawnMock.mockReset());
+
+  test("live-import driver: real exportResources → IR → generated source", async () => {
+    spawnMock.mockResolvedValue(ok(JSON.stringify({ TemplateBody: liveTemplate })));
+    const output = mkdtempSync(join(tmpdir(), "chant-aws-li-"));
+    try {
+      const result = await liveImportFromPlugins([awsPlugin], {
+        environment: "prod",
+        output,
+        force: true,
+      });
+      expect(result.success).toBe(true);
+      expect(result.generatedFiles.length).toBeGreaterThan(0);
+      const all = readdirSync(output)
+        .map((f) => readFileSync(join(output, f), "utf-8"))
+        .join("\n");
+      expect(all).toContain("new Bucket(");
+      expect(all).toContain("BucketName");
+    } finally {
+      rmSync(output, { recursive: true, force: true });
+    }
+  });
+
+  test("changeset path: real describeResources → buildChangeSet verdicts", async () => {
+    // describe-stack-resources then describe-stacks.
+    spawnMock.mockImplementation((argv?: string[]) => {
+      if (argv?.includes("describe-stack-resources")) {
+        return Promise.resolve(
+          ok(
+            JSON.stringify({
+              StackResources: [
+                {
+                  LogicalResourceId: "MyBucket",
+                  ResourceType: "AWS::S3::Bucket",
+                  PhysicalResourceId: "my-bucket",
+                  ResourceStatus: "CREATE_COMPLETE",
+                  Timestamp: "2026-01-01T00:00:00Z",
+                },
+              ],
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(ok(JSON.stringify({ Stacks: [{ Outputs: [] }] })));
+    });
+
+    const observedNow = await awsPlugin.describeResources!({
+      environment: "prod",
+      buildOutput: "",
+      entityNames: ["MyBucket"],
+    });
+    expect(observedNow.MyBucket?.type).toBe("AWS::S3::Bucket");
+
+    // Declared "MyQueue" is absent from live → create; live "MyBucket" is
+    // undeclared and unmarked → adopt (never delete without ownership).
+    const cs = buildChangeSet("prod", {
+      declared: new Set(["MyQueue"]),
+      observedNow,
+      observedThen: undefined,
+    });
+    const byName = Object.fromEntries(cs.entries.map((e) => [e.name, e.action]));
+    expect(byName.MyQueue).toBe("create");
+    expect(byName.MyBucket).toBe("adopt");
+
+    // Declared + live with no drift → noop.
+    const cs2 = buildChangeSet("prod", {
+      declared: new Set(["MyBucket"]),
+      observedNow,
+      observedThen: undefined,
+    });
+    expect(cs2.entries.find((e) => e.name === "MyBucket")!.action).toBe("noop");
+  });
+});

--- a/lexicons/azure/src/lifecycle-integration.test.ts
+++ b/lexicons/azure/src/lifecycle-integration.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Cross-lexicon lifecycle integration (#163) — Azure row.
+ *
+ * Drives the REAL azurePlugin through core's live-import driver and the
+ * changeset path, with the `az` CLI edge mocked.
+ */
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    exec: (
+      cmd: string,
+      cb: (err: Error | null, out: { stdout: string; stderr: string }) => void,
+    ) => {
+      const r = execMock(cmd);
+      queueMicrotask(() =>
+        r instanceof Error
+          ? cb(r, { stdout: "", stderr: "" })
+          : cb(null, r as { stdout: string; stderr: string }),
+      );
+    },
+  };
+});
+
+const { azurePlugin } = await import("./plugin");
+const { liveImportFromPlugins } = await import("@intentius/chant/cli/commands/import");
+const { buildChangeSet } = await import("@intentius/chant/lifecycle/change-set");
+
+const liveTemplate = {
+  $schema:
+    "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  contentVersion: "1.0.0.0",
+  resources: [
+    {
+      type: "Microsoft.Storage/storageAccounts",
+      apiVersion: "2021-09-01",
+      name: "mystore",
+      location: "eastus",
+      properties: {},
+    },
+  ],
+};
+
+const resourceShow = {
+  id: "/subscriptions/s/resourceGroups/prod/providers/Microsoft.Storage/storageAccounts/mystore",
+  name: "mystore",
+  type: "Microsoft.Storage/storageAccounts",
+  location: "eastus",
+  properties: { provisioningState: "Succeeded" },
+};
+
+describe("azure lifecycle integration (#163)", () => {
+  beforeEach(() => execMock.mockReset());
+
+  test("live-import driver: real exportResources → IR → generated source", async () => {
+    execMock.mockReturnValue({ stdout: JSON.stringify(liveTemplate), stderr: "" });
+    const output = mkdtempSync(join(tmpdir(), "chant-azure-li-"));
+    try {
+      const result = await liveImportFromPlugins([azurePlugin], {
+        environment: "prod",
+        output,
+        force: true,
+      });
+      expect(result.success).toBe(true);
+      expect(result.generatedFiles.length).toBeGreaterThan(0);
+      const all = readdirSync(output)
+        .map((f) => readFileSync(join(output, f), "utf-8"))
+        .join("\n");
+      expect(all).toContain("mystore");
+    } finally {
+      rmSync(output, { recursive: true, force: true });
+    }
+  });
+
+  test("changeset path: real describeResources → buildChangeSet verdicts", async () => {
+    execMock.mockImplementation((cmd?: string) =>
+      cmd?.includes("resource show")
+        ? { stdout: JSON.stringify(resourceShow), stderr: "" }
+        : new Error("unexpected"),
+    );
+
+    const observedNow = await azurePlugin.describeResources!({
+      environment: "prod",
+      buildOutput: "",
+      entityNames: ["myStore"],
+      entities: new Map([
+        ["myStore", { entityType: "Microsoft.Storage/storageAccounts", props: { name: "mystore" } }],
+      ]),
+    });
+    expect(observedNow.myStore?.type).toBe("Microsoft.Storage/storageAccounts");
+
+    const cs = buildChangeSet("prod", {
+      declared: new Set(["myVnet"]),
+      observedNow,
+      observedThen: undefined,
+    });
+    const byName = Object.fromEntries(cs.entries.map((e) => [e.name, e.action]));
+    expect(byName.myVnet).toBe("create");
+    expect(byName.myStore).toBe("adopt");
+
+    const cs2 = buildChangeSet("prod", {
+      declared: new Set(["myStore"]),
+      observedNow,
+      observedThen: undefined,
+    });
+    expect(cs2.entries.find((e) => e.name === "myStore")!.action).toBe("noop");
+  });
+});

--- a/lexicons/gcp/src/lifecycle-integration.test.ts
+++ b/lexicons/gcp/src/lifecycle-integration.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Cross-lexicon lifecycle integration (#163) — GCP row.
+ *
+ * Drives the REAL gcpPlugin through core's live-import driver and the changeset
+ * path, with the `kubectl` (Config Connector) edge mocked.
+ */
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    exec: (
+      cmd: string,
+      cb: (err: Error | null, out: { stdout: string; stderr: string }) => void,
+    ) => {
+      const r = execMock(cmd);
+      queueMicrotask(() =>
+        r instanceof Error
+          ? cb(r, { stdout: "", stderr: "" })
+          : cb(null, r as { stdout: string; stderr: string }),
+      );
+    },
+  };
+});
+
+const { gcpPlugin } = await import("./plugin");
+const { liveImportFromPlugins } = await import("@intentius/chant/cli/commands/import");
+const { buildChangeSet } = await import("@intentius/chant/lifecycle/change-set");
+
+const liveBucket = {
+  apiVersion: "storage.cnrm.cloud.google.com/v1beta1",
+  kind: "StorageBucket",
+  metadata: { name: "my-bucket", namespace: "default", uid: "u-1" },
+  spec: { location: "US", storageClass: "STANDARD" },
+};
+
+describe("gcp lifecycle integration (#163)", () => {
+  beforeEach(() => execMock.mockReset());
+
+  test("live-import driver: real exportResources → IR → generated source", async () => {
+    execMock.mockImplementation((cmd?: string) => {
+      if (cmd?.includes("api-resources")) {
+        return { stdout: "storagebuckets.storage.cnrm.cloud.google.com\n", stderr: "" };
+      }
+      if (cmd?.includes("storagebuckets.storage.cnrm")) {
+        return { stdout: JSON.stringify({ items: [liveBucket] }), stderr: "" };
+      }
+      return { stdout: JSON.stringify({ items: [] }), stderr: "" };
+    });
+    const output = mkdtempSync(join(tmpdir(), "chant-gcp-li-"));
+    try {
+      const result = await liveImportFromPlugins([gcpPlugin], {
+        environment: "prod",
+        output,
+        force: true,
+      });
+      expect(result.success).toBe(true);
+      expect(result.generatedFiles.length).toBeGreaterThan(0);
+      const all = readdirSync(output)
+        .map((f) => readFileSync(join(output, f), "utf-8"))
+        .join("\n")
+        .toLowerCase();
+      expect(all).toContain("bucket");
+    } finally {
+      rmSync(output, { recursive: true, force: true });
+    }
+  });
+
+  test("changeset path: real describeResources → buildChangeSet verdicts", async () => {
+    execMock.mockImplementation((cmd?: string) =>
+      cmd?.includes("data-bucket")
+        ? {
+            stdout: JSON.stringify({
+              metadata: { name: "data-bucket", namespace: "config-control", uid: "uid-1" },
+              status: { conditions: [{ type: "Ready", status: "True" }] },
+            }),
+            stderr: "",
+          }
+        : new Error("not found"),
+    );
+
+    const observedNow = await gcpPlugin.describeResources!({
+      environment: "prod",
+      buildOutput: "",
+      entityNames: ["dataBucket"],
+      entities: new Map([
+        [
+          "dataBucket",
+          {
+            entityType: "GCP::Storage::Bucket",
+            props: { metadata: { name: "data-bucket", namespace: "config-control" } },
+          },
+        ],
+      ]),
+    });
+    expect(observedNow.dataBucket?.type).toBe("GCP::Storage::Bucket");
+
+    const cs = buildChangeSet("prod", {
+      declared: new Set(["pubsubTopic"]),
+      observedNow,
+      observedThen: undefined,
+    });
+    const byName = Object.fromEntries(cs.entries.map((e) => [e.name, e.action]));
+    expect(byName.pubsubTopic).toBe("create");
+    expect(byName.dataBucket).toBe("adopt");
+
+    const cs2 = buildChangeSet("prod", {
+      declared: new Set(["dataBucket"]),
+      observedNow,
+      observedThen: undefined,
+    });
+    expect(cs2.entries.find((e) => e.name === "dataBucket")!.action).toBe("noop");
+  });
+});

--- a/lexicons/k8s/src/lifecycle-integration.test.ts
+++ b/lexicons/k8s/src/lifecycle-integration.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Cross-lexicon lifecycle integration (#163) — Kubernetes row.
+ *
+ * Drives the REAL k8sPlugin through core's live-import driver and the changeset
+ * path, with the `kubectl` edge mocked.
+ */
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const execMock = vi.fn();
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    exec: (
+      cmd: string,
+      cb: (err: Error | null, out: { stdout: string; stderr: string }) => void,
+    ) => {
+      const r = execMock(cmd);
+      queueMicrotask(() =>
+        r instanceof Error
+          ? cb(r, { stdout: "", stderr: "" })
+          : cb(null, r as { stdout: string; stderr: string }),
+      );
+    },
+  };
+});
+
+const { k8sPlugin } = await import("./plugin");
+const { liveImportFromPlugins } = await import("@intentius/chant/cli/commands/import");
+const { buildChangeSet } = await import("@intentius/chant/lifecycle/change-set");
+
+const liveDeployment = {
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  metadata: { name: "web", namespace: "default", uid: "d-1" },
+  spec: { replicas: 3, selector: { matchLabels: { app: "web" } } },
+};
+
+const emptyList = { stdout: JSON.stringify({ items: [] }), stderr: "" };
+
+describe("k8s lifecycle integration (#163)", () => {
+  beforeEach(() => execMock.mockReset());
+
+  test("live-import driver: real exportResources → IR → generated source", async () => {
+    execMock.mockImplementation((cmd?: string) =>
+      cmd?.includes("get deployment.apps")
+        ? { stdout: JSON.stringify({ items: [liveDeployment] }), stderr: "" }
+        : emptyList,
+    );
+    const output = mkdtempSync(join(tmpdir(), "chant-k8s-li-"));
+    try {
+      const result = await liveImportFromPlugins([k8sPlugin], {
+        environment: "prod",
+        output,
+        force: true,
+      });
+      expect(result.success).toBe(true);
+      expect(result.generatedFiles.length).toBeGreaterThan(0);
+      const all = readdirSync(output)
+        .map((f) => readFileSync(join(output, f), "utf-8"))
+        .join("\n")
+        .toLowerCase();
+      expect(all).toContain("deployment");
+    } finally {
+      rmSync(output, { recursive: true, force: true });
+    }
+  });
+
+  test("changeset path: real describeResources → buildChangeSet verdicts", async () => {
+    execMock.mockImplementation((cmd?: string) =>
+      cmd?.includes("deployment.apps web")
+        ? {
+            stdout: JSON.stringify({
+              metadata: { name: "web", namespace: "prod", uid: "uid-1" },
+              status: { readyReplicas: 3, replicas: 3 },
+            }),
+            stderr: "",
+          }
+        : new Error("not found"),
+    );
+
+    const observedNow = await k8sPlugin.describeResources!({
+      environment: "prod",
+      buildOutput: "",
+      entityNames: ["web"],
+      entities: new Map([
+        ["web", { entityType: "K8s::Apps::Deployment", props: { metadata: { name: "web", namespace: "prod" } } }],
+      ]),
+    });
+    expect(observedNow.web?.type).toBe("K8s::Apps::Deployment");
+
+    const cs = buildChangeSet("prod", {
+      declared: new Set(["webSvc"]),
+      observedNow,
+      observedThen: undefined,
+    });
+    const byName = Object.fromEntries(cs.entries.map((e) => [e.name, e.action]));
+    expect(byName.webSvc).toBe("create");
+    expect(byName.web).toBe("adopt");
+
+    const cs2 = buildChangeSet("prod", {
+      declared: new Set(["web"]),
+      observedNow,
+      observedThen: undefined,
+    });
+    expect(cs2.entries.find((e) => e.name === "web")!.action).toBe("noop");
+  });
+});


### PR DESCRIPTION
Closes #163.

## What
Proves the seam between core's lifecycle drivers and the **real** lexicon plugins — previously only `createMockPlugin` fixtures exercised this path. One matrix row per cloud, each driving two core entry points with the cloud edge mocked:

1. **live-import driver** (`@intentius/chant/cli/commands/import` `liveImportFromPlugins`): real `exportResources` → IR → generated source written to a temp dir.
2. **changeset path** (`@intentius/chant/lifecycle/change-set` `buildChangeSet`): real `describeResources` → `diffLive` verdicts (`create` / `adopt` / `noop`).

## Notable assertion
Confirms the audited safe default: a live, undeclared, **unmarked** resource classifies as `adopt`, never `delete` — because real `describeResources` does not populate the live ownership marker. The `owned → delete` path stays covered by `change-set.test.ts` with synthetic metadata.

## Placement
Per-lexicon (`lexicons/<cloud>/src/lifecycle-integration.test.ts`) rather than in `packages/core`, to avoid a core→lexicon reverse dependency. Each row imports core via the `@intentius/chant/*` subpath exports (which resolve to core source under vitest).

## Verification
- `npx vitest run lexicons/aws lexicons/azure lexicons/gcp lexicons/k8s packages/core/src/lifecycle` — 2279 passing.
- `npx tsc --noEmit -p packages/core/tsconfig.json` + eslint — clean.

The full `runLifecycleDiff` CLI handler remains covered by `lifecycle.test.ts` (mock plugins); this PR adds the real-plugin coverage it lacked.