### PR TITLE
ci(chant): run once per commit + cancel superseded runs

### DIFF
--- a/.github/workflows/chant.yml
+++ b/.github/workflows/chant.yml
@@ -1,6 +1,17 @@
 name: chant
 
-on: [push, pull_request]
+# Run once per commit: on PRs (pull_request) and on pushes to main
+# (post-merge validation). Without scoping `push` to main, a commit on a
+# branch that has an open PR triggers two identical runs.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref so a new push stops the previous run.
+concurrency:
+  group: chant-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
`chant.yml` used `on: [push, pull_request]`, so every commit on a branch with an open PR triggered **two identical runs** — one `push` (for the branch) and one `pull_request` (for the PR) — doubling CI time and cost on the heavy check/test/validate jobs.

## Change
```yaml
on:
  push:
    branches: [main]   # post-merge validation only
  pull_request:        # PR branches

concurrency:
  group: chant-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Now: PR commits run once (`pull_request`); merges to `main` run once (`push`); a new push cancels the previous in-progress run on the same ref.

## Note on required checks
If branch protection lists required status checks by name, they'll now come from the `pull_request` run on PRs (the same job names: `check` / `test` / `validate`). PRs already merge off these runs, so no name change — but worth a glance at branch-protection settings after merge.