### PR TITLE
feat(k8s): Argo composites (ArgoAppFor / ArgoAppSetForRegions / cluster register) (#105)

### DIFF
--- a/lexicons/k8s/src/composites/argo-app.ts
+++ b/lexicons/k8s/src/composites/argo-app.ts
@@ -1,0 +1,380 @@
+/**
+ * Argo CD composites — turn Chant build targets into Argo `Application`s.
+ *
+ * The k8s lexicon stays runtime-agnostic: it only emits manifests. These
+ * composites are the opt-in bridge to Argo CD's reconciliation layer. Authoring
+ * an `Application` by hand is ~30 lines of nested YAML; `ArgoAppFor` collapses
+ * it to one call with production-friendly defaults.
+ *
+ * - ArgoAppFor(target, opts)         → a single K8s::Argo::Application
+ * - ArgoAppSetForRegions(regions, …) → one ApplicationSet, fanned out per region
+ * - registerArgoCluster(opts)        → the cluster-registration Secret
+ */
+
+import { Composite, mergeDefaults } from "@intentius/chant";
+import {
+  Application as ApplicationResource,
+  ApplicationSet as ApplicationSetResource,
+  Secret as SecretResource,
+} from "../generated";
+
+// ── Shared types ─────────────────────────────────────────────────────────────
+
+/** Where Argo deploys the synced manifests. `server` and `name` are exclusive. */
+export interface ArgoDestination {
+  /** Target cluster API server URL (e.g. https://kubernetes.default.svc). */
+  server?: string;
+  /** Registered cluster name (alternative to server). */
+  name?: string;
+  /** Namespace the synced resources land in. */
+  namespace: string;
+}
+
+/** Argo sync policy. Omit `automated` for manual sync. */
+export interface ArgoSyncPolicy {
+  automated?: {
+    /** Delete resources that disappear from git. Default false (and required
+     * false on prod Applications — see ARGO001). */
+    prune?: boolean;
+    /** Revert out-of-band changes back to git state. */
+    selfHeal?: boolean;
+  };
+  /** e.g. ["CreateNamespace=true", "ServerSideApply=true"]. */
+  syncOptions?: string[];
+}
+
+const IN_CLUSTER_SERVER = "https://kubernetes.default.svc";
+
+/** The default, safe sync policy: automated, non-pruning, self-healing. */
+function defaultSyncPolicy(): ArgoSyncPolicy {
+  return {
+    automated: { prune: false, selfHeal: true },
+    syncOptions: ["CreateNamespace=true"],
+  };
+}
+
+function renderSyncPolicy(policy: ArgoSyncPolicy): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (policy.automated) {
+    out.automated = {
+      ...(policy.automated.prune !== undefined && { prune: policy.automated.prune }),
+      ...(policy.automated.selfHeal !== undefined && { selfHeal: policy.automated.selfHeal }),
+    };
+  }
+  if (policy.syncOptions && policy.syncOptions.length > 0) {
+    out.syncOptions = policy.syncOptions;
+  }
+  return out;
+}
+
+function renderDestination(dest: ArgoDestination): Record<string, unknown> {
+  return {
+    ...(dest.server !== undefined && { server: dest.server }),
+    ...(dest.name !== undefined && { name: dest.name }),
+    namespace: dest.namespace,
+  };
+}
+
+// ── ArgoAppFor ───────────────────────────────────────────────────────────────
+
+export interface ArgoAppForOptions {
+  /** Git repository URL the Application syncs from. */
+  repo: string;
+  /** Path within the repo holding the manifests. */
+  path: string;
+  /** Where Argo deploys. Defaults to the in-cluster target if omitted. */
+  destination?: ArgoDestination;
+  /** Git revision to track (default "HEAD"). */
+  targetRevision?: string;
+  /** AppProject the Application belongs to (default "default"). */
+  project?: string;
+  /** Namespace the Application object itself lives in (default "argocd"). */
+  argoNamespace?: string;
+  /** Sync policy. Omit for the safe automated default; pass `{}` for manual. */
+  syncPolicy?: ArgoSyncPolicy;
+  /** Extra labels applied to the Application. */
+  labels?: Record<string, string>;
+  defaults?: { application?: Partial<Record<string, unknown>> };
+}
+
+export interface ArgoAppForResult {
+  application: InstanceType<typeof ApplicationResource>;
+}
+
+const ArgoApplication = Composite<{ target: string } & ArgoAppForOptions, ArgoAppForResult>(
+  (props) => {
+    const {
+      target,
+      repo,
+      path,
+      destination = { server: IN_CLUSTER_SERVER, namespace: target },
+      targetRevision = "HEAD",
+      project = "default",
+      argoNamespace = "argocd",
+      syncPolicy,
+      labels = {},
+      defaults,
+    } = props;
+
+    const resolvedSyncPolicy = syncPolicy ?? defaultSyncPolicy();
+    const renderedSync = renderSyncPolicy(resolvedSyncPolicy);
+
+    const application = new ApplicationResource(mergeDefaults({
+      metadata: {
+        name: target,
+        namespace: argoNamespace,
+        labels: {
+          "app.kubernetes.io/name": target,
+          "app.kubernetes.io/managed-by": "chant",
+          ...labels,
+        },
+      },
+      spec: {
+        project,
+        source: { repoURL: repo, path, targetRevision },
+        destination: renderDestination(destination),
+        ...(Object.keys(renderedSync).length > 0 && { syncPolicy: renderedSync }),
+      },
+    }, defaults?.application));
+
+    return { application };
+  },
+  "ArgoApplication",
+);
+
+/**
+ * Turn a Chant build target into an Argo CD `Application` in one call.
+ *
+ * @example
+ * ```ts
+ * import { ArgoAppFor } from "@intentius/chant-lexicon-k8s";
+ *
+ * export const api = ArgoAppFor("api", {
+ *   repo: "https://github.com/acme/infra",
+ *   path: "dist/api",
+ *   destination: { server: "https://kubernetes.default.svc", namespace: "api" },
+ * });
+ * ```
+ */
+export function ArgoAppFor(target: string, options: ArgoAppForOptions): ArgoAppForResult {
+  return ArgoApplication({ target, ...options });
+}
+
+// ── ArgoAppSetForRegions ─────────────────────────────────────────────────────
+
+/** Per-region values resolved by the caller's mapper. */
+export interface ArgoRegionTarget {
+  /** Target cluster API server URL for this region. */
+  server?: string;
+  /** Registered cluster name for this region (alternative to server). */
+  name?: string;
+  /** Namespace the synced resources land in. */
+  namespace: string;
+  /** Per-region repo path (overrides the set-level path). */
+  path?: string;
+  /** Per-region git revision (overrides the set-level revision). */
+  targetRevision?: string;
+}
+
+export interface ArgoAppSetForRegionsOptions {
+  /** Base name; generated Applications are `<region>-<name>`. */
+  name: string;
+  /** Git repository URL the generated Applications sync from. */
+  repo: string;
+  /** Set-level repo path (per-region mapper may override). */
+  path?: string;
+  /** Single static AppProject for every generated Application (see ARGO004). */
+  project?: string;
+  /** Namespace the ApplicationSet object lives in (default "argocd"). */
+  argoNamespace?: string;
+  /** Set-level git revision (default "HEAD"). */
+  targetRevision?: string;
+  /** Sync policy applied to the template. Omit for the safe automated default. */
+  syncPolicy?: ArgoSyncPolicy;
+  /** Extra labels applied to the ApplicationSet. */
+  labels?: Record<string, string>;
+  defaults?: { applicationSet?: Partial<Record<string, unknown>> };
+}
+
+export interface ArgoAppSetForRegionsResult {
+  applicationSet: InstanceType<typeof ApplicationSetResource>;
+}
+
+/**
+ * Emit one `ApplicationSet` that fans out across regions via a list generator —
+ * one synced Application per region, all scoped to a single AppProject.
+ *
+ * @example
+ * ```ts
+ * import { ArgoAppSetForRegions } from "@intentius/chant-lexicon-k8s";
+ *
+ * export const crdb = ArgoAppSetForRegions(
+ *   ["east", "central", "west"],
+ *   (region) => ({
+ *     server: clusterServers[region],
+ *     namespace: `crdb-${region}`,
+ *     path: `dist/${region}`,
+ *   }),
+ *   { name: "crdb", repo: "https://github.com/acme/infra", project: "crdb" },
+ * );
+ * ```
+ */
+export function ArgoAppSetForRegions(
+  regions: string[],
+  fn: (region: string) => ArgoRegionTarget,
+  options: ArgoAppSetForRegionsOptions,
+): ArgoAppSetForRegionsResult {
+  return ArgoApplicationSet({ regions, fn, options });
+}
+
+const ArgoApplicationSet = Composite<
+  {
+    regions: string[];
+    fn: (region: string) => ArgoRegionTarget;
+    options: ArgoAppSetForRegionsOptions;
+  },
+  ArgoAppSetForRegionsResult
+>((props) => {
+  const { regions, fn, options } = props;
+  const {
+    name,
+    repo,
+    path: setPath,
+    project = "default",
+    argoNamespace = "argocd",
+    targetRevision: setRevision = "HEAD",
+    syncPolicy,
+    labels = {},
+    defaults,
+  } = options;
+
+  // One list-generator element per region, carrying the resolved per-region
+  // values the template interpolates.
+  const elements = regions.map((region) => {
+    const t = fn(region);
+    const path = t.path ?? setPath;
+    if (path === undefined) {
+      throw new Error(
+        `ArgoAppSetForRegions("${name}"): region "${region}" has no path — set options.path or return a path from the mapper.`,
+      );
+    }
+    return {
+      region,
+      ...(t.server !== undefined && { server: t.server }),
+      ...(t.name !== undefined && { clusterName: t.name }),
+      namespace: t.namespace,
+      path,
+      targetRevision: t.targetRevision ?? setRevision,
+    };
+  });
+
+  // Destination interpolates server or name depending on what the mapper gave.
+  const usesServer = elements.every((e) => "server" in e);
+  const destination: Record<string, unknown> = usesServer
+    ? { server: "{{server}}", namespace: "{{namespace}}" }
+    : { name: "{{clusterName}}", namespace: "{{namespace}}" };
+
+  const resolvedSyncPolicy = syncPolicy ?? defaultSyncPolicy();
+  const renderedSync = renderSyncPolicy(resolvedSyncPolicy);
+
+  const applicationSet = new ApplicationSetResource(mergeDefaults({
+    metadata: {
+      name,
+      namespace: argoNamespace,
+      labels: {
+        "app.kubernetes.io/name": name,
+        "app.kubernetes.io/managed-by": "chant",
+        ...labels,
+      },
+    },
+    spec: {
+      generators: [{ list: { elements } }],
+      template: {
+        metadata: { name: `{{region}}-${name}` },
+        spec: {
+          // Single static AppProject for the whole set (ARGO004).
+          project,
+          source: { repoURL: repo, path: "{{path}}", targetRevision: "{{targetRevision}}" },
+          destination,
+          ...(Object.keys(renderedSync).length > 0 && { syncPolicy: renderedSync }),
+        },
+      },
+    },
+  }, defaults?.applicationSet));
+
+  return { applicationSet };
+}, "ArgoApplicationSet");
+
+// ── registerArgoCluster ──────────────────────────────────────────────────────
+
+export interface RegisterArgoClusterOptions {
+  /** Cluster name as Argo will know it (referenced by Application destinations). */
+  name: string;
+  /** Cluster API server URL. */
+  server: string;
+  /**
+   * Argo cluster connection config (TLS, bearer token, exec auth). Serialized
+   * into the Secret's `config` field. See the Argo CD cluster Secret format.
+   */
+  config?: Record<string, unknown> | string;
+  /** Namespace Argo CD runs in (default "argocd"). */
+  argoNamespace?: string;
+  /** Extra labels (merged with the required secret-type label). */
+  labels?: Record<string, string>;
+  defaults?: { secret?: Partial<Record<string, unknown>> };
+}
+
+export interface RegisterArgoClusterResult {
+  secret: InstanceType<typeof SecretResource>;
+}
+
+/**
+ * Register an external cluster with Argo CD — emits the cluster Secret labelled
+ * `argocd.argoproj.io/secret-type: cluster` that ARGO003 looks for.
+ *
+ * @example
+ * ```ts
+ * import { registerArgoCluster } from "@intentius/chant-lexicon-k8s";
+ *
+ * export const east = registerArgoCluster({
+ *   name: "east",
+ *   server: "https://east.example.com",
+ *   config: { tlsClientConfig: { insecure: false } },
+ * });
+ * ```
+ */
+export function registerArgoCluster(options: RegisterArgoClusterOptions): RegisterArgoClusterResult {
+  return ArgoClusterSecret(options);
+}
+
+const ArgoClusterSecret = Composite<RegisterArgoClusterOptions, RegisterArgoClusterResult>(
+  (options) => {
+    const { name, server, config, argoNamespace = "argocd", labels = {}, defaults } = options;
+
+    const configString =
+      config === undefined ? undefined : typeof config === "string" ? config : JSON.stringify(config);
+
+    const secret = new SecretResource(mergeDefaults({
+      metadata: {
+        // Secret names can't contain characters from the server URL; use the
+        // cluster name as the object name.
+        name: `cluster-${name}`,
+        namespace: argoNamespace,
+        labels: {
+          "argocd.argoproj.io/secret-type": "cluster",
+          "app.kubernetes.io/managed-by": "chant",
+          ...labels,
+        },
+      },
+      type: "Opaque",
+      stringData: {
+        name,
+        server,
+        ...(configString !== undefined && { config: configString }),
+      },
+    }, defaults?.secret));
+
+    return { secret };
+  },
+  "ArgoClusterSecret",
+);

--- a/lexicons/k8s/src/composites/composites.test.ts
+++ b/lexicons/k8s/src/composites/composites.test.ts
@@ -8,6 +8,7 @@ function p(member: unknown): Record<string, unknown> {
   return (member as any).props;
 }
 import { StatefulApp } from "./stateful-app";
+import { ArgoAppFor, ArgoAppSetForRegions, registerArgoCluster } from "./argo-app";
 import { CronWorkload } from "./cron-workload";
 import { AutoscaledService } from "./autoscaled-service";
 import { WorkerPool } from "./worker-pool";
@@ -3221,5 +3222,131 @@ describe("CockroachDbCluster", () => {
     const result = CockroachDbCluster({ name: "crdb", image: "cockroachdb/cockroach:v23.2.0" });
     const container = (p(result.certGenJob).spec as any).template.spec.containers[0];
     expect(container.image).toBe("cockroachdb/cockroach:v23.2.0");
+  });
+});
+
+describe("ArgoAppFor", () => {
+  test("returns a single Application", () => {
+    const result = ArgoAppFor("api", { repo: "https://github.com/acme/infra", path: "dist/api" });
+    expect(result.application).toBeDefined();
+    expect((result.application as any).entityType).toBe("K8s::Argo::Application");
+  });
+
+  test("maps repo/path/revision onto spec.source", () => {
+    const result = ArgoAppFor("api", {
+      repo: "https://github.com/acme/infra",
+      path: "dist/api",
+      targetRevision: "v1.2.3",
+    });
+    const spec = p(result.application).spec as any;
+    expect(spec.source.repoURL).toBe("https://github.com/acme/infra");
+    expect(spec.source.path).toBe("dist/api");
+    expect(spec.source.targetRevision).toBe("v1.2.3");
+  });
+
+  test("defaults to the in-cluster destination and default project", () => {
+    const spec = p(ArgoAppFor("api", { repo: "r", path: "p" }).application).spec as any;
+    expect(spec.destination.server).toBe("https://kubernetes.default.svc");
+    expect(spec.destination.namespace).toBe("api");
+    expect(spec.project).toBe("default");
+  });
+
+  test("default sync policy is automated, non-pruning, self-healing", () => {
+    const spec = p(ArgoAppFor("api", { repo: "r", path: "p" }).application).spec as any;
+    expect(spec.syncPolicy.automated.prune).toBe(false);
+    expect(spec.syncPolicy.automated.selfHeal).toBe(true);
+    expect(spec.syncPolicy.syncOptions).toContain("CreateNamespace=true");
+  });
+
+  test("explicit empty sync policy yields manual sync (no automated block)", () => {
+    const spec = p(ArgoAppFor("api", { repo: "r", path: "p", syncPolicy: {} }).application).spec as any;
+    expect(spec.syncPolicy).toBeUndefined();
+  });
+
+  test("honors an explicit destination", () => {
+    const spec = p(
+      ArgoAppFor("api", {
+        repo: "r",
+        path: "p",
+        destination: { server: "https://east.example.com", namespace: "prod" },
+      }).application,
+    ).spec as any;
+    expect(spec.destination.server).toBe("https://east.example.com");
+    expect(spec.destination.namespace).toBe("prod");
+  });
+});
+
+describe("ArgoAppSetForRegions", () => {
+  const opts = { name: "crdb", repo: "https://github.com/acme/infra", project: "crdb" };
+  const mapper = (region: string) => ({
+    server: `https://${region}.example.com`,
+    namespace: `crdb-${region}`,
+    path: `dist/${region}`,
+  });
+
+  test("produces one ApplicationSet fanned out to 3 Applications", () => {
+    const result = ArgoAppSetForRegions(["east", "central", "west"], mapper, opts);
+    expect((result.applicationSet as any).entityType).toBe("K8s::Argo::ApplicationSet");
+    const spec = p(result.applicationSet).spec as any;
+    const elements = spec.generators[0].list.elements;
+    expect(elements).toHaveLength(3);
+    expect(elements.map((e: any) => e.region)).toEqual(["east", "central", "west"]);
+    expect(elements[0].server).toBe("https://east.example.com");
+    expect(elements[0].path).toBe("dist/east");
+  });
+
+  test("template scopes to a single static AppProject (ARGO004)", () => {
+    const spec = p(ArgoAppSetForRegions(["east"], mapper, opts).applicationSet).spec as any;
+    expect(spec.template.spec.project).toBe("crdb");
+    expect(spec.template.spec.project).not.toContain("{{");
+  });
+
+  test("template destination interpolates the per-region server", () => {
+    const spec = p(ArgoAppSetForRegions(["east"], mapper, opts).applicationSet).spec as any;
+    expect(spec.template.spec.destination.server).toBe("{{server}}");
+    expect(spec.template.spec.destination.namespace).toBe("{{namespace}}");
+  });
+
+  test("falls back to the set-level path when the mapper omits one", () => {
+    const spec = p(
+      ArgoAppSetForRegions(
+        ["east"],
+        (r) => ({ server: `https://${r}.example.com`, namespace: `ns-${r}` }),
+        { ...opts, path: "dist/shared" },
+      ).applicationSet,
+    ).spec as any;
+    expect(spec.generators[0].list.elements[0].path).toBe("dist/shared");
+  });
+
+  test("throws when no path is resolvable for a region", () => {
+    expect(() =>
+      ArgoAppSetForRegions(
+        ["east"],
+        (r) => ({ server: `https://${r}.example.com`, namespace: `ns-${r}` }),
+        opts,
+      ),
+    ).toThrow(/no path/);
+  });
+});
+
+describe("registerArgoCluster", () => {
+  test("emits a Secret labelled as an Argo cluster registration", () => {
+    const result = registerArgoCluster({ name: "east", server: "https://east.example.com" });
+    expect((result.secret as any).entityType).toBe("K8s::Core::Secret");
+    const meta = (p(result.secret).metadata as any);
+    expect(meta.labels["argocd.argoproj.io/secret-type"]).toBe("cluster");
+    const stringData = p(result.secret).stringData as any;
+    expect(stringData.name).toBe("east");
+    expect(stringData.server).toBe("https://east.example.com");
+  });
+
+  test("serializes an object config to JSON", () => {
+    const result = registerArgoCluster({
+      name: "east",
+      server: "https://east.example.com",
+      config: { tlsClientConfig: { insecure: false } },
+    });
+    const stringData = p(result.secret).stringData as any;
+    expect(JSON.parse(stringData.config)).toEqual({ tlsClientConfig: { insecure: false } });
   });
 });

--- a/lexicons/k8s/src/composites/index.ts
+++ b/lexicons/k8s/src/composites/index.ts
@@ -81,3 +81,15 @@ export { RayJob } from "./ray-job";
 export type { RayJobProps, RayJobResult } from "./ray-job";
 export { RayService } from "./ray-service";
 export type { RayServiceProps, RayServiceResult } from "./ray-service";
+export { ArgoAppFor, ArgoAppSetForRegions, registerArgoCluster } from "./argo-app";
+export type {
+  ArgoDestination,
+  ArgoSyncPolicy,
+  ArgoAppForOptions,
+  ArgoAppForResult,
+  ArgoRegionTarget,
+  ArgoAppSetForRegionsOptions,
+  ArgoAppSetForRegionsResult,
+  RegisterArgoClusterOptions,
+  RegisterArgoClusterResult,
+} from "./argo-app";


### PR DESCRIPTION
Part of #100. Closes #105.

Adds Argo composites to `lexicons/k8s/src/composites/argo-app.ts`, mirroring the `ray-*` composites. The k8s lexicon stays runtime-agnostic — Argo is opt-in via these composites.

## API
- **`ArgoAppFor(target, opts)`** — one call → a `K8s::Argo::Application`. Defaults: in-cluster destination, `default` project, automated **non-pruning** self-healing sync with `CreateNamespace=true`. Pass `syncPolicy: {}` for manual sync.
- **`ArgoAppSetForRegions(regions, fn, opts)`** — one `ApplicationSet` with a list generator fanned out per region; the template scopes to a single **static** `AppProject` (ARGO004-clean) and interpolates per-region server/namespace/path.
- **`registerArgoCluster(opts)`** — the cluster-registration `Secret` labelled `argocd.argoproj.io/secret-type=cluster` (what ARGO003 resolves against).

## Acceptance criteria
- ✅ One `ArgoAppFor` call replaces ~30 lines of hand-written Application YAML.
- ✅ `ArgoAppSetForRegions(['east','central','west'], …)` → 3 Applications (list generator, 3 elements).
- ✅ `composites.test.ts` covers props/defaults/dependencies for each.
- ✅ check-lexicon: 44 composites, Tier 3 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)