### PR TITLE
docs: propagate lifecycle/BYOL framing into reference, guides, changelog (#187)

### DIFF
--- a/docs/src/content/docs/cli/import.mdx
+++ b/docs/src/content/docs/cli/import.mdx
@@ -32,13 +32,13 @@ The import process:
 | `-d, --lexicon <name>` | With `--from`, restrict to one lexicon (e.g. `aws`, `k8s`) |
 | `--type <ResourceType>` | With `--from`, export only resources of this type |
 | `--name <name>` | With `--from`, export only the resource with this name |
-| `--owned` | With `--from`, restrict to chant-owned resources (inert until ownership marking lands) |
+| `--owned` | With `--from`, restrict to chant-owned resources — those carrying the live [ownership marker](/chant/configuration/config-file/#ownership) |
 | `--verbatim` | With `--from`, keep server-defaulted fields instead of stripping to declared shape |
 | `-o, --output <dir>` | Output directory (default: `./infra/`) |
 | `--force` | Overwrite existing files |
 
 :::caution
-Live import may emit sensitive values (keys, tokens, passwords) into generated source — unlike `state`, which only reads scrubbed metadata. The command prints a warning; review generated files before committing.
+Live import may emit sensitive values (keys, tokens, passwords) into generated source — unlike `chant lifecycle` observation, which only reads scrubbed metadata. The command prints a warning; review generated files before committing.
 :::
 
 ## Usage

--- a/docs/src/content/docs/cli/lifecycle.mdx
+++ b/docs/src/content/docs/cli/lifecycle.mdx
@@ -94,6 +94,21 @@ The classification reads ownership from the live marker, **never from the snapsh
 
 `lifecycle plan` is strictly read-only: it builds, queries, and classifies. It never mutates the cloud and never deploys — `chant build` stays pure.
 
+#### Crosswalk: observation categories → plan actions
+
+The six `diff --live` categories and the five `plan` actions describe the same signal on different axes. Observation categories key on three sets — declared in source, observed now, in the last snapshot. The plan collapses the snapshot axis (it's evidence, never authority) and adds an ownership axis. The mapping:
+
+| Observation category (`diff --live`) | Plan action (`plan`) | Why |
+|---|---|---|
+| **missing** | **create** | Declared, absent from the cloud |
+| **drifted** | **update** *(when declared)* | Declared and live, attributes changed since the snapshot |
+| **orphan** | **adopt**, or **delete** when the live ownership marker confirms it's chant's | The one decision the **marker** makes — never the snapshot |
+| **newly observed** | **noop** | Declared and live; no snapshot baseline to drift against yet |
+| **unchanged** | **noop** *(when declared)* | Declared and live, identical |
+| **disappeared** | **create** if still declared, else **noop** | A snapshot-history signal; the plan reads live + source, not snapshot age |
+
+The "when declared" qualifiers are where the axes diverge: an undeclared resource that also **drifted** or is **unchanged** is still an **orphan** to the plan — the snapshot history doesn't change that it's live-but-undeclared, so ownership decides between `adopt` and `delete`.
+
 ### Resources vs artifacts
 
 A single lexicon may report both **resources** (entity-keyed, via `describeResources()`) and **artifacts** (context-keyed, via `listArtifacts()`); `lifecycle diff --live` shows them in separate sections. Artifacts use a four-category two-way diff (no "declared" axis):

--- a/docs/src/content/docs/cli/lifecycle.mdx
+++ b/docs/src/content/docs/cli/lifecycle.mdx
@@ -1,6 +1,6 @@
 ---
 title: "chant lifecycle"
-description: Capture and compare deployed infrastructure state
+description: Capture, diff, and plan against deployed infrastructure — the observational lifecycle commands
 ---
 
 ## Synopsis
@@ -9,6 +9,7 @@ description: Capture and compare deployed infrastructure state
 chant lifecycle snapshot <env> [lexicon]
 chant lifecycle show <env>
 chant lifecycle diff <env> [--live]
+chant lifecycle plan <env> [--json] [--owned]
 chant lifecycle log [env]
 ```
 
@@ -24,7 +25,7 @@ For the conceptual model behind these commands — observational vs. authoritati
 
 ### `lifecycle snapshot <env>`
 
-Query the provider API for the current deployed state, then save a snapshot to the `chant-state/<env>` orphan branch.
+Query the provider API for the current deployed state, then save a snapshot to the `chant/lifecycle` orphan branch.
 
 ```bash
 chant lifecycle snapshot dev

--- a/docs/src/content/docs/concepts/drift-detection.mdx
+++ b/docs/src/content/docs/concepts/drift-detection.mdx
@@ -20,7 +20,7 @@ chant's snapshots are **observational**. They're a forensic record: "this is wha
 | State must be locked; concurrent writes corrupt | A stale snapshot is inconvenient, not dangerous |
 | Sensitive data leaks into state file | Snapshots record metadata only — no secrets |
 | Bad state breaks deploys | Bad snapshot is a record problem; deploys query live APIs |
-| `apply` knows exactly what to change | No automatic plan/apply — agents verify before acting |
+| `apply` knows exactly what to change | Precise change set comes from live projection (`lifecycle plan`); chant computes it but never auto-applies |
 
 For the broader trade-off comparison, see [State: authoritative vs. observational](/chant/concepts/comparison/#state-authoritative-vs-observational) in the comparison guide.
 
@@ -98,7 +98,7 @@ The pragmatic test: would you act on a drift signal if it fired right now? If ye
 chant's observational model is a deliberate choice, not a missing feature. The costs:
 
 - **No automatic remediation.** Drift tells you something changed; it doesn't snap the cloud back. That's an agent or a human decision because the right answer is domain-specific.
-- **No automatic plan/apply.** Without authoritative state, chant can't compute a precise change set the way Terraform does. Diff output is informational; the apply step is your existing tooling.
+- **It plans, but never applies.** chant computes a precise create/update/delete change set against live — [`chant lifecycle plan`](/chant/cli/lifecycle/) reads ownership from the live marker, not the snapshot — but it stops at the artifact. Executing it is your tooling's job: a CI job, an agent, or a [`ReconcileOp`](/chant/guide/reconciling-lifecycle/) / [`ApplyOp`](/chant/guide/reconciling-lifecycle/). The diff is informational; the plan is actionable; neither mutates the cloud.
 - **No locking.** Two operators snapshotting the same env at the same time race on the orphan branch. The push uses `--force-with-lease` so the second writer fails fast rather than silently overwriting (see [Concurrent snapshots](/chant/cli/lifecycle/#concurrent-snapshots)).
 - **Coverage is per-lexicon.** A lexicon without `describeResources()` / `listArtifacts()` is warn-skipped. The [Runtime observation coverage matrix](/chant/lexicons/overview/#runtime-observation-coverage) lists where coverage exists today.
 

--- a/docs/src/content/docs/concepts/drift-detection.mdx
+++ b/docs/src/content/docs/concepts/drift-detection.mdx
@@ -55,6 +55,8 @@ The diff engine compares three axes: what's declared in source now, what was obs
 
 Drifted entries include attribute-level deltas so you can see *what* changed, not just *that* something changed.
 
+These six categories collapse into the five `create/update/delete/adopt/noop` actions `chant lifecycle plan` emits — see the [observation-to-action crosswalk](/chant/cli/lifecycle/#crosswalk-observation-categories--plan-actions).
+
 #### Resolving an `orphan`
 
 An orphan is a resource in the cloud that source doesn't know about. Detection is the first position on the [dial](/chant/concepts/lifecycle-models/#the-dial); resolving it is the next. There are two moves:

--- a/docs/src/content/docs/concepts/durable-workflows.mdx
+++ b/docs/src/content/docs/concepts/durable-workflows.mdx
@@ -3,7 +3,7 @@ title: Durable Workflows for Infrastructure (Temporal IaC)
 description: Why infrastructure orchestration wants durable execution — approval gates, compensation, and crash-resume — and how chant uses Temporal for it.
 ---
 
-Most infrastructure-as-code stops at synthesis: it produces the artifact and hands off. The orchestration that actually applies it — the gates, the retries, the rollback when step seven of nine fails — lives in shell scripts, CI YAML, and the operator's memory. chant takes the opposite position. Orchestration is declared as code in `*.op.ts` files and runs as an inspectable, durable workflow.
+Synthesis is the easy half. Every IaC toolchain produces an artifact. The hard half is what happens after — the gated, multi-step, cross-system apply, and the rollback when step seven of nine fails. The others weld a fixed lifecycle to their engine and still leave that orchestration to shell scripts, CI YAML, and the operator's memory. chant keeps synthesis pure and holds no opinion of its own, then lets you declare the orchestration as code in `*.op.ts` files that run as inspectable, durable workflows.
 
 No other IaC toolchain exposes its orchestration as first-class durable execution. This page explains why that matters, and why it stays optional.
 

--- a/docs/src/content/docs/guide/live-import.mdx
+++ b/docs/src/content/docs/guide/live-import.mdx
@@ -15,7 +15,7 @@ chant import --from prod --output src/
 2. Call each project lexicon's `exportResources()` capability for full-fidelity config.
 3. Generate TypeScript with the same by-category organization as file import.
 
-Unlike `state`, which only ever reads scrubbed metadata, live import emits the resource's **full input config** — so it may surface secrets. The command prints a warning; review generated files before committing.
+Unlike `chant lifecycle` observation, which only ever reads scrubbed metadata, live import emits the resource's **full input config** — so it may surface secrets. The command prints a warning; review generated files before committing.
 
 ## Selectors
 

--- a/docs/src/content/docs/guide/ops.mdx
+++ b/docs/src/content/docs/guide/ops.mdx
@@ -93,7 +93,7 @@ Pre-built step builders:
 | `helmInstall(name, chart, opts?)` | `helm upgrade --install` |
 | `waitForStack(stackFile, opts?)` | Poll until a chant stack output file is ready |
 | `gitlabPipeline(projectId, ref, opts?)` | Trigger a GitLab pipeline and wait |
-| `stateSnapshot(env, opts?)` | `chant lifecycle snapshot` |
+| `lifecycleSnapshot(env, opts?)` | `chant lifecycle snapshot` |
 | `teardown(path, opts?)` | Build + destroy |
 
 A reconcile activity is also available via `activity("reconcilePr", args)`: given the change-set entries that triggered it, it regenerates TypeScript with `chant import --from <env>` and opens a reviewable PR (modes: `pull-request`, `issue`, `report`). It never commits to the main branch. It is the building block for the reconcile workflow (cloud → code).
@@ -213,9 +213,9 @@ Activity steps support an optional `outcomeAttribute` field that captures the ac
 phase("Diff", [
   {
     kind: "activity",
-    fn: "stateDiff",
+    fn: "lifecycleDiff",
     args: { env: "prod", live: true },
-    // Capture stateDiff's `drifted` field and tag the run Drift=true/false
+    // Capture lifecycleDiff's `drifted` field and tag the run Drift=true/false
     outcomeAttribute: { name: "Drift", from: "drifted" },
   },
 ]),
@@ -224,7 +224,7 @@ phase("Diff", [
 The serializer turns this into:
 
 ```typescript
-const __r0 = await stateDiff({"env":"prod","live":true});
+const __r0 = await lifecycleDiff({"env":"prod","live":true});
 upsertSearchAttributes({ "Drift": [String(__r0?.drifted)] });
 ```
 

--- a/docs/src/content/docs/guide/reconciling-lifecycle.mdx
+++ b/docs/src/content/docs/guide/reconciling-lifecycle.mdx
@@ -66,6 +66,8 @@ The same project can sit at different positions per environment:
 
 Nothing forces an environment past the position you chose for it. Turn the dial up as trust and tooling allow.
 
+The position is not a config field. `environments` in `chant.config.ts` is just a list of names — there is no `model` or `dial` setting on an environment. You choose the position by which verb you run against it: `chant lifecycle diff --live` for observe, a `ReconcileOp` for reconcile, an `ApplyOp` for apply. An environment sits at observe until a reconcile or apply Op is wired to it and run. To pin a position, control what exists and what runs — put `lifecycle diff --live` in dev's CI and commit no apply Op for dev, and dev stays observe-only by construction. There is no global switch to flip, which is why nothing can force an environment past where you left it.
+
 ## When to pick each
 
 - **Observe** when the cloud is changed by other tools you don't want to fight, and you just need visibility.

--- a/docs/src/content/docs/guide/watching-lifecycle.mdx
+++ b/docs/src/content/docs/guide/watching-lifecycle.mdx
@@ -55,8 +55,8 @@ chant run prod-watch         # one-shot run, useful for smoke-testing
 
 The two phases compile down to a workflow that, on each tick:
 
-1. **`Snapshot`** — calls the `stateSnapshot` activity, which shells out to `chant lifecycle snapshot prod`. The result is committed to the `chant/lifecycle` orphan branch. (Concurrent runs are protected by `--force-with-lease` — see [Concurrent snapshots](/chant/cli/lifecycle/#concurrent-snapshots).)
-2. **`Diff`** — calls `stateDiff` with `live: true`. The activity returns `{ output, exitCode, drifted }`. The `drifted` boolean is captured as a workflow search attribute via `outcomeAttribute: { name: "Drift", from: "drifted" }`.
+1. **`Snapshot`** — calls the `lifecycleSnapshot` activity, which shells out to `chant lifecycle snapshot prod`. The result is committed to the `chant/lifecycle` orphan branch. (Concurrent runs are protected by `--force-with-lease` — see [Concurrent snapshots](/chant/cli/lifecycle/#concurrent-snapshots).)
+2. **`Diff`** — calls `lifecycleDiff` with `live: true`. The activity returns `{ output, exitCode, drifted }`. The `drifted` boolean is captured as a workflow search attribute via `outcomeAttribute: { name: "Drift", from: "drifted" }`.
 
 Set `live: false` on the composite to use digest-only diff (faster, no cloud queries) for environments without `describeResources()` coverage. With `live: true` (the default) you get external-mutation detection. (See the [Runtime observation coverage matrix](/chant/lexicons/overview/#runtime-observation-coverage) for which lexicons report what.)
 
@@ -102,7 +102,7 @@ ARTIFACTS ADDED (1)
   helm:demo-drift  chart=nginx  rev=1
 ```
 
-`stateDiff`'s `drifted` flag is true (the `ARTIFACTS ADDED` header matches the drift detector). On the next watch tick the corresponding workflow run will be tagged `Drift = "true"`. Clean up:
+`lifecycleDiff`'s `drifted` flag is true (the `ARTIFACTS ADDED` header matches the drift detector). On the next watch tick the corresponding workflow run will be tagged `Drift = "true"`. Clean up:
 
 ```bash
 helm uninstall demo-drift
@@ -118,7 +118,7 @@ The next tick should show `Drift = "false"` again.
 phase("Diff", [
   {
     kind: "activity",
-    fn: "stateDiff",
+    fn: "lifecycleDiff",
     args: { env: "prod", live: true },
     outcomeAttribute: { name: "Drift", from: "drifted" },
   },
@@ -128,11 +128,11 @@ phase("Diff", [
 The serializer produces:
 
 ```typescript
-const __r0 = await stateDiff({ env: "prod", live: true });
+const __r0 = await lifecycleDiff({ env: "prod", live: true });
 upsertSearchAttributes({ Drift: [String(__r0?.drifted)] });
 ```
 
-`from` is a dot-path into the activity's return value. With `stateDiff`'s shape `{ output, exitCode, drifted }`, you could just as easily capture the exit code (`from: "exitCode"`) or the raw output (omit `from` to stringify the whole result). The composite picks `drifted` because it's the field most worth filtering on.
+`from` is a dot-path into the activity's return value. With `lifecycleDiff`'s shape `{ output, exitCode, drifted }`, you could just as easily capture the exit code (`from: "exitCode"`) or the raw output (omit `from` to stringify the whole result). The composite picks `drifted` because it's the field most worth filtering on.
 
 ## Choosing a schedule
 
@@ -148,7 +148,7 @@ Bias toward less frequent. Each tick re-queries every covered lexicon's API; rat
 
 ## Profile selection
 
-`stateSnapshot` and `stateDiff` are activities — they pick up the same Temporal retry/timeout profiles as any other Op step. Both default to `fastIdempotent` (5 min timeout, 3 retries) which is right for most environments.
+`lifecycleSnapshot` and `lifecycleDiff` are activities — they pick up the same Temporal retry/timeout profiles as any other Op step. Both default to `fastIdempotent` (5 min timeout, 3 retries) which is right for most environments.
 
 If your snapshot regularly takes longer than five minutes (large multi-region estates, slow `kubectl` against many resources), declare the activity with `profile: "longInfra"` directly instead of using the composite — `WatchOp` is a thin wrapper, you can always emit the equivalent `Op({ phases: [...] })` by hand.
 

--- a/docs/src/content/docs/lexicon-authoring/live-export.mdx
+++ b/docs/src/content/docs/lexicon-authoring/live-export.mdx
@@ -20,7 +20,7 @@ exportResources?(options: {
 }): Promise<ExportedTemplate>;
 ```
 
-The result is the existing import IR (`TemplateIR`), branded as `ExportedTemplate`, so it feeds your lexicon's `templateGenerator()` unchanged. The brand keeps a full-fidelity export — which may carry secrets — from flowing into the `state` code paths, which consume scrubbed metadata through the `ObservationLexicon` view.
+The result is the existing import IR (`TemplateIR`), branded as `ExportedTemplate`, so it feeds your lexicon's `templateGenerator()` unchanged. The brand keeps a full-fidelity export — which may carry secrets — from flowing into the `lifecycle` code paths, which consume scrubbed metadata through the `ObservationLexicon` view.
 
 <Aside type="caution">
 Keep the scrubbing boundary single-purpose. `describeResources()` scrubs for diffing; `exportResources()` returns full config for regeneration. Never overload one method for both — the secret-exposure surface stays in one place.

--- a/docs/src/content/docs/lexicon-authoring/observation.mdx
+++ b/docs/src/content/docs/lexicon-authoring/observation.mdx
@@ -269,12 +269,12 @@ That is a separate, opt-in capability:
 exportResources?(options: {
   environment: string;
   selector?: ResourceSelector;   // { type?, name? }
-  owned?: boolean;               // inert until ownership marking lands
+  owned?: boolean;               // restrict to chant-owned resources (live marker)
   verbatim?: boolean;            // keep server-defaulted fields; default strips
 }): Promise<ExportedTemplate>;
 ```
 
-`ExportedTemplate` is the existing import IR (`TemplateIR`) — so the result feeds your lexicon's `templateGenerator()` unchanged — branded distinct from the observation types. The brand is the contract's guardrail: a full-fidelity export (which may carry secrets) can never flow into the `state` code paths, which consume `ResourceMetadata` through the `ObservationLexicon` view that omits `exportResources` entirely.
+`ExportedTemplate` is the existing import IR (`TemplateIR`) — so the result feeds your lexicon's `templateGenerator()` unchanged — branded distinct from the observation types. The brand is the contract's guardrail: a full-fidelity export (which may carry secrets) can never flow into the `lifecycle` code paths, which consume `ResourceMetadata` through the `ObservationLexicon` view that omits `exportResources` entirely.
 
 <Aside type="caution">
 Keep the scrubbing boundary single-purpose. `describeResources()` scrubs for diffing; `exportResources()` returns full config for regeneration. Never overload one method for both — the secret-exposure surface stays in one place.

--- a/docs/src/content/docs/whats-new.mdx
+++ b/docs/src/content/docs/whats-new.mdx
@@ -1,19 +1,19 @@
 ---
 title: What's New
-description: Recent capabilities shipped in chant — live import, the state-model dial, ownership markers, reconcile/apply Ops, observation contracts, drift detection, and more
+description: Recent capabilities shipped in chant — live import, the lifecycle dial, ownership markers, reconcile/apply Ops, observation contracts, drift detection, and more
 ---
 
 A hand-curated rollup of capabilities shipped recently. If you learned chant before this lands, this page is the catch-up. Each entry links to the closing issue or PR for the full context.
 
 For the day-to-day reference docs see [Lifecycle Models](/chant/concepts/lifecycle-models/), [`chant lifecycle`](/chant/cli/lifecycle/), [Live Import](/chant/guide/live-import/), [Reconciling Lifecycle](/chant/guide/reconciling-lifecycle/), [Drift Detection](/chant/concepts/drift-detection/), and [Implementing Observation](/chant/lexicon-authoring/observation/).
 
-## Live import & the state-model dial
+## Live import & the lifecycle dial
 
 The follow-on to the observation thread: chant turned its single observational drift workflow into a full family — **observe → reconcile → authoritative**, chosen per environment. It gained *live import* (regenerate TypeScript from running cloud/cluster state) and *projection + cloud-side ownership* (a precise create/update/delete change set computed against live), **without** hosting an authoritative state file. The snapshot is never load-bearing — the projection reads ownership from the live resource only. Primitives need no executor; only gated/destructive Ops require Temporal.
 
 | # | Capability |
 |---|---|
-| [#113](https://github.com/INTENTIUS/chant/issues/113) | `exportResources()` on the `LexiconPlugin` contract — full-fidelity import IR from a live API, branded distinct from the scrubbed observation types so a secret-bearing export can never reach the `state` code paths |
+| [#113](https://github.com/INTENTIUS/chant/issues/113) | `exportResources()` on the `LexiconPlugin` contract — full-fidelity import IR from a live API, branded distinct from the scrubbed observation types so a secret-bearing export can never reach the `lifecycle` code paths |
 | [#114](https://github.com/INTENTIUS/chant/issues/114) | [`chant import --from <env>`](/chant/cli/import/) — live import driver with `--type` / `--name` / `--owned` / `--verbatim` selectors and a secrets warning |
 | [#115](https://github.com/INTENTIUS/chant/issues/115), [#116](https://github.com/INTENTIUS/chant/issues/116), [#117](https://github.com/INTENTIUS/chant/issues/117) | Live export for AWS (CloudFormation `get-template`), Kubernetes (`kubectl get -o json`, stripped to declared shape), and GCP Config Connector |
 | [#159](https://github.com/INTENTIUS/chant/issues/159) | Live export for Azure (`az group export`) — makes Azure a full live-import peer alongside AWS, GCP, and Kubernetes; `--owned` filtering via the `chant-managed-by` tag |
@@ -40,8 +40,6 @@ The biggest single thread. `chant lifecycle diff` went from a digest-vs-digest f
 | [#51](https://github.com/INTENTIUS/chant/issues/51) | `listArtifacts()` plugin contract — context-keyed observation for lexicons whose chant entities describe authoring primitives rather than 1:1 cloud resources |
 | [#52](https://github.com/INTENTIUS/chant/issues/52) | Helm `listArtifacts()` — Helm releases via `helm list -A -o json` |
 | [#53](https://github.com/INTENTIUS/chant/issues/53) | Docker `listArtifacts()` — containers / images / networks via three independent NDJSON queries |
-| [#54](https://github.com/INTENTIUS/chant/issues/54) | Flyway `listArtifacts()` — per-environment migration history |
-| [#55](https://github.com/INTENTIUS/chant/issues/55) | Slurm `listArtifacts()` — partition state via `sinfo` |
 | [#56](https://github.com/INTENTIUS/chant/issues/56) | GitHub / GitLab — runtime observation documented as N/A; both describe git-tracked authoring primitives where drift is `git diff` |
 | [#30](https://github.com/INTENTIUS/chant/issues/30) | `chant/lifecycle` orphan branch concurrency — pushes use `--force-with-lease`; concurrent snapshots fail fast instead of silently overwriting |
 | [#31](https://github.com/INTENTIUS/chant/issues/31) | `WatchOp` composite — periodic lifecycle observation by pairing an `Op` (Snapshot + Diff phases) with a `TemporalSchedule` |
@@ -53,8 +51,8 @@ The Op composite gained two ergonomic upgrades that were previously hand-coded b
 | # | Capability |
 |---|---|
 | [#28](https://github.com/INTENTIUS/chant/issues/28) | Op codegen auto-emits `upsertSearchAttributes()` — `OpName` at workflow start, `Phase` at each phase boundary, plus any user-declared `searchAttributes`. No more hand-rolled boilerplate; `chant run list` and Temporal UI filters work out of the box |
-| [#41](https://github.com/INTENTIUS/chant/issues/41) | `outcomeAttribute` on activity steps — capture an activity's return value (e.g. `stateDiff`'s `drifted` boolean) as a workflow search attribute. Used by `WatchOp` to surface `Drift = "true"`/`"false"` per run |
-| [#29](https://github.com/INTENTIUS/chant/issues/29), [#40](https://github.com/INTENTIUS/chant/issues/40) | Test coverage for `cli/handlers/state.ts`, `run.ts`, `graph.ts`, and `runOp` — refactor surface is now safe |
+| [#41](https://github.com/INTENTIUS/chant/issues/41) | `outcomeAttribute` on activity steps — capture an activity's return value (e.g. `lifecycleDiff`'s `drifted` boolean) as a workflow search attribute. Used by `WatchOp` to surface `Drift = "true"`/`"false"` per run |
+| [#29](https://github.com/INTENTIUS/chant/issues/29), [#40](https://github.com/INTENTIUS/chant/issues/40) | Test coverage for `cli/handlers/lifecycle.ts` (then `state.ts`), `run.ts`, `graph.ts`, and `runOp` — refactor surface is now safe |
 | [#161](https://github.com/INTENTIUS/chant/issues/161) | Temporal runtime harness — runs the serializer's *actual* generated workflow under a time-skipping `TestWorkflowEnvironment`: phase ordering, gate waits for the approval signal (not the timeout), `onFailure` compensation in reverse, and `ApplyOp`'s gated destructive apply ([#125](https://github.com/INTENTIUS/chant/issues/125)) |
 | [#162](https://github.com/INTENTIUS/chant/issues/162) | Compile-smoke for generated Op output — type-checks the emitted `workflow.ts`/`worker.ts`/`activities.ts` against the live activity signatures, so an activity-signature change that the serializer doesn't track fails at compile time instead of drifting silently |
 | [#173](https://github.com/INTENTIUS/chant/issues/173) | Generated workflows are workflow-sandbox-safe — activity profiles import from the import-free `config` leaf instead of the package root, so the Temporal worker's bundler no longer drags `node:fs`/`node:path` into the deterministic workflow VM (the generated workflow now bundles and runs). Surfaced by the [#161](https://github.com/INTENTIUS/chant/issues/161) harness |
@@ -96,7 +94,7 @@ After all the runtime work shipped, the docs site got a sweep to surface it:
 |---|---|
 | [#63](https://github.com/INTENTIUS/chant/issues/63) | Accuracy fixes — stale claims, broken links, rollup misses across `index.mdx`, comparison, philosophy, installation, quick-start, cli/overview |
 | [#64](https://github.com/INTENTIUS/chant/issues/64) | [Watching Lifecycle](/chant/guide/watching-lifecycle/) — first-class user-guide page for `WatchOp` (was previously a subsection of the Ops guide) |
-| [#65](https://github.com/INTENTIUS/chant/issues/65) | [Implementing Observation](/chant/lexicon-authoring/observation/) — lexicon-author walkthrough of `describeResources()` and `listArtifacts()` with patterns from all 9 shipping implementations |
+| [#65](https://github.com/INTENTIUS/chant/issues/65) | [Implementing Observation](/chant/lexicon-authoring/observation/) — lexicon-author walkthrough of `describeResources()` and `listArtifacts()` with patterns from every shipping implementation |
 | [#66](https://github.com/INTENTIUS/chant/issues/66) | [Drift Detection](/chant/concepts/drift-detection/) — concept page for the observational lifecycle model, ten diff categories, and when drift detection earns its keep |
 | [#67](https://github.com/INTENTIUS/chant/issues/67) | This page + the [lexicon observation coverage matrix](/chant/lexicons/overview/#runtime-observation-coverage) |
 


### PR DESCRIPTION
Closes #187.

Docs-only. The `state → lifecycle` rename and the BYOL capability landing (live import, `lifecycle plan`, ownership markers, reconcile/apply Ops) were cohesive at the concept-page layer but had not propagated into the reference docs, the two `*.op.ts` guides, and the changelog. This fixes every reader-facing break (items A–F from the issue).

## Fixes

- **A — drift-detection self-contradiction.** Removed the retired "without authoritative state, chant can't compute a precise change set" concession that contradicted `governance`/`comparison`/`introduction`/`durable-workflows` and the page's own `lifecycle plan` section. Reframed as "plans, but never applies" with links to `lifecycle plan` / `ReconcileOp` / `ApplyOp`.
- **B — stale Op activity names.** `stateSnapshot`/`stateDiff` → `lifecycleSnapshot`/`lifecycleDiff` (matches `lexicons/temporal/src/op/activities/lifecycle.ts`) in `watching-lifecycle`, `ops`, `whats-new`. The `ops.mdx` `outcomeAttribute` example was copy-paste-broken before this.
- **C — ownership shipped.** Dropped "inert until ownership marking lands" (#119–#121 landed) in `cli/import` and `observation`.
- **D — stale `state` noun.** Replaced the old command/module/path noun with `lifecycle`/observation in `live-import`, `cli/import`, `observation`, `live-export`, `whats-new`.
- **E — `cli/lifecycle`.** Fixed the orphan-branch name (`chant-state/<env>` → `chant/lifecycle`), added `plan` to the Synopsis, updated frontmatter.
- **F — `whats-new`.** Removed retired Flyway/Slurm `listArtifacts` rows (#181) and dropped a brittle "9 implementations" count.

Left out: **G** (diff-vocabulary crosswalk, "no state / state is essential" tension) — optional polish, documented in #187, not a contradiction.

## Verification

Re-grep of every stale token (`stateSnapshot`/`stateDiff`, `inert until ownership`, `unlike \`state\``, `\`state\` code paths`, `flyway`/`slurm`, `state-model dial`, `chant-state`, `can't compute a precise`) returns CLEAN across `docs/`. No code changes — the code was already correct; the docs lagged it.
