### PR TITLE
docs: add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in chant a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Showing empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Taking responsibility, apologizing to those affected by our mistakes, and learning from the experience.
+- Focusing on what is best for the community.
+
+Examples of unacceptable behavior:
+
+- Sexualized language or imagery, and unwelcome sexual attention or advances.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information without explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the maintainers at conduct@intentius.io. All complaints will be reviewed and investigated promptly and fairly. Maintainers will respect the privacy and security of the reporter of any incident.
+
+Maintainers are responsible for clarifying and enforcing these standards and may take corrective action — including warning, temporary ban, or permanent ban — in response to behavior they deem inappropriate, threatening, offensive, or harmful.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.


### PR DESCRIPTION
Adds a Contributor Covenant-style `CODE_OF_CONDUCT.md` at the repo root for the chant community.

Note: `CONTRIBUTING.md` and `GOVERNANCE.md` are also present untracked locally but left out of this PR — say the word if you want them added too.