### PR TITLE
docs: op files must default-export the Op (chant run discovery)

### DIFF
--- a/docs/src/content/docs/guide/ops.mdx
+++ b/docs/src/content/docs/guide/ops.mdx
@@ -243,17 +243,18 @@ The `ReconcileOp` composite takes the next step on the dial: when live drifts fr
 ```typescript
 import { ReconcileOp } from "@intentius/chant-lexicon-temporal";
 
-// one-shot on the local executor
-export const { op } = ReconcileOp({ name: "prod-reconcile", env: "prod" });
-
-// scheduled on Temporal, owned-only
-export const { op, schedule } = ReconcileOp({
+// Scheduled on Temporal, owned-only. Omit `schedule` for a one-shot
+// `chant run prod-reconcile` on the local executor.
+const { op, schedule } = ReconcileOp({
   name: "prod-reconcile",
   env: "prod",
   schedule: "0 * * * *",       // hourly
   scope: { owned: true },
   onDrift: "pull-request",      // or "issue" | "report"
 });
+
+export default op;        // the Op — discovered by `chant run prod-reconcile`
+export { schedule };      // the TemporalSchedule — deployed by `chant build`
 ```
 
 Run `chant run prod-reconcile` for a one-shot reconcile on the local executor; give it a `schedule` to run continuously on Temporal, where the cron and run history are the value (as with `WatchOp`). The primitives need no executor — only the scheduled, durable form requires Temporal.
@@ -265,17 +266,17 @@ The `ApplyOp` composite is the other direction: compute the plan, then apply via
 ```typescript
 import { ApplyOp } from "@intentius/chant-lexicon-temporal";
 
-// additive apply on the local executor
-export const { op } = ApplyOp({ name: "prod-apply", env: "prod", target: "kubectl" });
-
-// gated destructive apply on Temporal
-export const { op } = ApplyOp({
+// Gated destructive apply on Temporal. Drop `delete`/`gate` for an additive
+// apply that also runs one-shot on the local executor.
+const { op } = ApplyOp({
   name: "prod-apply",
   env: "prod",
   target: "kubectl",
   delete: "gated",   // "never" | "owned-only" | "gated"
   gate: { signalName: "approve-apply", description: "Approve prod apply with deletes" },
 });
+
+export default op;
 ```
 
 `delete` controls how apply treats resources no longer declared. Deletes ride the target's **native** delete path scoped to the ownership marker — `kubectl apply --prune --selector app.kubernetes.io/managed-by=chant`, the CloudFormation stack boundary, or ARM `--mode Complete`. Because the prune is marker-scoped, a foreign (unmarked) resource is never touched: deletes are owned-only by construction.

--- a/docs/src/content/docs/guide/reconciling-lifecycle.mdx
+++ b/docs/src/content/docs/guide/reconciling-lifecycle.mdx
@@ -18,13 +18,16 @@ When the live system is ahead of source — someone created or changed a resourc
 ```typescript
 import { ReconcileOp } from "@intentius/chant-lexicon-temporal";
 
-export const { op, schedule } = ReconcileOp({
+const { op, schedule } = ReconcileOp({
   name: "prod-reconcile",
   env: "prod",
   schedule: "0 * * * *",      // hourly, on Temporal
   scope: { owned: true },     // only chant-owned resources
   onDrift: "pull-request",    // or "issue" | "report"
 });
+
+export default op;        // the Op — discovered by `chant run prod-reconcile`
+export { schedule };      // the TemporalSchedule — deployed by `chant build`
 ```
 
 Phases: **Snapshot → Plan → Reconcile**, where the Reconcile phase's `reconcilePr` activity regenerates source ([live import](/chant/guide/live-import/)) and opens the PR in one step. Run `chant run prod-reconcile` for a one-shot reconcile on the local executor; give it a `schedule` to run continuously on Temporal. The PR's diff *is* the regenerated TypeScript, so review is a normal code review.
@@ -38,13 +41,15 @@ When source is the intended truth and the cloud should follow, [`ApplyOp`](/chan
 ```typescript
 import { ApplyOp } from "@intentius/chant-lexicon-temporal";
 
-export const { op } = ApplyOp({
+const { op } = ApplyOp({
   name: "prod-apply",
   env: "prod",
   target: "kubectl",
   delete: "gated",   // "never" | "owned-only" | "gated"
   gate: { signalName: "approve-apply" },
 });
+
+export default op;
 ```
 
 Authority stays with the platform — chant hosts no state file. Deletes ride the native delete path scoped to the ownership marker, so they only ever touch **chant-owned** orphans. A destructive apply gets an approval gate and saga-style rollback; see [Gates and compensation](/chant/guide/ops/#gates-and-compensation--where-temporal-is-load-bearing) for why that half is Temporal-bound.

--- a/docs/src/content/docs/guide/watching-lifecycle.mdx
+++ b/docs/src/content/docs/guide/watching-lifecycle.mdx
@@ -29,11 +29,14 @@ Save anywhere in your project as a `*.op.ts` file. The composite returns a chant
 // prod-watch.op.ts
 import { WatchOp } from "@intentius/chant-lexicon-temporal";
 
-export const { op, schedule } = WatchOp({
+const { op, schedule } = WatchOp({
   name: "prod-watch",
   env: "prod",
   schedule: "*/15 * * * *",  // every 15 minutes
 });
+
+export default op;        // the Op — discovered by `chant run prod-watch`
+export { schedule };      // the TemporalSchedule — deployed by `chant build`
 ```
 
 That's the whole declaration. Run `chant build` and you'll get:


### PR DESCRIPTION
The **Ops**, **Watching Lifecycle**, and **Reconciling Lifecycle** guides showed `export const { op } = ReconcileOp(...)` / `WatchOp(...)` / `ApplyOp(...)`. But `chant run` discovery (`discoverOps`) reads only the module's **default** export — a named `op` export is never found, failing with *"default export is not an object."* Every shipped example (`local-op-quickstart`, `lifecycle-reconcile-aws`, …) uses `export default`.

Fixes all snippets to the working pattern:

```ts
const { op, schedule } = ReconcileOp({ … });
export default op;        // discovered by `chant run`
export { schedule };      // the TemporalSchedule, deployed by `chant build`
```

Verified empirically that with this shape, discovery sees the default Op **and** the named schedule (so `chant run` finds the op and `chant build` still deploys the schedule). Consolidated the two-variant `ops.mdx` blocks so a single file never shows two `export default`.

## Verification
- `grep -rn "export const { op" docs/` — nothing.
- `npm run --prefix docs build` — 109 pages, clean.