### PR TITLE
feat(k8s): Argo lint rules + post-synth checks (#104)

### DIFF
--- a/lexicons/k8s/src/lint/post-synth/argo-helpers.ts
+++ b/lexicons/k8s/src/lint/post-synth/argo-helpers.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared helpers for the Argo post-synth checks (ARGO002, ARGO003, ARGO005).
+ *
+ * Excluded from check auto-discovery by the "helper" filename filter.
+ */
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, parseK8sManifests, type K8sManifest } from "./k8s-helpers";
+
+/** The always-present, in-cluster Argo destination. */
+export const IN_CLUSTER_SERVER = "https://kubernetes.default.svc";
+export const IN_CLUSTER_NAME = "in-cluster";
+
+/** Label that marks a Secret as an Argo CD external cluster registration. */
+export const CLUSTER_SECRET_TYPE_LABEL = "argocd.argoproj.io/secret-type";
+
+/** All manifests across every lexicon output. */
+export function allManifests(ctx: PostSynthContext): K8sManifest[] {
+  const manifests: K8sManifest[] = [];
+  for (const [, output] of ctx.outputs) {
+    manifests.push(...parseK8sManifests(getPrimaryOutput(output)));
+  }
+  return manifests;
+}
+
+/** Manifests of a given Argo kind. */
+export function manifestsOfKind(manifests: K8sManifest[], kind: string): K8sManifest[] {
+  return manifests.filter((m) => m.kind === kind);
+}
+
+/**
+ * Read a string field from a Secret's stringData or data block.
+ * (Argo cluster Secrets conventionally use stringData.)
+ */
+export function secretField(manifest: K8sManifest, key: string): string | undefined {
+  const stringData = manifest.stringData as Record<string, unknown> | undefined;
+  const data = manifest.data as Record<string, unknown> | undefined;
+  const fromStringData = stringData?.[key];
+  if (typeof fromStringData === "string") return fromStringData;
+  const fromData = data?.[key];
+  if (typeof fromData === "string") return fromData;
+  return undefined;
+}
+
+/** True if the Secret is labelled as an Argo cluster registration. */
+export function isClusterSecret(manifest: K8sManifest): boolean {
+  if (manifest.kind !== "Secret") return false;
+  const labels = manifest.metadata?.labels;
+  return labels?.[CLUSTER_SECRET_TYPE_LABEL] === "cluster";
+}

--- a/lexicons/k8s/src/lint/post-synth/argo002.ts
+++ b/lexicons/k8s/src/lint/post-synth/argo002.ts
@@ -1,0 +1,47 @@
+/**
+ * ARGO002: Application.spec.project must reference a declared AppProject
+ *
+ * An Argo `Application` names an `AppProject` in `spec.project`; the project is
+ * the RBAC and source/destination guardrail. If the named project isn't
+ * declared in the build, Argo will reject the Application at sync time. The
+ * built-in `default` project always exists on an Argo install, so a reference
+ * to `default` is never flagged.
+ */
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { allManifests, manifestsOfKind } from "./argo-helpers";
+
+export const argo002: PostSynthCheck = {
+  id: "ARGO002",
+  description: "Application.spec.project must reference a declared AppProject (or the built-in default)",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+    const manifests = allManifests(ctx);
+
+    const declaredProjects = new Set(
+      manifestsOfKind(manifests, "AppProject")
+        .map((p) => p.metadata?.name)
+        .filter((n): n is string => typeof n === "string"),
+    );
+    // Argo ships a built-in default project.
+    declaredProjects.add("default");
+
+    for (const app of manifestsOfKind(manifests, "Application")) {
+      const project = app.spec?.project;
+      const name = app.metadata?.name ?? "Application";
+      // No project set → defaults to `default` at sync time; not this check's job.
+      if (typeof project !== "string" || project === "") continue;
+      if (declaredProjects.has(project)) continue;
+
+      diagnostics.push({
+        checkId: "ARGO002",
+        severity: "error",
+        message: `Application "${name}" references AppProject "${project}", which is not declared. Add an AppProject named "${project}" or reference an existing project.`,
+        entity: name,
+        lexicon: "k8s",
+      });
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/k8s/src/lint/post-synth/argo003.ts
+++ b/lexicons/k8s/src/lint/post-synth/argo003.ts
@@ -1,0 +1,80 @@
+/**
+ * ARGO003: Application.spec.destination must reference a registered cluster
+ *
+ * An Argo `Application` targets a cluster via `spec.destination.server` (an API
+ * server URL) or `spec.destination.name` (a registered cluster name). External
+ * clusters are registered with a Secret labelled
+ * `argocd.argoproj.io/secret-type: cluster`. The in-cluster target
+ * (`https://kubernetes.default.svc` / name `in-cluster`) is always available.
+ * A destination that names neither a registered cluster nor the in-cluster
+ * target won't resolve at sync time.
+ */
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import {
+  allManifests,
+  manifestsOfKind,
+  isClusterSecret,
+  secretField,
+  IN_CLUSTER_SERVER,
+  IN_CLUSTER_NAME,
+} from "./argo-helpers";
+
+export const argo003: PostSynthCheck = {
+  id: "ARGO003",
+  description: "Application.spec.destination must reference a registered cluster or the in-cluster target",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+    const manifests = allManifests(ctx);
+
+    const registeredServers = new Set<string>([IN_CLUSTER_SERVER]);
+    const registeredNames = new Set<string>([IN_CLUSTER_NAME]);
+    for (const secret of manifests.filter(isClusterSecret)) {
+      const server = secretField(secret, "server");
+      if (server) registeredServers.add(server);
+      const name = secretField(secret, "name") ?? secret.metadata?.name;
+      if (typeof name === "string") registeredNames.add(name);
+    }
+
+    for (const app of manifestsOfKind(manifests, "Application")) {
+      const name = app.metadata?.name ?? "Application";
+      const destination = app.spec?.destination as
+        | { server?: unknown; name?: unknown }
+        | undefined;
+
+      if (!destination || (destination.server === undefined && destination.name === undefined)) {
+        diagnostics.push({
+          checkId: "ARGO003",
+          severity: "error",
+          message: `Application "${name}" has no spec.destination.server or spec.destination.name — Argo cannot resolve a target cluster.`,
+          entity: name,
+          lexicon: "k8s",
+        });
+        continue;
+      }
+
+      if (typeof destination.server === "string" && !registeredServers.has(destination.server)) {
+        diagnostics.push({
+          checkId: "ARGO003",
+          severity: "error",
+          message: `Application "${name}" targets cluster server "${destination.server}", which is not registered. Register it with a cluster Secret (label argocd.argoproj.io/secret-type=cluster) or use the in-cluster target.`,
+          entity: name,
+          lexicon: "k8s",
+        });
+        continue;
+      }
+
+      if (typeof destination.name === "string" && !registeredNames.has(destination.name)) {
+        diagnostics.push({
+          checkId: "ARGO003",
+          severity: "error",
+          message: `Application "${name}" targets cluster name "${destination.name}", which is not registered. Register it with a cluster Secret or use the in-cluster target.`,
+          entity: name,
+          lexicon: "k8s",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/k8s/src/lint/post-synth/argo005.ts
+++ b/lexicons/k8s/src/lint/post-synth/argo005.ts
@@ -1,0 +1,59 @@
+/**
+ * ARGO005: Application source.path should point at an existing directory (warn)
+ *
+ * When an Argo `Application` syncs from a git source it names a `source.path`
+ * inside the repo. In the common monorepo layout — Argo watches the same repo
+ * Chant builds — that path is relative to the build root, so a typo'd or moved
+ * path surfaces as a sync error only after deploy. This check warns when the
+ * path doesn't resolve to a directory under the build root.
+ *
+ * It is a warning, not an error: Applications that sync from a *different*
+ * remote repo legitimately reference paths that don't exist locally. Helm chart
+ * sources (`source.chart`) and pathless sources are skipped.
+ */
+import { existsSync, statSync } from "fs";
+import { isAbsolute, resolve } from "path";
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { allManifests, manifestsOfKind } from "./argo-helpers";
+
+function dirExists(path: string): boolean {
+  try {
+    const full = isAbsolute(path) ? path : resolve(process.cwd(), path);
+    return existsSync(full) && statSync(full).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export const argo005: PostSynthCheck = {
+  id: "ARGO005",
+  description: "Application source.path should resolve to an existing directory under the build root",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const app of manifestsOfKind(allManifests(ctx), "Application")) {
+      const name = app.metadata?.name ?? "Application";
+      const source = app.spec?.source as
+        | { path?: unknown; chart?: unknown }
+        | undefined;
+      if (!source) continue;
+      // Helm chart sources have no filesystem path.
+      if (typeof source.chart === "string" && source.chart !== "") continue;
+
+      const path = source.path;
+      if (typeof path !== "string" || path === "") continue;
+      if (dirExists(path)) continue;
+
+      diagnostics.push({
+        checkId: "ARGO005",
+        severity: "warning",
+        message: `Application "${name}" source.path "${path}" does not resolve to a directory under the build root. Confirm the path (or ignore if it lives in a different repo).`,
+        entity: name,
+        lexicon: "k8s",
+      });
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/k8s/src/lint/post-synth/post-synth.test.ts
+++ b/lexicons/k8s/src/lint/post-synth/post-synth.test.ts
@@ -28,6 +28,9 @@ import { wk8306 } from "./wk8306";
 import { wk8401 } from "./wk8401";
 import { wk8402 } from "./wk8402";
 import { wk8403 } from "./wk8403";
+import { argo002 } from "./argo002";
+import { argo003 } from "./argo003";
+import { argo005 } from "./argo005";
 
 function makeCtx(yaml: string): PostSynthContext {
   return {
@@ -41,6 +44,11 @@ function makeCtx(yaml: string): PostSynthContext {
       sourceFileCount: 1,
     },
   };
+}
+
+/** Join several manifests (objects) into a multi-document YAML string. */
+function manifestsCtx(...objs: unknown[]): PostSynthContext {
+  return makeCtx(objs.map((o) => JSON.stringify(o)).join("\n---\n"));
 }
 
 // ── WK8005: Secrets in env ──────────────────────────────────────────
@@ -1474,5 +1482,120 @@ describe("WK8403: spec.rayVersion does not match image tag", () => {
     const ctx = makeCtx(makeRayCluster({ rayVersion: "2.40.0", headImage: "rayproject/ray:latest" }));
     const diags = wk8403.check(ctx);
     expect(diags.filter((d) => d.checkId === "WK8403").length).toBe(0);
+  });
+});
+
+// ── ARGO002: Application.spec.project references a declared AppProject ─────────
+
+function argoApp(name: string, spec: Record<string, unknown>) {
+  return { apiVersion: "argoproj.io/v1alpha1", kind: "Application", metadata: { name }, spec };
+}
+function appProject(name: string) {
+  return { apiVersion: "argoproj.io/v1alpha1", kind: "AppProject", metadata: { name }, spec: {} };
+}
+const inClusterDest = { server: "https://kubernetes.default.svc", namespace: "demo" };
+
+describe("ARGO002: Application project references a declared AppProject", () => {
+  test("metadata", () => {
+    expect(argo002.id).toBe("ARGO002");
+  });
+
+  test("flags an Application referencing an undeclared project", () => {
+    const ctx = manifestsCtx(argoApp("api", { project: "team-a", destination: inClusterDest }));
+    const diags = argo002.check(ctx);
+    expect(diags.length).toBe(1);
+    expect(diags[0].checkId).toBe("ARGO002");
+    expect(diags[0].message).toContain("team-a");
+  });
+
+  test("passes when the AppProject is declared in the same build", () => {
+    const ctx = manifestsCtx(
+      appProject("team-a"),
+      argoApp("api", { project: "team-a", destination: inClusterDest }),
+    );
+    expect(argo002.check(ctx).length).toBe(0);
+  });
+
+  test("does NOT flag the built-in default project", () => {
+    const ctx = manifestsCtx(argoApp("api", { project: "default", destination: inClusterDest }));
+    expect(argo002.check(ctx).length).toBe(0);
+  });
+});
+
+// ── ARGO003: Application destination references a registered cluster ──────────
+
+function clusterSecret(name: string, server: string) {
+  return {
+    apiVersion: "v1",
+    kind: "Secret",
+    metadata: { name, labels: { "argocd.argoproj.io/secret-type": "cluster" } },
+    stringData: { name, server },
+  };
+}
+
+describe("ARGO003: Application destination references a registered cluster", () => {
+  test("metadata", () => {
+    expect(argo003.id).toBe("ARGO003");
+  });
+
+  test("does NOT flag the in-cluster destination", () => {
+    const ctx = manifestsCtx(argoApp("api", { project: "default", destination: inClusterDest }));
+    expect(argo003.check(ctx).length).toBe(0);
+  });
+
+  test("flags an unregistered cluster server", () => {
+    const ctx = manifestsCtx(
+      argoApp("api", { project: "default", destination: { server: "https://prod.example.com", namespace: "demo" } }),
+    );
+    const diags = argo003.check(ctx);
+    expect(diags.length).toBe(1);
+    expect(diags[0].checkId).toBe("ARGO003");
+    expect(diags[0].message).toContain("prod.example.com");
+  });
+
+  test("passes when the cluster is registered via a cluster Secret", () => {
+    const ctx = manifestsCtx(
+      clusterSecret("prod", "https://prod.example.com"),
+      argoApp("api", { project: "default", destination: { server: "https://prod.example.com", namespace: "demo" } }),
+    );
+    expect(argo003.check(ctx).length).toBe(0);
+  });
+
+  test("flags a destination with neither server nor name", () => {
+    const ctx = manifestsCtx(argoApp("api", { project: "default", destination: { namespace: "demo" } }));
+    expect(argo003.check(ctx).length).toBe(1);
+  });
+});
+
+// ── ARGO005: Application source.path resolves to an existing directory ────────
+
+describe("ARGO005: Application source path exists", () => {
+  test("metadata", () => {
+    expect(argo005.id).toBe("ARGO005");
+  });
+
+  test("does NOT flag a path that exists under the build root", () => {
+    // `lexicons` is a directory at the repo root (the vitest cwd).
+    const ctx = manifestsCtx(
+      argoApp("api", { project: "default", destination: inClusterDest, source: { repoURL: "x", path: "lexicons" } }),
+    );
+    expect(argo005.check(ctx).length).toBe(0);
+  });
+
+  test("warns on a path that does not resolve to a directory", () => {
+    const ctx = manifestsCtx(
+      argoApp("api", { project: "default", destination: inClusterDest, source: { repoURL: "x", path: "no-such-argo-dir-xyz" } }),
+    );
+    const diags = argo005.check(ctx);
+    expect(diags.length).toBe(1);
+    expect(diags[0].checkId).toBe("ARGO005");
+    expect(diags[0].severity).toBe("warning");
+  });
+
+  test("skips Helm chart sources", () => {
+    const ctx = manifestsCtx(
+      argoApp("api", { project: "default", destination: inClusterDest, source: { repoURL: "x", chart: "redis" } }),
+    );
+    expect(argo005.check(ctx).length).toBe(0);
   });
 });

--- a/lexicons/k8s/src/lint/rules/argo-appset-single-project.ts
+++ b/lexicons/k8s/src/lint/rules/argo-appset-single-project.ts
@@ -1,0 +1,66 @@
+import type { LintRule, LintDiagnostic, LintContext } from "@intentius/chant/lint/rule";
+import { findResourceLiterals, getNestedObject, getNestedString, lineCol } from "./argo-ast";
+
+/**
+ * ARGO004: ApplicationSet template must scope to a single AppProject
+ *
+ * An `ApplicationSet` generates many Applications from one template. The
+ * template's `spec.project` should name a single, static `AppProject` so every
+ * generated Application lands in the same security boundary. If `project` is
+ * missing, the generated Applications fall back to whatever default and dodge
+ * project-level RBAC; if it is templated with a generator placeholder
+ * (`{{...}}`) the set sprays Applications across many projects, which defeats
+ * the point of an AppProject as a guardrail.
+ *
+ * Bad:  new ApplicationSet({ spec: { template: { spec: { repoURL: "..." } } } })          // no project
+ * Bad:  new ApplicationSet({ spec: { template: { spec: { project: "{{path.basename}}" } } } }) // templated
+ * Good: new ApplicationSet({ spec: { template: { spec: { project: "team-a" } } } })
+ */
+
+export const argoAppSetSingleProjectRule: LintRule = {
+  id: "ARGO004",
+  severity: "warning",
+  category: "correctness",
+  description:
+    "ApplicationSet template must scope to a single static AppProject (spec.template.spec.project)",
+
+  check(context: LintContext): LintDiagnostic[] {
+    const { sourceFile } = context;
+    const diagnostics: LintDiagnostic[] = [];
+
+    for (const { literal } of findResourceLiterals(sourceFile, new Set(["ApplicationSet"]))) {
+      const templateSpec = getNestedObject(literal, ["spec", "template", "spec"]);
+      // No template/spec to inspect — leave it to other tooling.
+      if (!templateSpec) continue;
+
+      const project = getNestedString(literal, ["spec", "template", "spec", "project"]);
+      const { line, column } = lineCol(sourceFile, templateSpec);
+
+      if (project === undefined) {
+        diagnostics.push({
+          file: sourceFile.fileName,
+          line,
+          column,
+          ruleId: "ARGO004",
+          severity: "warning",
+          message:
+            "ApplicationSet template has no spec.project — scope it to a single AppProject so every generated Application inherits the same RBAC boundary.",
+        });
+        continue;
+      }
+
+      if (project.includes("{{")) {
+        diagnostics.push({
+          file: sourceFile.fileName,
+          line,
+          column,
+          ruleId: "ARGO004",
+          severity: "warning",
+          message: `ApplicationSet template scopes spec.project to a generator placeholder ("${project}"), spraying Applications across projects. Pin it to a single static AppProject.`,
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/k8s/src/lint/rules/argo-ast.ts
+++ b/lexicons/k8s/src/lint/rules/argo-ast.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared AST helpers for the Argo declarative lint rules (ARGO001, ARGO004).
+ *
+ * The Argo CRDs are constructed like any other k8s resource —
+ * `new Application({ metadata, spec })` / `new ApplicationSet({ ... })`. These
+ * helpers walk the object-literal first argument so a rule can read a nested
+ * property by path without re-implementing the traversal each time.
+ */
+import * as ts from "typescript";
+
+/**
+ * Find the object-literal first argument of every `new <Kind>(...)` expression
+ * in the file, where Kind is one of the supplied resource kinds.
+ */
+export function findResourceLiterals(
+  sourceFile: ts.SourceFile,
+  kinds: Set<string>,
+): Array<{ kind: string; literal: ts.ObjectLiteralExpression; node: ts.NewExpression }> {
+  const found: Array<{ kind: string; literal: ts.ObjectLiteralExpression; node: ts.NewExpression }> = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isNewExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      kinds.has(node.expression.text) &&
+      node.arguments &&
+      node.arguments.length > 0 &&
+      ts.isObjectLiteralExpression(node.arguments[0])
+    ) {
+      found.push({
+        kind: node.expression.text,
+        literal: node.arguments[0],
+        node,
+      });
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
+}
+
+/** Read the initializer node for `key` on an object literal, if present. */
+export function getProp(
+  obj: ts.ObjectLiteralExpression,
+  key: string,
+): ts.Expression | undefined {
+  for (const prop of obj.properties) {
+    if (
+      ts.isPropertyAssignment(prop) &&
+      (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)) &&
+      prop.name.text === key
+    ) {
+      return prop.initializer;
+    }
+  }
+  return undefined;
+}
+
+/** Read a nested object literal by walking `path` (each segment an object). */
+export function getNestedObject(
+  obj: ts.ObjectLiteralExpression,
+  path: string[],
+): ts.ObjectLiteralExpression | undefined {
+  let current: ts.ObjectLiteralExpression | undefined = obj;
+  for (const segment of path) {
+    if (!current) return undefined;
+    const next = getProp(current, segment);
+    current = next && ts.isObjectLiteralExpression(next) ? next : undefined;
+  }
+  return current;
+}
+
+/** Read a string-literal property value by path (last segment is the key). */
+export function getNestedString(
+  obj: ts.ObjectLiteralExpression,
+  path: string[],
+): string | undefined {
+  const key = path[path.length - 1];
+  const parent = getNestedObject(obj, path.slice(0, -1));
+  if (!parent) return undefined;
+  const value = getProp(parent, key);
+  return value && ts.isStringLiteral(value) ? value.text : undefined;
+}
+
+/** Read a boolean-literal property value by path (last segment is the key). */
+export function getNestedBoolean(
+  obj: ts.ObjectLiteralExpression,
+  path: string[],
+): boolean | undefined {
+  const key = path[path.length - 1];
+  const parent = getNestedObject(obj, path.slice(0, -1));
+  if (!parent) return undefined;
+  const value = getProp(parent, key);
+  if (!value) return undefined;
+  if (value.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (value.kind === ts.SyntaxKind.FalseKeyword) return false;
+  return undefined;
+}
+
+/**
+ * True if the literal carries the given annotation key under
+ * `metadata.annotations`, regardless of value.
+ */
+export function hasAnnotation(
+  obj: ts.ObjectLiteralExpression,
+  annotationKey: string,
+): boolean {
+  const annotations = getNestedObject(obj, ["metadata", "annotations"]);
+  if (!annotations) return false;
+  return getProp(annotations, annotationKey) !== undefined;
+}
+
+/** Line/column (1-based) for a node, for diagnostics. */
+export function lineCol(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+): { line: number; column: number } {
+  const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+  return { line: line + 1, column: character + 1 };
+}

--- a/lexicons/k8s/src/lint/rules/argo-automated-prune.ts
+++ b/lexicons/k8s/src/lint/rules/argo-automated-prune.ts
@@ -1,0 +1,75 @@
+import type { LintRule, LintDiagnostic, LintContext } from "@intentius/chant/lint/rule";
+import {
+  findResourceLiterals,
+  getNestedBoolean,
+  getNestedString,
+  getProp,
+  hasAnnotation,
+  lineCol,
+} from "./argo-ast";
+import * as ts from "typescript";
+
+/**
+ * ARGO001: Production Application must not enable automated prune
+ *
+ * An Argo CD `Application` whose `syncPolicy.automated.prune` is `true` lets the
+ * controller delete live resources that disappear from git. On a production
+ * Application that is a foot-gun — a bad merge can sweep away running
+ * infrastructure. Require `prune: false` for prod Applications unless the author
+ * opts in explicitly with the `argocd.chant.dev/allow-prune` annotation.
+ *
+ * "Production" is inferred from the Application name, its `metadata.namespace`,
+ * or its `spec.destination.namespace` containing `prod`.
+ *
+ * Bad:  new Application({ metadata: { name: "api-prod" }, spec: { syncPolicy: { automated: { prune: true } } } })
+ * Good: new Application({ metadata: { name: "api-prod" }, spec: { syncPolicy: { automated: { prune: false } } } })
+ * Good: new Application({ metadata: { name: "api-prod", annotations: { "argocd.chant.dev/allow-prune": "true" } }, spec: { syncPolicy: { automated: { prune: true } } } })
+ */
+
+export const ALLOW_PRUNE_ANNOTATION = "argocd.chant.dev/allow-prune";
+
+function looksProd(obj: ts.ObjectLiteralExpression): boolean {
+  const candidates = [
+    getNestedString(obj, ["metadata", "name"]),
+    getNestedString(obj, ["metadata", "namespace"]),
+    getNestedString(obj, ["spec", "destination", "namespace"]),
+  ];
+  return candidates.some((v) => v !== undefined && /prod/i.test(v));
+}
+
+export const argoAutomatedPruneRule: LintRule = {
+  id: "ARGO001",
+  severity: "warning",
+  category: "correctness",
+  description:
+    "Production Argo Application must not enable syncPolicy.automated.prune without the allow-prune override annotation",
+
+  check(context: LintContext): LintDiagnostic[] {
+    const { sourceFile } = context;
+    const diagnostics: LintDiagnostic[] = [];
+
+    for (const { literal } of findResourceLiterals(sourceFile, new Set(["Application"]))) {
+      const prune = getNestedBoolean(literal, ["spec", "syncPolicy", "automated", "prune"]);
+      if (prune !== true) continue;
+      if (!looksProd(literal)) continue;
+      if (hasAnnotation(literal, ALLOW_PRUNE_ANNOTATION)) continue;
+
+      // Anchor the diagnostic at the `prune` assignment when we can find it.
+      const automated = getProp(literal, "spec");
+      const anchor: ts.Node = automated ?? literal;
+      const { line, column } = lineCol(sourceFile, anchor);
+
+      const name = getNestedString(literal, ["metadata", "name"]) ?? "(unnamed)";
+      diagnostics.push({
+        file: sourceFile.fileName,
+        line,
+        column,
+        ruleId: "ARGO001",
+        severity: "warning",
+        message: `Production Application "${name}" enables automated prune. Set syncPolicy.automated.prune=false, or opt in explicitly with the "${ALLOW_PRUNE_ANNOTATION}" annotation.`,
+      });
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/k8s/src/lint/rules/rules.test.ts
+++ b/lexicons/k8s/src/lint/rules/rules.test.ts
@@ -2,6 +2,8 @@ import { describe, test, expect } from "vitest";
 import { hardcodedNamespaceRule } from "./hardcoded-namespace";
 import { latestImageTagRule } from "./latest-image-tag";
 import { missingResourceLimitsRule } from "./missing-resource-limits";
+import { argoAutomatedPruneRule } from "./argo-automated-prune";
+import { argoAppSetSingleProjectRule } from "./argo-appset-single-project";
 import * as ts from "typescript";
 
 function createContext(code: string) {
@@ -257,5 +259,112 @@ describe("WK8003: Missing Resource Limits", () => {
     `);
     const diags = missingResourceLimitsRule.check(ctx);
     expect(diags.length).toBe(2);
+  });
+});
+
+describe("ARGO001: Production Application automated prune", () => {
+  test("rule metadata", () => {
+    expect(argoAutomatedPruneRule.id).toBe("ARGO001");
+    expect(argoAutomatedPruneRule.severity).toBe("warning");
+    expect(argoAutomatedPruneRule.category).toBe("correctness");
+  });
+
+  test("flags prod Application with automated prune and no override", () => {
+    const ctx = createContext(`
+      new Application({
+        metadata: { name: "api-prod" },
+        spec: { syncPolicy: { automated: { prune: true, selfHeal: true } } },
+      });
+    `);
+    const diags = argoAutomatedPruneRule.check(ctx);
+    expect(diags.length).toBe(1);
+    expect(diags[0].ruleId).toBe("ARGO001");
+    expect(diags[0].message).toContain("api-prod");
+  });
+
+  test("does NOT flag when prune is false", () => {
+    const ctx = createContext(`
+      new Application({
+        metadata: { name: "api-prod" },
+        spec: { syncPolicy: { automated: { prune: false } } },
+      });
+    `);
+    expect(argoAutomatedPruneRule.check(ctx).length).toBe(0);
+  });
+
+  test("does NOT flag prod Application carrying the allow-prune override annotation", () => {
+    const ctx = createContext(`
+      new Application({
+        metadata: { name: "api-prod", annotations: { "argocd.chant.dev/allow-prune": "true" } },
+        spec: { syncPolicy: { automated: { prune: true } } },
+      });
+    `);
+    expect(argoAutomatedPruneRule.check(ctx).length).toBe(0);
+  });
+
+  test("does NOT flag a non-prod Application with automated prune", () => {
+    const ctx = createContext(`
+      new Application({
+        metadata: { name: "api-staging" },
+        spec: { syncPolicy: { automated: { prune: true } } },
+      });
+    `);
+    expect(argoAutomatedPruneRule.check(ctx).length).toBe(0);
+  });
+
+  test("infers prod from destination namespace", () => {
+    const ctx = createContext(`
+      new Application({
+        metadata: { name: "api" },
+        spec: {
+          destination: { namespace: "production" },
+          syncPolicy: { automated: { prune: true } },
+        },
+      });
+    `);
+    expect(argoAutomatedPruneRule.check(ctx).length).toBe(1);
+  });
+});
+
+describe("ARGO004: ApplicationSet single AppProject", () => {
+  test("rule metadata", () => {
+    expect(argoAppSetSingleProjectRule.id).toBe("ARGO004");
+    expect(argoAppSetSingleProjectRule.severity).toBe("warning");
+    expect(argoAppSetSingleProjectRule.category).toBe("correctness");
+  });
+
+  test("does NOT flag a static single project", () => {
+    const ctx = createContext(`
+      new ApplicationSet({
+        metadata: { name: "team-a-apps" },
+        spec: { template: { spec: { project: "team-a", repoURL: "https://example.com/repo" } } },
+      });
+    `);
+    expect(argoAppSetSingleProjectRule.check(ctx).length).toBe(0);
+  });
+
+  test("flags a missing template project", () => {
+    const ctx = createContext(`
+      new ApplicationSet({
+        metadata: { name: "team-a-apps" },
+        spec: { template: { spec: { repoURL: "https://example.com/repo" } } },
+      });
+    `);
+    const diags = argoAppSetSingleProjectRule.check(ctx);
+    expect(diags.length).toBe(1);
+    expect(diags[0].ruleId).toBe("ARGO004");
+    expect(diags[0].message).toContain("no spec.project");
+  });
+
+  test("flags a templated (generator placeholder) project", () => {
+    const ctx = createContext(`
+      new ApplicationSet({
+        metadata: { name: "per-cluster" },
+        spec: { template: { spec: { project: "{{path.basename}}" } } },
+      });
+    `);
+    const diags = argoAppSetSingleProjectRule.check(ctx);
+    expect(diags.length).toBe(1);
+    expect(diags[0].message).toContain("placeholder");
   });
 });

--- a/lexicons/k8s/src/plugin.ts
+++ b/lexicons/k8s/src/plugin.ts
@@ -15,6 +15,8 @@ import { k8sSerializer } from "./serializer";
 import { hardcodedNamespaceRule } from "./lint/rules/hardcoded-namespace";
 import { latestImageTagRule } from "./lint/rules/latest-image-tag";
 import { missingResourceLimitsRule } from "./lint/rules/missing-resource-limits";
+import { argoAutomatedPruneRule } from "./lint/rules/argo-automated-prune";
+import { argoAppSetSingleProjectRule } from "./lint/rules/argo-appset-single-project";
 import { k8sCompletions } from "./lsp/completions";
 import { k8sHover } from "./lsp/hover";
 import { K8sParser } from "./import/parser";
@@ -25,7 +27,13 @@ export const k8sPlugin: LexiconPlugin = {
   serializer: k8sSerializer,
 
   lintRules(): LintRule[] {
-    return [hardcodedNamespaceRule, latestImageTagRule, missingResourceLimitsRule];
+    return [
+      hardcodedNamespaceRule,
+      latestImageTagRule,
+      missingResourceLimitsRule,
+      argoAutomatedPruneRule,
+      argoAppSetSingleProjectRule,
+    ];
   },
 
   postSynthChecks() {


### PR DESCRIPTION
Part of #100. Closes #104.

Adds Argo-specific quality checks to the k8s lexicon.

## Declarative lint rules (`plugin.lintRules()`)
- **ARGO001** — production `Application` must not enable `syncPolicy.automated.prune` without the `argocd.chant.dev/allow-prune` override annotation (prod inferred from name / namespace / destination namespace).
- **ARGO004** — `ApplicationSet` template must scope to a single **static** `AppProject`; flags a missing `spec.template.spec.project` or a generator-templated (`{{...}}`) one.

## Post-synth checks (auto-discovered)
- **ARGO002** — `Application.spec.project` must reference a declared `AppProject` (built-in `default` exempt).
- **ARGO003** — `Application.spec.destination` must reference a registered cluster Secret (`argocd.argoproj.io/secret-type=cluster`) or the in-cluster target.
- **ARGO005** — `Application` `source.path` should resolve to an existing directory under the build root (warn; skips Helm chart sources).

## Acceptance criteria
- ✅ Passing + failing fixtures for each rule/check (`rules.test.ts`, `post-synth.test.ts`).
- ✅ Registered in `lintRules()` / discovered by `postSynthChecks()`.
- ✅ `chant dev check-lexicon lexicons/k8s` stays Tier 3 (7 rules, 31 checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)