### PR TITLE
feat(aws): FargateAlb repositoryCredentials for private-registry pull

### DIFF
--- a/lexicons/aws/src/composites/fargate-alb.ts
+++ b/lexicons/aws/src/composites/fargate-alb.ts
@@ -27,6 +27,13 @@ import { ecsTrustPolicy } from "./ecs-trust-policy";
 
 export interface FargateAlbProps {
   image: string;
+  /**
+   * Secrets Manager ARN holding private-registry pull credentials
+   * (`{"username","password"}`). Sets the container's `RepositoryCredentials`
+   * and grants the execution role `secretsmanager:GetSecretValue` on it — needed
+   * to pull from a private registry such as GHCR. Omit for public images / ECR.
+   */
+  repositoryCredentials?: string;
   containerPort?: number;
   cpu?: string;
   memory?: string;
@@ -79,6 +86,14 @@ export const FargateAlb = Composite<FargateAlbProps>((props) => {
         Action: LogsActions.Write,
         Resource: "*",
       },
+      // Allow pulling private-registry credentials when configured.
+      ...(props.repositoryCredentials
+        ? [{
+            Effect: "Allow",
+            Action: ["secretsmanager:GetSecretValue"],
+            Resource: props.repositoryCredentials,
+          }]
+        : []),
     ],
   };
 
@@ -136,6 +151,9 @@ export const FargateAlb = Composite<FargateAlbProps>((props) => {
     LogConfiguration: logConfiguration,
     Environment: environmentVars.length > 0 ? environmentVars : undefined,
     Command: props.command,
+    RepositoryCredentials: props.repositoryCredentials
+      ? { CredentialsParameter: props.repositoryCredentials }
+      : undefined,
   });
 
   // Task definition


### PR DESCRIPTION
Adds an optional `repositoryCredentials` prop to the `FargateAlb` composite (a Secrets Manager secret ARN). When set, the composite:
- sets the container's `RepositoryCredentials.CredentialsParameter`, and
- adds a `secretsmanager:GetSecretValue` statement (scoped to that ARN) to the execution role's policy.

That's what ECS needs to pull from a **private** registry such as GHCR. Omitted for public images / ECR (no behavior change). Used by the `grid` project to pull its private `ghcr.io/lex00/grid-api` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)