### PR TITLE
docs: scrub the word "honest" from documentation

### DIFF
--- a/docs/src/content/docs/concepts/lifecycle-models.mdx
+++ b/docs/src/content/docs/concepts/lifecycle-models.mdx
@@ -59,7 +59,7 @@ observe  →  reconcile  →  authoritative
 
 You turn the dial up per environment as trust and tooling allow. Nothing forces an environment past the position you chose for it.
 
-## The invariant that keeps it honest
+## The invariant that holds the line
 
 There is exactly one rule that prevents this model from quietly becoming the thing it avoids:
 


### PR DESCRIPTION
Removes the only occurrence of "honest" in the docs: the `lifecycle-models.mdx` heading "The invariant that keeps it honest" → "The invariant that holds the line".

Verified `grep -rni honest docs/src/content/docs/` returns nothing. `npm run --prefix docs build` passes (109 pages).