### PR TITLE
test: raise global vitest timeout to 20s (absorb CI contention)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,10 @@ export default defineConfig({
   test: {
     include: ["packages/**/*.test.ts", "lexicons/**/*.test.ts"],
     environment: "node",
+    // The Temporal runtime/compile-smoke suites bundle workflows with webpack
+    // in-process, which loads the CI runner enough to push short-timeout tests
+    // (e.g. build.test.ts discovery) past the 5s default under contention.
+    // 20s absorbs that without masking a genuinely hung test for long.
+    testTimeout: 20_000,
   },
 });


### PR DESCRIPTION
The Temporal runtime/compile-smoke suites (#161/#162) bundle workflows with webpack in-process. On the CI runner that load intermittently pushes short-timeout tests past the 5s vitest default — `build.test.ts`'s discovery tests timed out on an unrelated one-word docs PR (#179), then passed on re-run.

Raises the global `testTimeout` to 20s. Tests that pass quickly still pass quickly; only tests that would otherwise time out are affected. The Temporal harness tests already set their own 120s per-test timeouts.

## Verification
- `npx vitest run packages/core/src/build.test.ts` — 16 passing.