### PR TITLE
docs: Argo CRD page + tutorial + split guidance (#109)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -77,6 +77,8 @@ export default defineConfig({
 						{ label: 'Durable Infrastructure Workflows', slug: 'tutorials/temporal-crdb-deploy' },
 						{ label: 'Fargate + Lucene/Solr + EFS', slug: 'tutorials/fargate-lucene-efs-solr' },
 						{ label: 'Ray + KubeRay on GKE', slug: 'tutorials/ray-kuberay-gke' },
+						{ label: 'Argo CD on GKE', slug: 'tutorials/argo-cd-gke' },
+						{ label: 'Argo CD Composites', link: '/lexicons/k8s/argo-composites/' },
 					],
 				},
 				{

--- a/docs/src/content/docs/tutorials/argo-cd-gke.mdx
+++ b/docs/src/content/docs/tutorials/argo-cd-gke.mdx
@@ -1,0 +1,136 @@
+---
+title: "Argo CD on GKE"
+description: "A minimal Argo CD on-ramp — one Chant-authored workload reconciled by Argo CD on a single GKE cluster, declared in TypeScript with ArgoAppFor."
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The smallest example of the **three-layer split**: Chant authors typed manifests, Argo CD reconciles them, and Temporal (not needed here) orchestrates anything procedural. A single GKE cluster runs Argo CD, and one Chant-authored workload is deployed through a `K8s::Argo::Application` declared in TypeScript with [`ArgoAppFor`](/chant/lexicons/k8s/argo-composites/).
+
+This mirrors the [`argo-cd-gke` example](https://github.com/INTENTIUS/chant/tree/main/examples/argo-cd-gke).
+
+## What you'll build
+
+```
+GKE cluster (Autopilot)
+  └── Argo CD (namespace argocd)
+        └── Application "web"  ──watches──▶  git repo (dist/app/)
+              └── reconciles ──▶  Deployment + Service  (namespace demo)
+```
+
+The key idea: **the k8s lexicon stays runtime-agnostic.** The workload (`src/app`) is plain Chant k8s — it knows nothing about Argo. Argo is **opt-in**, added by one `ArgoAppFor` call in `src/bootstrap`.
+
+## Layout
+
+```
+src/
+  config.ts                 # repo URL, paths, namespaces, the demo image
+  app/web.ts                # the workload — WebApp (Deployment + Service)
+  bootstrap/application.ts   # ArgoAppFor → the Argo Application that syncs src/app
+```
+
+Two build outputs:
+
+- `dist/app/manifests.yaml` — the workload. Commit it to the repo Argo watches.
+- `dist/argo.yaml` — the Argo `Application`. Apply it once to bootstrap the GitOps loop.
+
+## 1. Declare the workload
+
+`src/app/web.ts` is ordinary Chant — a `WebApp` composite. No Argo anywhere:
+
+```typescript
+import { WebApp } from "@intentius/chant-lexicon-k8s";
+import { config } from "../config";
+
+const { deployment, service } = WebApp({
+  name: config.appName,
+  image: config.appImage,
+  port: config.appPort,
+  namespace: config.appNamespace,
+  replicas: 2,
+});
+
+export { deployment, service };
+```
+
+## 2. Declare the Argo Application
+
+`src/bootstrap/application.ts` adds Argo in one call:
+
+```typescript
+import { ArgoAppFor } from "@intentius/chant-lexicon-k8s";
+import { config } from "../config";
+
+export const web = ArgoAppFor(config.appName, {
+  repo: config.repo,
+  path: config.appPath,
+  destination: { server: config.destinationServer, namespace: config.appNamespace },
+});
+```
+
+That renders to ~20 lines of `Application` YAML with a safe automated, non-pruning, self-healing sync policy:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: web
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/your-org/argo-cd-gke-demo
+    path: dist/app
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: demo
+  syncPolicy:
+    automated: { prune: false, selfHeal: true }
+    syncOptions: ["CreateNamespace=true"]
+```
+
+<Aside type="tip">
+`prune: false` keeps this [ARGO001](/chant/lexicons/k8s/lint-rules/)-clean. Flip pruning on per the rule's guidance once you trust the loop.
+</Aside>
+
+## 3. Build and push the workload
+
+```bash
+npm install
+npm run build           # → dist/app/manifests.yaml + dist/argo.yaml
+```
+
+Commit `dist/app/` to the repo referenced by `ARGO_REPO` so Argo has something to sync.
+
+## 4. Create the cluster and install Argo CD
+
+```bash
+npm run cluster           # GKE Autopilot cluster (idempotent)
+npm run configure-kubectl
+npm run install-argocd    # Argo CD v2.13.3 into namespace argocd
+```
+
+## 5. Bootstrap the Application
+
+```bash
+npm run bootstrap         # kubectl apply dist/argo.yaml
+npm run wait              # block until the Application is Healthy
+npm run status
+```
+
+## What success looks like
+
+```
+$ npm run status
+NAME   SYNC STATUS   HEALTH STATUS
+web    Synced        Healthy
+```
+
+The `web` Deployment and Service exist in the `demo` namespace — created by Argo, not by `kubectl apply` of the workload. Change `src/app`, rebuild, push to git, and Argo reconciles the diff on its own.
+
+## Next steps
+
+- Scope the Application to a real `AppProject` for RBAC ([ARGO002](/chant/lexicons/k8s/lint-rules/)).
+- Fan out across regional clusters with [`ArgoAppSetForRegions`](/chant/lexicons/k8s/argo-composites/).
+- Gate procedural steps on Argo finishing with the temporal lexicon's `waitForArgoSync` activity — see the [CockroachDB multi-region tutorial](/chant/tutorials/temporal-crdb-deploy/), which uses Argo for the apply layer and Temporal for the procedural one.

--- a/lexicons/k8s/docs/astro.config.mjs
+++ b/lexicons/k8s/docs/astro.config.mjs
@@ -61,6 +61,10 @@ export default defineConfig({
                   "slug": "serialization"
             },
             {
+                  "label": "Argo CD Composites",
+                  "slug": "argo-composites"
+            },
+            {
                   "label": "Vendor Composites",
                   "items": [
                         {

--- a/lexicons/k8s/docs/src/content/docs/argo-composites.mdx
+++ b/lexicons/k8s/docs/src/content/docs/argo-composites.mdx
@@ -1,0 +1,107 @@
+---
+title: "Argo CD Composites"
+description: "Argo CD support in the k8s lexicon — the argoproj.io CRDs, ArgoAppFor / ArgoAppSetForRegions composites, cluster registration, the ARGO00x rules, and the Argo-vs-Temporal split."
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Argo CD's `Application`, `ApplicationSet`, and `AppProject` are Kubernetes CRDs (`argoproj.io`). The k8s lexicon registers them via codegen — the same precedent as KubeRay — so you get typed `K8s::Argo::*` resources, the serializer, LSP, hover, and MCP for free. The value-add ships as composites, lint rules, and a skill.
+
+<Aside type="note">
+The k8s lexicon stays **runtime-agnostic** — it only emits manifests. Argo is **opt-in** via the composites below; nothing here is implied unless you reach for it.
+</Aside>
+
+## The three-layer model: Argo vs Temporal vs CI
+
+Chant authors typed infra into manifests. From there, who applies them?
+
+| Layer | Owns | Reach for it when |
+|---|---|---|
+| **Argo CD** | Continuously reconciling declarative manifests | the desired state lives in git and *converges* — Deployments, CRs, Helm releases |
+| **Temporal** | Procedural steps with ordering, signals, human gates, one-shot RPCs | the step is a *procedure*, not a state — DNS delegation, cert generation, `db init` |
+| **CI** | One-shot, fire-and-forget apply | a simple pipeline with no reconciliation or long-running orchestration need |
+
+Rule of thumb: **if it's declarative and converges, let Argo reconcile it; if it's a procedure with ordering or gates, orchestrate it in Temporal.** Prefer Argo CD over Argo *Workflows* — the procedural layer stays Temporal. See the [temporal-crdb-deploy tutorial](/chant/tutorials/temporal-crdb-deploy/) for a deployment that uses both.
+
+## The CRDs
+
+Pinned to Argo CD **v2.13.3**, the codegen produces:
+
+| Type | apiVersion / kind |
+|---|---|
+| `Application` | `argoproj.io/v1alpha1` / `Application` |
+| `ApplicationSet` | `argoproj.io/v1alpha1` / `ApplicationSet` |
+| `AppProject` | `argoproj.io/v1alpha1` / `AppProject` |
+
+Install the operator with:
+
+```bash
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v2.13.3/manifests/install.yaml
+```
+
+## ArgoAppFor — one Application from a build target
+
+```typescript
+import { ArgoAppFor } from "@intentius/chant-lexicon-k8s";
+
+export const api = ArgoAppFor("api", {
+  repo: "https://github.com/acme/infra",
+  path: "dist/api",
+  destination: { server: "https://kubernetes.default.svc", namespace: "api" },
+});
+```
+
+One call replaces ~30 lines of hand-written `Application` YAML. Defaults are production-friendly:
+
+- **destination** — the in-cluster target (`https://kubernetes.default.svc`, namespace = target name) when omitted.
+- **project** — `default`. Pass `project` to scope to a declared `AppProject`.
+- **syncPolicy** — automated, **non-pruning**, self-healing, with `CreateNamespace=true`. Pass `syncPolicy: {}` for manual sync.
+
+## ArgoAppSetForRegions — fan out across clusters
+
+```typescript
+import { ArgoAppSetForRegions } from "@intentius/chant-lexicon-k8s";
+
+export const crdb = ArgoAppSetForRegions(
+  ["east", "central", "west"],
+  (region) => ({ server: servers[region], namespace: `crdb-${region}`, path: `dist/${region}` }),
+  { name: "crdb", repo: "https://github.com/acme/infra", project: "crdb" },
+);
+```
+
+Emits one `ApplicationSet` with a list generator — Argo expands it into one synced `Application` per region (`east-crdb`, `central-crdb`, `west-crdb`). The template scopes to a single static `AppProject`.
+
+## registerArgoCluster — external clusters
+
+The in-cluster target needs no registration. For any other cluster:
+
+```typescript
+import { registerArgoCluster } from "@intentius/chant-lexicon-k8s";
+
+export const east = registerArgoCluster({
+  name: "east",
+  server: "https://east.example.com",
+  config: { tlsClientConfig: { insecure: false } },
+});
+```
+
+Produces a `Secret` labelled `argocd.argoproj.io/secret-type: cluster`. Applications can then target it by `destination.server` or `destination.name: "east"`.
+
+## Lint rules
+
+The k8s lexicon ships five Argo-specific checks (see [Lint Rules](../lint-rules/)):
+
+| Rule | Kind | What it catches |
+|---|---|---|
+| **ARGO001** | declarative | Production `Application` with automated `prune: true` and no `argocd.chant.dev/allow-prune` override |
+| **ARGO002** | post-synth | `Application.spec.project` references an undeclared `AppProject` |
+| **ARGO003** | post-synth | `Application.spec.destination` references an unregistered cluster |
+| **ARGO004** | declarative | `ApplicationSet` template doesn't scope to a single static `AppProject` |
+| **ARGO005** | post-synth | `Application` `source.path` doesn't resolve to a directory (warn) |
+
+## See also
+
+- [argo-cd-gke tutorial](/chant/tutorials/argo-cd-gke/) — a minimal single-cluster on-ramp.
+- The `chant-k8s-argo` [skill](../skills/) — agent guidance for these patterns.
+- [temporal-crdb-deploy tutorial](/chant/tutorials/temporal-crdb-deploy/) — Argo + Temporal together.

--- a/lexicons/k8s/docs/src/content/docs/index.mdx
+++ b/lexicons/k8s/docs/src/content/docs/index.mdx
@@ -58,12 +58,12 @@ The lexicon provides **147 resource types** (Deployment, Service, ConfigMap, Sta
 
 | Metric | Count |
 |--------|-------|
-| Resources | 150 |
-| Property types | 70 |
-| Services | 22 |
+| Resources | 153 |
+| Property types | 109 |
+| Services | 23 |
 | Intrinsic functions | 0 |
 | Pseudo-parameters | 0 |
-| Lint rules | 29 |
+| Lint rules | 34 |
 
 **Lexicon version:** 0.1.14  
 **Namespace:** `K8s`

--- a/lexicons/k8s/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/k8s/docs/src/content/docs/lint-rules.mdx
@@ -61,6 +61,18 @@ Post-synth checks run against the serialized YAML after build.
 | WK8302 | Single replica Deployment |
 | WK8303 | HA Deployment without PodDisruptionBudget |
 
+### Argo CD
+
+Quality checks for the [Argo CD composites](/chant/lexicons/k8s/argo-composites/). ARGO001/ARGO004 are declarative (source AST); ARGO002/003/005 are post-synth (cross-resource / filesystem).
+
+| Rule | Description |
+|------|-------------|
+| ARGO001 | Production `Application` enables automated `prune` without the `argocd.chant.dev/allow-prune` override |
+| ARGO002 | `Application.spec.project` references an undeclared `AppProject` |
+| ARGO003 | `Application.spec.destination` references an unregistered cluster |
+| ARGO004 | `ApplicationSet` template doesn't scope to a single static `AppProject` |
+| ARGO005 | `Application` `source.path` doesn't resolve to a directory (warn) |
+
 ## Running lint
 
 ```bash

--- a/lexicons/k8s/src/codegen/docs.ts
+++ b/lexicons/k8s/src/codegen/docs.ts
@@ -397,6 +397,18 @@ Post-synth checks run against the serialized YAML after build.
 | WK8302 | Single replica Deployment |
 | WK8303 | HA Deployment without PodDisruptionBudget |
 
+### Argo CD
+
+Quality checks for the [Argo CD composites](/chant/lexicons/k8s/argo-composites/). ARGO001/ARGO004 are declarative (source AST); ARGO002/003/005 are post-synth (cross-resource / filesystem).
+
+| Rule | Description |
+|------|-------------|
+| ARGO001 | Production \`Application\` enables automated \`prune\` without the \`argocd.chant.dev/allow-prune\` override |
+| ARGO002 | \`Application.spec.project\` references an undeclared \`AppProject\` |
+| ARGO003 | \`Application.spec.destination\` references an unregistered cluster |
+| ARGO004 | \`ApplicationSet\` template doesn't scope to a single static \`AppProject\` |
+| ARGO005 | \`Application\` \`source.path\` doesn't resolve to a directory (warn) |
+
 ## Running lint
 
 \`\`\`bash
@@ -1139,6 +1151,7 @@ The lexicon also provides MCP (Model Context Protocol) tools and resources:
     ],
     basePath: "/chant/lexicons/k8s/",
     sidebarExtra: [
+      { label: "Argo CD Composites", slug: "argo-composites" },
       {
         label: "Vendor Composites",
         items: [

--- a/lexicons/temporal/docs/src/content/docs/ops.mdx
+++ b/lexicons/temporal/docs/src/content/docs/ops.mdx
@@ -85,10 +85,21 @@ Profiles control Temporal retry and timeout settings via `TEMPORAL_ACTIVITY_PROF
 | `longInfra` | Slow infra changes (cluster create, Helm installs) |
 | `k8sWait` | Polling until K8s resources are ready |
 | `humanGate` | Activities that may take hours (approvals, DNS delegation) |
+| `argoSync` | Waiting for an Argo CD Application to become Healthy + Synced |
 
 ```ts
 activity("helmInstall", { name: "crdb", chart: "cockroachdb/cockroachdb" }, { profile: "longInfra" })
 ```
+
+## Bridging to Argo CD
+
+When Argo CD owns the declarative apply layer, Temporal gates procedural steps on Argo converging. The `waitForArgoSync` activity (dependency-free, primitives-only signature) polls an Application until `health=Healthy && sync=Synced`, paired with the `argoSync` profile (30m timeout, 60s heartbeat, cheap idempotent retries; a terminal-unhealthy Application fails fast).
+
+```ts
+await waitForArgoSync({ appName: "east-crdb", namespace: "argocd" });
+```
+
+See the [Argo CD composites](/chant/lexicons/k8s/argo-composites/) in the k8s lexicon for the manifest side, and the [CockroachDB multi-region tutorial](/chant/tutorials/temporal-crdb-deploy/) for the full Argo + Temporal split.
 
 ## Gate steps
 


### PR DESCRIPTION
Part of #100. Closes #109.

Documents Argo as part of the k8s lexicon docs, mirroring the Ray/KubeRay tutorial.

## Changes
- **k8s lexicon page** `Argo CD Composites` (`argo-composites.mdx`) — the `argoproj.io` CRDs, `ArgoAppFor` / `ArgoAppSetForRegions` / `registerArgoCluster`, the ARGO00x rules, and the three-layer **Argo vs Temporal vs CI** model. Wired into the generated sidebar + the lint-rules table via the docs generator (`codegen/docs.ts`) so it survives regeneration.
- **Tutorial** `Argo CD on GKE` (`tutorials/argo-cd-gke.mdx`) mirroring `ray-kuberay-gke` for the argo-cd-gke example; added to the docs sidebar.
- **Temporal `ops.mdx`** — documents the `argoSync` profile + `waitForArgoSync`, cross-linked to the k8s Argo page and the crdb tutorial.
- States the decision throughout: **the k8s lexicon stays runtime-agnostic; Argo is opt-in via composites.**
- Regenerated k8s lexicon docs (counts now reflect the +3 Argo CRDs / +5 ARGO rules from #101/#104).

## Verification
- ✅ Full-site `lychee` link check passes — **0 errors** across 2,200 unique links (the same check CI runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)