### PR TITLE
ci: distinct run-name per workflow (stop identical run titles)

### DIFF
--- a/.github/workflows/chant.yml
+++ b/.github/workflows/chant.yml
@@ -1,5 +1,8 @@
 name: chant
 
+# Distinct title so it isn't confused with other workflows on the same commit.
+run-name: chant — ${{ github.head_ref || github.ref_name }}
+
 # Run once per commit: on PRs (pull_request) and on pushes to main
 # (post-merge validation). Without scoping `push` to main, a commit on a
 # branch that has an open PR triggers two identical runs.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: docs
 
+# Distinct title so it isn't confused with the chant workflow on the same commit.
+run-name: docs — ${{ github.head_ref || github.ref_name }}
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
On the same commit, the `chant` and `docs` workflows both ran with the **same title** — the commit message — because neither set a `run-name`. In the Actions UI that's two visually identical rows, distinguishable only by the workflow-name column.

Adds a distinct `run-name` to each:
- `chant — <ref>`
- `docs — <ref>`

So concurrent runs read e.g. `chant — main` / `docs — main` instead of two copies of the commit message. No behavior change — display only.