### PR TITLE
feat(k8s): add argoproj.io CRD sources + regenerate (#101)

### DIFF
--- a/lexicons/k8s/src/crd/crd-sources.ts
+++ b/lexicons/k8s/src/crd/crd-sources.ts
@@ -22,8 +22,26 @@ import type { CRDSource } from "./types";
 const KUBERAY_VERSION = "v1.3.0";
 const KUBERAY_CRD_BASE = `https://raw.githubusercontent.com/ray-project/kuberay/${KUBERAY_VERSION}/helm-chart/kuberay-operator/crds`;
 
+/**
+ * Argo CD CRDs — argoproj.io/v1alpha1
+ *
+ * Produces (the `argoproj.io` group is mapped to the `Argo` namespace —
+ * see GROUP_NAMESPACE_OVERRIDES in crd/parser.ts):
+ *   K8s::Argo::Application     → apiVersion: argoproj.io/v1alpha1, kind: Application
+ *   K8s::Argo::ApplicationSet  → apiVersion: argoproj.io/v1alpha1, kind: ApplicationSet
+ *   K8s::Argo::AppProject      → apiVersion: argoproj.io/v1alpha1, kind: AppProject
+ *
+ * Operator install: kubectl apply -n argocd -f
+ *   https://raw.githubusercontent.com/argoproj/argo-cd/v2.13.3/manifests/install.yaml
+ */
+const ARGOCD_VERSION = "v2.13.3";
+const ARGOCD_CRD_BASE = `https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/crds`;
+
 export const CRD_SOURCES: CRDSource[] = [
   { type: "url", url: `${KUBERAY_CRD_BASE}/ray.io_rayclusters.yaml` },
   { type: "url", url: `${KUBERAY_CRD_BASE}/ray.io_rayjobs.yaml` },
   { type: "url", url: `${KUBERAY_CRD_BASE}/ray.io_rayservices.yaml` },
+  { type: "url", url: `${ARGOCD_CRD_BASE}/application-crd.yaml` },
+  { type: "url", url: `${ARGOCD_CRD_BASE}/applicationset-crd.yaml` },
+  { type: "url", url: `${ARGOCD_CRD_BASE}/appproject-crd.yaml` },
 ];

--- a/lexicons/k8s/src/crd/parser.test.ts
+++ b/lexicons/k8s/src/crd/parser.test.ts
@@ -214,4 +214,65 @@ describe("parseCRDSpec", () => {
     const results = parseCRDSpec(spec);
     expect(results[0].resource.typeName).toBe("K8s::CertManager::Certificate");
   });
+
+  test("argoproj.io group maps to the Argo namespace (override)", () => {
+    const spec = {
+      group: "argoproj.io",
+      names: { kind: "Application", plural: "applications" },
+      scope: "Namespaced" as const,
+      versions: [
+        { name: "v1alpha1", served: true, storage: true },
+      ],
+    };
+
+    const results = parseCRDSpec(spec);
+    expect(results[0].resource.typeName).toBe("K8s::Argo::Application");
+  });
+
+  test("dedupes property-type names when a scalar and array sibling collide", () => {
+    // Argo Application has both `source` (object) and `sources` (array of the
+    // same shape); singularizing `sources` → `Source` would collide.
+    const spec = {
+      group: "argoproj.io",
+      names: { kind: "Application", plural: "applications" },
+      scope: "Namespaced" as const,
+      versions: [
+        {
+          name: "v1alpha1",
+          served: true,
+          storage: true,
+          schema: {
+            openAPIV3Schema: {
+              type: "object",
+              properties: {
+                spec: {
+                  type: "object",
+                  properties: {
+                    source: {
+                      type: "object",
+                      properties: { repoURL: { type: "string" } },
+                    },
+                    sources: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: { repoURL: { type: "string" } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const results = parseCRDSpec(spec);
+    const names = results[0].propertyTypes.map((pt) => pt.name);
+    expect(names).toContain("Application_Source");
+    expect(names).toContain("Application_Sources");
+    // No duplicate identifiers.
+    expect(new Set(names).size).toBe(names.length);
+  });
 });

--- a/lexicons/k8s/src/crd/parser.ts
+++ b/lexicons/k8s/src/crd/parser.ts
@@ -13,11 +13,23 @@ import type { PropertyConstraints } from "@intentius/chant/codegen/json-schema";
 import { loadAll } from "js-yaml";
 
 /**
+ * Group names whose first segment doesn't yield the conventional namespace.
+ * "argoproj.io" → "Argo" (not "Argoproj") to match the Argo CD vocabulary
+ * and the ArgoAppFor / ArgoAppSetForRegions composites.
+ */
+const GROUP_NAMESPACE_OVERRIDES: Record<string, string> = {
+  "argoproj.io": "Argo",
+};
+
+/**
  * Normalize a CRD group to a PascalCase namespace segment.
  * "cert-manager.io" → "CertManager"
  * "monitoring.coreos.com" → "Monitoring"
+ * "argoproj.io" → "Argo" (override)
  */
 function normalizeGroupName(group: string): string {
+  const override = GROUP_NAMESPACE_OVERRIDES[group];
+  if (override) return override;
   // Take the first segment before the first dot
   const firstSegment = group.split(".")[0];
   // Convert kebab-case to PascalCase
@@ -165,10 +177,33 @@ function extractPropertyTypes(schema: OpenAPISchema, parentTypeName: string): Pa
   // "K8s::Ray::RayCluster::AutoscalerOptions".
   const shortName = parentTypeName.split("::").pop()!;
 
+  // Property-type identifiers must be unique within a resource. Singularizing
+  // array names can collide a sibling scalar object — e.g. Argo Application has
+  // both `source` (object) and `sources` (array), which both reduce to
+  // `Application_Source`. Track emitted names and fall back to the raw
+  // (un-singularized) name, then a numeric suffix, on collision.
+  const usedNames = new Set<string>();
+  const uniqueName = (base: string, raw: string): string => {
+    if (!usedNames.has(base)) {
+      usedNames.add(base);
+      return base;
+    }
+    const rawCandidate = `${shortName}_${pascalCase(raw)}`;
+    if (!usedNames.has(rawCandidate)) {
+      usedNames.add(rawCandidate);
+      return rawCandidate;
+    }
+    let i = 2;
+    while (usedNames.has(`${base}${i}`)) i++;
+    const suffixed = `${base}${i}`;
+    usedNames.add(suffixed);
+    return suffixed;
+  };
+
   for (const [name, prop] of Object.entries(specSchema.properties)) {
     // Extract inline object definitions as property types
     if (prop.type === "object" && prop.properties) {
-      const ptName = `${shortName}_${pascalCase(name)}`;
+      const ptName = uniqueName(`${shortName}_${pascalCase(name)}`, name);
       const requiredSet = new Set<string>(prop.required ?? []);
 
       results.push({
@@ -189,7 +224,7 @@ function extractPropertyTypes(schema: OpenAPISchema, parentTypeName: string): Pa
     if (prop.type === "array" && prop.items?.type === "object" && prop.items.properties) {
       const itemSchema = prop.items;
       const itemProps = itemSchema.properties!;
-      const ptName = `${shortName}_${pascalCase(singularize(name))}`;
+      const ptName = uniqueName(`${shortName}_${pascalCase(singularize(name))}`, name);
       const requiredSet = new Set<string>(itemSchema.required ?? []);
 
       results.push({

--- a/lexicons/k8s/src/serializer.test.ts
+++ b/lexicons/k8s/src/serializer.test.ts
@@ -128,6 +128,31 @@ describe("k8sSerializer", () => {
     expect(result).not.toContain("spec:");
   });
 
+  test("Argo Application serializes with argoproj.io/v1alpha1 GVK", () => {
+    const entities = new Map<string, any>();
+    entities.set(
+      "guestbook",
+      mockResource("K8s::Argo::Application", {
+        metadata: { name: "guestbook", namespace: "argocd" },
+        spec: {
+          project: "default",
+          source: {
+            repoURL: "https://github.com/argoproj/argocd-example-apps",
+            path: "guestbook",
+            targetRevision: "HEAD",
+          },
+          destination: { server: "https://kubernetes.default.svc", namespace: "guestbook" },
+        },
+      }),
+    );
+
+    const result = k8sSerializer.serialize(entities);
+    expect(result).toContain("apiVersion: argoproj.io/v1alpha1");
+    expect(result).toContain("kind: Application");
+    expect(result).toContain("name: guestbook");
+    expect(result).toContain("project: default");
+  });
+
   test("Namespace is specless type", () => {
     const entities = new Map<string, any>();
     entities.set(


### PR DESCRIPTION
Part of #100. Closes #101.

Registers Argo CD's `Application`, `ApplicationSet`, and `AppProject` CRDs (`argoproj.io/v1alpha1`, pinned to ArgoCD **v2.13.3**) in the k8s lexicon codegen, following the KubeRay precedent. Generates `K8s::Argo::Application`, `K8s::Argo::ApplicationSet`, `K8s::Argo::AppProject`.

## Changes
- `crd/crd-sources.ts` — three new `argoproj.io` CRD URL sources.
- `crd/parser.ts` — map the `argoproj.io` group to the **Argo** namespace (not `Argoproj`) via a group-name override, so types match the Argo CD vocabulary and the upcoming `ArgoAppFor`/`ArgoAppSetForRegions` composites. Also a generic dedup for property-type identifiers when a scalar and array sibling collide (Argo `Application` has both `source` and `sources`, both reducing to `Application_Source`).
- Tests for the group override, the collision dedup, and a serializer round-trip asserting `apiVersion: argoproj.io/v1alpha1` / `kind: Application`.

## Acceptance criteria
- ✅ Generated types exist for all three Argo CRDs; serializer round-trips to correct GVK YAML.
- ✅ `chant dev check-lexicon lexicons/k8s` passes (Tier 3 fully green; no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)