### PR TITLE
fix(codegen): retry transient HTTP failures when fetching schemas

### DIFF
--- a/packages/core/src/codegen/fetch.test.ts
+++ b/packages/core/src/codegen/fetch.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from "vitest";
-import { extractFromTar } from "./fetch";
+import { describe, test, expect, vi, afterEach } from "vitest";
+import { extractFromTar, fetchWithRetry } from "./fetch";
 
 /**
  * Build a minimal valid tar buffer with a single file entry.
@@ -115,5 +115,65 @@ describe("extractFromTar", () => {
     const files = extractFromTar(tar);
     expect(files.size).toBe(1);
     expect(files.get("multi.txt")!.toString()).toBe(content);
+  });
+});
+
+describe("fetchWithRetry", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const ok = () => new Response("payload", { status: 200 });
+  const status = (code: number) => new Response("", { status: code });
+
+  test("returns immediately on a successful response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resp = await fetchWithRetry("https://example.test/x", 4, 1);
+    expect(resp.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries a transient status then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(status(504))
+      .mockResolvedValueOnce(status(503))
+      .mockResolvedValueOnce(ok());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resp = await fetchWithRetry("https://example.test/x", 4, 1);
+    expect(resp.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  test("retries a network error then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNRESET"))
+      .mockResolvedValueOnce(ok());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resp = await fetchWithRetry("https://example.test/x", 4, 1);
+    expect(resp.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry a permanent status", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(status(404));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchWithRetry("https://example.test/x", 4, 1)).rejects.toThrow("returned 404");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws after exhausting retries on a transient status", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(status(504));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchWithRetry("https://example.test/x", 2, 1)).rejects.toThrow("returned 504");
+    // initial attempt + 2 retries
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/core/src/codegen/fetch.ts
+++ b/packages/core/src/codegen/fetch.ts
@@ -20,6 +20,61 @@ export interface FetchConfig {
   cacheTtlMs?: number;
 }
 
+// ── Transient-aware fetch ──────────────────────────────────────────
+
+/**
+ * HTTP statuses worth retrying. These are transient: a gateway hiccup,
+ * a rate limit, or an overloaded upstream — not a permanent 404/403.
+ */
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+const DEFAULT_RETRIES = 4;
+const DEFAULT_BACKOFF_MS = 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fetch a URL, retrying on transient failures (network errors and
+ * retryable HTTP statuses) with exponential backoff.
+ *
+ * Permanent failures (e.g. 404, 403) are not retried — they throw on the
+ * first response. The returned response is guaranteed `ok`.
+ */
+export async function fetchWithRetry(
+  url: string,
+  retries = DEFAULT_RETRIES,
+  backoffMs = DEFAULT_BACKOFF_MS,
+): Promise<Response> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) {
+      const delay = backoffMs * 2 ** (attempt - 1);
+      debug(`retrying ${url} (attempt ${attempt}/${retries}) after ${delay}ms: ${lastError?.message}`);
+      await sleep(delay);
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(url);
+    } catch (e) {
+      // Network-level failure (DNS, connection reset, timeout). Transient.
+      lastError = e instanceof Error ? e : new Error(String(e));
+      continue;
+    }
+
+    if (response.ok) return response;
+
+    const err = new Error(`Download from ${url} returned ${response.status}`);
+    if (!RETRYABLE_STATUSES.has(response.status)) throw err;
+    lastError = err;
+  }
+
+  throw lastError ?? new Error(`Download from ${url} failed after ${retries} retries`);
+}
+
 // ── Fetch with cache ───────────────────────────────────────────────
 
 const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -46,11 +101,7 @@ export async function fetchWithCache(config: FetchConfig, force = false): Promis
     }
   }
 
-  const response = await fetch(config.url);
-  if (!response.ok) {
-    throw new Error(`Download from ${config.url} returned ${response.status}`);
-  }
-
+  const response = await fetchWithRetry(config.url);
   const arrayBuffer = await response.arrayBuffer();
   const data = Buffer.from(arrayBuffer);
 
@@ -205,11 +256,7 @@ export async function fetchAndExtractTar(
     }
   }
 
-  const resp = await fetch(config.url);
-  if (!resp.ok) {
-    throw new Error(`Tarball download from ${config.url} returned ${resp.status}`);
-  }
-
+  const resp = await fetchWithRetry(config.url);
   const compressed = new Uint8Array(await resp.arrayBuffer());
   const { gunzipSync } = await import("fflate");
   const tarData = gunzipSync(compressed);


### PR DESCRIPTION
## What

Adds `fetchWithRetry` to codegen's HTTP layer and routes both schema-fetch sites (`fetchWithCache`, `fetchAndExtractTar`) through it.

## Why

Pre-existing bug. Both fetch sites threw on the **first** non-OK response with no retry. A transient upstream gateway error therefore failed the whole pipeline. This broke `main` after the merge of #209:

- `chant` / `validate`: `Download from https://github.com/Azure/azure-resource-manager-schemas/.../main.tar.gz returned 504`
- `docs`: `Download from https://github.com/GoogleCloudPlatform/k8s-config-connector/.../v1.145.0.tar.gz returned 504`

Neither was caused by the docs change — they were latent flakes waiting on a bad gateway response.

## Behavior

`fetchWithRetry` retries network-level errors (DNS, reset, timeout) and retryable HTTP statuses (`408, 425, 429, 500, 502, 503, 504`) with exponential backoff (4 retries, 1s base). Permanent statuses (`404`, `403`, …) still throw on the first response. The returned `Response` is guaranteed `ok`.

## Tests

5 new cases in `fetch.test.ts` (10 total pass): immediate success, retry-transient-then-succeed, retry-network-error-then-succeed, no-retry-on-permanent (404), throw-after-exhaustion. `tsc` and `eslint` clean.

## Out of scope

Same class of raw `fetch()`, but did **not** break CI, so left as follow-ups: `lexicons/aws/src/codegen/versions.ts`, `lexicons/k8s/src/codegen/versions.ts`, `lexicons/k8s/src/crd/loader.ts`.
