### PR TITLE
feat(temporal): waitForArgoSync activity + argoSync profile (#106)

### DIFF
--- a/lexicons/temporal/src/config.ts
+++ b/lexicons/temporal/src/config.ts
@@ -125,6 +125,24 @@ export const TEMPORAL_ACTIVITY_PROFILES = {
     heartbeatTimeout: "90s",
     retry: { maximumAttempts: 1 },
   },
+
+  /**
+   * Argo CD sync waits: poll an Application until `health=Healthy && sync=Synced`
+   * (`waitForArgoSync`). Long timeout for slow first syncs, 60s heartbeat, cheap
+   * idempotent retries — re-polling is free. A terminal-unhealthy Application
+   * fails fast via `ArgoSyncFailedError` (non-retryable).
+   */
+  argoSync: {
+    startToCloseTimeout: "30m",
+    heartbeatTimeout: "60s",
+    retry: {
+      maximumAttempts: 5,
+      initialInterval: "10s",
+      backoffCoefficient: 2,
+      maximumInterval: "1m",
+      nonRetryableErrorTypes: ["ArgoSyncFailedError"],
+    },
+  },
 } as const satisfies Record<string, TemporalActivityProfile>;
 
 export interface TemporalWorkerProfile {

--- a/lexicons/temporal/src/op/activities/argo.test.ts
+++ b/lexicons/temporal/src/op/activities/argo.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from "vitest";
+import {
+  waitForArgoSync,
+  ArgoSyncFailedError,
+  type ArgoAppStatus,
+  type ArgoStatusFetcher,
+} from "./argo";
+import { TEMPORAL_ACTIVITY_PROFILES } from "../../config";
+
+/** A fetcher that returns a scripted sequence of statuses, repeating the last. */
+function scriptedFetcher(sequence: ArgoAppStatus[]): ArgoStatusFetcher {
+  let i = 0;
+  return async () => {
+    const status = sequence[Math.min(i, sequence.length - 1)];
+    i++;
+    return status;
+  };
+}
+
+const fast = { appName: "guestbook", intervalMs: 0 };
+
+describe("waitForArgoSync", () => {
+  test("resolves once the Application is Healthy and Synced", async () => {
+    const fetcher = scriptedFetcher([
+      { health: "Progressing", sync: "OutOfSync" },
+      { health: "Progressing", sync: "Synced" },
+      { health: "Healthy", sync: "Synced" },
+    ]);
+    const result = await waitForArgoSync(fast, undefined, fetcher);
+    expect(result).toEqual({ health: "Healthy", sync: "Synced" });
+  });
+
+  test("does not resolve while Synced but still Progressing", async () => {
+    // First Healthy+Synced read is the third; ensure it polls past the
+    // Progressing reads rather than returning early.
+    let calls = 0;
+    const fetcher: ArgoStatusFetcher = async () => {
+      calls++;
+      if (calls < 3) return { health: "Progressing", sync: "Synced" };
+      return { health: "Healthy", sync: "Synced" };
+    };
+    await waitForArgoSync(fast, undefined, fetcher);
+    expect(calls).toBe(3);
+  });
+
+  test("throws ArgoSyncFailedError when the Application is Degraded", async () => {
+    const fetcher = scriptedFetcher([{ health: "Degraded", sync: "Synced" }]);
+    await expect(waitForArgoSync(fast, undefined, fetcher)).rejects.toBeInstanceOf(
+      ArgoSyncFailedError,
+    );
+  });
+
+  test("throws ArgoSyncFailedError when the Application is Missing", async () => {
+    const fetcher = scriptedFetcher([{ health: "Missing", sync: "OutOfSync" }]);
+    await expect(waitForArgoSync(fast, undefined, fetcher)).rejects.toThrow(/Missing/);
+  });
+
+  test("honors an aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fetcher = scriptedFetcher([{ health: "Progressing", sync: "OutOfSync" }]);
+    await expect(waitForArgoSync(fast, controller.signal, fetcher)).rejects.toThrow(/aborted/);
+  });
+});
+
+describe("argoSync profile", () => {
+  test("is exported with a long timeout and 60s heartbeat", () => {
+    const p = TEMPORAL_ACTIVITY_PROFILES.argoSync;
+    expect(p.startToCloseTimeout).toBe("30m");
+    expect(p.heartbeatTimeout).toBe("60s");
+  });
+
+  test("treats ArgoSyncFailedError as non-retryable", () => {
+    expect(TEMPORAL_ACTIVITY_PROFILES.argoSync.retry?.nonRetryableErrorTypes).toContain(
+      "ArgoSyncFailedError",
+    );
+  });
+});

--- a/lexicons/temporal/src/op/activities/argo.ts
+++ b/lexicons/temporal/src/op/activities/argo.ts
@@ -1,0 +1,147 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { safeHeartbeat } from "./heartbeat";
+import { sleep } from "./util";
+
+const execAsync = promisify(exec);
+
+/**
+ * waitForArgoSync — block until an Argo CD Application reports
+ * `health=Healthy && sync=Synced`.
+ *
+ * This activity is intentionally **dependency-free**: it must not import the k8s
+ * lexicon or its generated Argo CRD types. Its signature is primitives-only
+ * (app name / namespace / server). It reads the Application's status either via
+ * `kubectl get application` (default) or the Argo CD REST API (when `server` is
+ * given), so Temporal can gate procedural steps on a declarative apply that Argo
+ * owns.
+ */
+
+export interface WaitForArgoSyncArgs {
+  /** Argo Application name. */
+  appName: string;
+  /** Namespace the Application object lives in (default "argocd"). */
+  namespace?: string;
+  /**
+   * Argo CD API base URL (e.g. https://argocd.example.com). When set, status is
+   * read from the REST API instead of kubectl. Pass `authToken` with it.
+   */
+  server?: string;
+  /** Bearer token for the Argo CD REST API (used with `server`). */
+  authToken?: string;
+  /** Skip TLS verification for the REST API (default false). */
+  insecure?: boolean;
+  /** kubectl context (used when `server` is not set). */
+  context?: string;
+  /** Poll interval in ms (default 15000). Heartbeats every poll. */
+  intervalMs?: number;
+}
+
+/** The two status fields the activity gates on. */
+export interface ArgoAppStatus {
+  /** Application health: Healthy | Progressing | Degraded | Missing | Suspended | Unknown. */
+  health: string;
+  /** Sync status: Synced | OutOfSync | Unknown. */
+  sync: string;
+}
+
+/** Pluggable status reader — overridden in tests with a faked Argo API. */
+export type ArgoStatusFetcher = (
+  args: WaitForArgoSyncArgs,
+  signal?: AbortSignal,
+) => Promise<ArgoAppStatus>;
+
+/** Health states that will never become Healthy without intervention. */
+const TERMINAL_UNHEALTHY = new Set(["Degraded", "Missing"]);
+
+/** Error thrown when the Application reaches a terminal unhealthy state. */
+export class ArgoSyncFailedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgoSyncFailedError";
+  }
+}
+
+/** Read status via the Argo CD REST API. */
+async function fetchViaApi(args: WaitForArgoSyncArgs, signal?: AbortSignal): Promise<ArgoAppStatus> {
+  const base = args.server!.replace(/\/$/, "");
+  const ns = args.namespace ?? "argocd";
+  const url = `${base}/api/v1/applications/${encodeURIComponent(args.appName)}?appNamespace=${encodeURIComponent(ns)}`;
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (args.authToken) headers.Authorization = `Bearer ${args.authToken}`;
+
+  // Honor `insecure` without importing https Agent types — Node respects this
+  // env toggle for the duration of the call.
+  const prevTlsReject = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  if (args.insecure) process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+  try {
+    const res = await fetch(url, { headers, signal });
+    if (!res.ok) {
+      throw new Error(`Argo CD API returned ${res.status} for application "${args.appName}"`);
+    }
+    const body = (await res.json()) as { status?: { health?: { status?: string }; sync?: { status?: string } } };
+    return {
+      health: body.status?.health?.status ?? "Unknown",
+      sync: body.status?.sync?.status ?? "Unknown",
+    };
+  } finally {
+    if (args.insecure) {
+      if (prevTlsReject === undefined) delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+      else process.env.NODE_TLS_REJECT_UNAUTHORIZED = prevTlsReject;
+    }
+  }
+}
+
+/** Read status via `kubectl get application -o json`. */
+async function fetchViaKubectl(args: WaitForArgoSyncArgs, signal?: AbortSignal): Promise<ArgoAppStatus> {
+  const ns = args.namespace ?? "argocd";
+  const ctx = args.context ? `--context ${args.context}` : "";
+  const cmd =
+    `kubectl get application ${args.appName} -n ${ns} ${ctx} ` +
+    `-o jsonpath='{.status.health.status}|{.status.sync.status}'`;
+  const { stdout } = await execAsync(cmd, { signal });
+  const [health = "Unknown", sync = "Unknown"] = stdout.trim().replace(/^'|'$/g, "").split("|");
+  return { health: health || "Unknown", sync: sync || "Unknown" };
+}
+
+/** Default fetcher: REST API when `server` is set, else kubectl. */
+export const defaultArgoStatusFetcher: ArgoStatusFetcher = (args, signal) =>
+  args.server ? fetchViaApi(args, signal) : fetchViaKubectl(args, signal);
+
+/**
+ * Poll until the Application is Healthy and Synced. Throws
+ * `ArgoSyncFailedError` if it reaches a terminal unhealthy state (Degraded /
+ * Missing). Heartbeats every poll so the `argoSync` profile's 60s heartbeat
+ * timeout never trips.
+ *
+ * @param fetcher injectable status reader (defaults to kubectl/REST). Tests pass
+ *   a fake to drive Healthy/Progressing/Degraded transitions.
+ */
+export async function waitForArgoSync(
+  args: WaitForArgoSyncArgs,
+  signal?: AbortSignal,
+  fetcher: ArgoStatusFetcher = defaultArgoStatusFetcher,
+): Promise<ArgoAppStatus> {
+  const interval = args.intervalMs ?? 15_000;
+  let attempt = 0;
+
+  while (true) {
+    if (signal?.aborted) throw new Error("waitForArgoSync aborted");
+    attempt++;
+
+    const status = await fetcher(args, signal);
+    safeHeartbeat({ step: "waitForArgoSync", app: args.appName, attempt, ...status });
+
+    if (TERMINAL_UNHEALTHY.has(status.health)) {
+      throw new ArgoSyncFailedError(
+        `Argo Application "${args.appName}" is ${status.health} (sync=${status.sync}) — it will not become Healthy without intervention.`,
+      );
+    }
+
+    if (status.health === "Healthy" && status.sync === "Synced") {
+      return status;
+    }
+
+    await sleep(interval, signal);
+  }
+}

--- a/lexicons/temporal/src/op/activities/index.ts
+++ b/lexicons/temporal/src/op/activities/index.ts
@@ -27,3 +27,6 @@ export type { ReconcilePrArgs, ReconcileResult, ReconcileMode, ReconcileEntry } 
 
 export { nativeApply, compensateApply } from "./apply";
 export type { NativeApplyArgs, CompensateApplyArgs, ApplyTarget, DeleteMode } from "./apply";
+
+export { waitForArgoSync, defaultArgoStatusFetcher, ArgoSyncFailedError } from "./argo";
+export type { WaitForArgoSyncArgs, ArgoAppStatus, ArgoStatusFetcher } from "./argo";


### PR DESCRIPTION
Part of #100. Closes #106.

A **dependency-free** Temporal activity that lets workflows gate procedural steps on a declarative apply that Argo owns.

## `waitForArgoSync(args, signal?, fetcher?)`
- Polls an Argo `Application` until `health=Healthy && sync=Synced`.
- Primitives-only signature (`appName` / `namespace` / `server` / …) — imports **neither** the k8s lexicon **nor** the generated Argo CRD types.
- Reads status via `kubectl get application` by default, or the Argo CD REST API when `server` is set.
- Heartbeats every poll; fails fast with `ArgoSyncFailedError` on a terminal-unhealthy state (Degraded / Missing).
- Status reader is **injectable** (`fetcher`) → unit-tested against a faked Argo API with Healthy/Progressing/Degraded transitions.

## `argoSync` profile (`TEMPORAL_ACTIVITY_PROFILES`)
30m timeout, 60s heartbeat, cheap idempotent retries, `ArgoSyncFailedError` non-retryable.

Auto-registered with the generated worker via the activities barrel export.

## Acceptance criteria
- ✅ Unit test against a faked Argo API (Healthy/Progressing/Degraded).
- ✅ `argoSync` profile exported + documented; signature primitives-only.
- ⚠️ Integration test against a real Argo Application is an E2E (cluster-dependent) and not runnable in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)