### PR TITLE
feat(examples): golden teaching example — L1 synthesis (#216 T2)

### DIFF
--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -49,6 +49,27 @@ describeExample("gitlab-aws-alb-ui", {
   examplesDir: import.meta.dir,
 });
 
+// ── Golden teaching example — L1 (synthesis core) ────────────────────
+
+describeExample(
+  "getting-started",
+  {
+    lexicon: "aws",
+    serializer: awsSerializer,
+    outputKey: "aws",
+    examplesDir: import.meta.dir,
+  },
+  {
+    checks: (output) => {
+      const parsed = JSON.parse(output);
+      const types = Object.values(parsed.Resources).map((r: any) => r.Type);
+      expect(types).toContain("AWS::Lambda::Function");
+      expect(types).toContain("AWS::S3::Bucket");
+      expect(Object.keys(parsed.Outputs)).toContain("DocsBucketArn");
+    },
+  },
+);
+
 // ── K8s + AWS EKS microservice (comprehensive) ──────────────────────
 
 describe("k8s-eks-microservice example", () => {

--- a/examples/getting-started/.gitignore
+++ b/examples/getting-started/.gitignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+.chant/
+template.json

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -1,0 +1,59 @@
+# getting-started — the golden teaching example
+
+The one example that teaches chant from the core up. It is built in levels. Each
+level adds one capability over the **same declarations**, so you start with pure
+synthesis and end with a full deployment workflow without rewriting anything.
+
+Start here if you are new to chant. Stop at whatever level answers your question.
+
+> **Status:** L1 is here now. L2–L5 land in follow-up work — see
+> [#216](https://github.com/INTENTIUS/chant/issues/216). The level plan below is
+> the target shape, not a claim that every level already exists.
+
+## The levels
+
+| Level | Adds | Needs |
+|---|---|---|
+| **L1 — synthesis** (this directory) | typed resources → `chant build` → spec-native output, plus `chant lint` and `chant graph` | nothing — no server, no cloud |
+| **L2 — Ops, local** | wrap the declarations in an Op, run it in-process | nothing |
+| **L3 — gate + Temporal** | a human-approval gate | a local Temporal (Docker) |
+| **L4 — the lifecycle dial** | observe drift, reconcile, apply | a target environment |
+| **L5 — capstone** | the alert-triage app ([#74](https://github.com/INTENTIUS/chant/issues/74)) | the full local stack |
+
+## L1 — what is here
+
+A Lambda that lists objects in an S3 bucket, declared as typed TypeScript.
+
+| File | Teaches |
+|---|---|
+| `src/main.ts` | typed resources and composites; intrinsics (`Sub`, `Ref`, `AWS.StackName`) |
+| `src/params.ts` | a deploy-time input (a CloudFormation Parameter the platform fills in) |
+| `src/outputs.ts` | a cross-resource reference (`app.bucket.Arn`) resolved at synthesis |
+| `src/tags.ts` | a reused `const` — static config resolved at synthesis |
+
+### Run it
+
+```bash
+npm install
+
+# Synthesize spec-native CloudFormation. No AWS call, no state, no deploy.
+npm run build      # → template.json
+
+# Validate meaning, not just structure.
+npm run lint
+
+# See the resource dependency graph.
+npm run graph
+```
+
+`template.json` is standard CloudFormation. You can hand it to
+`aws cloudformation deploy` or any pipeline — there is nothing chant-specific in
+the output. That is the whole of L1: deterministic, spec-true synthesis.
+
+## A standalone first taste
+
+If you want to run *something* in under a minute with no cloud account and no
+Docker, the [`local-op-quickstart`](../local-op-quickstart/) example runs a
+one-step Op on the local executor (`chant run hello`). It is the smallest Op
+demo and stands on its own; this golden example is the guided path that starts
+from synthesis and builds up.

--- a/examples/getting-started/chant.config.ts
+++ b/examples/getting-started/chant.config.ts
@@ -1,0 +1,2 @@
+import type { ChantConfig } from "@intentius/chant";
+export default { lexicons: ["aws"] } satisfies ChantConfig;

--- a/examples/getting-started/package.json
+++ b/examples/getting-started/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "getting-started-example",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "chant build src --lexicon aws -o template.json",
+    "lint": "chant lint src",
+    "graph": "chant graph src",
+    "dev": "chant build src --lexicon aws --watch -o template.json",
+    "test": "npx vitest run"
+  },
+  "dependencies": {
+    "@intentius/chant-lexicon-aws": "*",
+    "@intentius/chant": "*"
+  },
+  "devDependencies": {
+    "typescript": "*"
+  }
+}

--- a/examples/getting-started/src/main.ts
+++ b/examples/getting-started/src/main.ts
@@ -1,0 +1,33 @@
+// L1 — the synthesis core.
+//
+// Typed resources in, spec-native CloudFormation out. `chant build` imports
+// this file, reads the objects it exports, and serializes them. It never calls
+// AWS, reads state, or deploys. Same source always produces the same output.
+import { LambdaS3, Sub, AWS, Ref } from "@intentius/chant-lexicon-aws";
+import { environment } from "./params";
+
+// A Lambda that lists objects in an S3 bucket.
+//
+// `LambdaS3` is a composite — one call that returns several wired resources
+// (the function, its execution role, the bucket, the read policy). The returned
+// `app` exposes them as `app.func`, `app.bucket`, etc. so other files can
+// reference their attributes. `Sub` / `AWS.StackName` / `Ref` are intrinsics:
+// placeholders the platform resolves at apply, not values read at build time.
+export const app = LambdaS3({
+  name: Sub`${AWS.StackName}-${Ref(environment)}-docs-fn`,
+  bucketName: Sub`${AWS.StackName}-${Ref(environment)}-docs`,
+  Runtime: "nodejs20.x",
+  Handler: "index.handler",
+  Code: {
+    ZipFile: `const { S3Client, ListObjectsV2Command } = require("@aws-sdk/client-s3");
+const s3 = new S3Client();
+
+exports.handler = async () => {
+  const out = await s3.send(
+    new ListObjectsV2Command({ Bucket: process.env.BUCKET_NAME })
+  );
+  return { statusCode: 200, body: JSON.stringify(out.Contents ?? []) };
+};`,
+  },
+  access: "ReadOnly",
+});

--- a/examples/getting-started/src/outputs.ts
+++ b/examples/getting-started/src/outputs.ts
@@ -1,0 +1,9 @@
+// A cross-resource reference.
+//
+// `app.bucket.Arn` points at another resource's attribute. chant resolves the
+// reference during synthesis and emits the correct CloudFormation intrinsic in
+// the output. Every value in the artifact traces back to a line of source.
+import { output } from "@intentius/chant-lexicon-aws";
+import { app } from "./main";
+
+export const bucketArn = output(app.bucket.Arn, "DocsBucketArn");

--- a/examples/getting-started/src/params.ts
+++ b/examples/getting-started/src/params.ts
@@ -1,0 +1,11 @@
+// A deploy-time input.
+//
+// Its value is not known at synthesis. chant emits a CloudFormation Parameter
+// placeholder and the platform fills it in at apply. This is one of the three
+// places a value can come from — see the "Where Values Come From" concept doc.
+import { Parameter } from "@intentius/chant-lexicon-aws";
+
+export const environment = new Parameter("String", {
+  description: "Runtime environment (dev, staging, prod)",
+  defaultValue: "dev",
+});

--- a/examples/getting-started/src/tags.ts
+++ b/examples/getting-started/src/tags.ts
@@ -1,0 +1,10 @@
+// A plain `const`, applied to every resource as default tags.
+//
+// This is static data — fixed by the source, resolved at synthesis. Reusing a
+// const like this is the whole of "layered configuration" at its simplest.
+import { defaultTags } from "@intentius/chant-lexicon-aws";
+
+export const tags = defaultTags([
+  { Key: "Project", Value: "chant-getting-started" },
+  { Key: "Level", Value: "L1-synthesis" },
+]);

--- a/examples/getting-started/tsconfig.json
+++ b/examples/getting-started/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
Implements **#216 T2** — scaffold the golden teaching example at `examples/getting-started/` with **L1 (the synthesis core)**.

## What this is

One example that teaches chant from the core up, in levels, each adding one capability over the **same declarations**. This PR lands L1 and the structure; L2–L5 are follow-ups.

| Level | Adds | Status |
|---|---|---|
| **L1 — synthesis** | typed resources → `chant build` → spec-native output, `chant lint`, `chant graph`; no executor | **this PR** |
| L2 — Ops, local | wrap the declarations in an Op, run in-process | follow-up |
| L3 — gate + Temporal | a human-approval gate | follow-up |
| L4 — lifecycle dial | observe → reconcile → apply | follow-up |
| L5 — capstone | the alert-triage app (#74) | follow-up |

## L1 contents

A Lambda that lists an S3 bucket, declared as typed TypeScript. Each file maps to one concept:

- `src/main.ts` — typed resources, a composite, intrinsics (`Sub`/`Ref`/`AWS.StackName`)
- `src/params.ts` — a deploy-time input (CloudFormation Parameter)
- `src/outputs.ts` — a cross-resource reference resolved at synthesis
- `src/tags.ts` — a reused `const` (static config)

Wired into the example harness via `describeExample`, so L1 **lints and builds in CI** (with a check asserting the CloudFormation output contains the function, the bucket, and the `DocsBucketArn` output).

## Quickstart consolidation decision (T2 AC)

`local-op-quickstart` **stays in place** — the `chant` CI job's regression guard runs `chant run hello` against `examples/local-op-quickstart`, so moving it would break that step. The golden example references it as the standalone zero-dependency Op demo. The golden example's own L2 (an Op over L1's declarations) is authored fresh in a later PR rather than by relocating quickstart.

## Validation

Local: the example builds (`template.json`, spec-native CloudFormation) and `chant lint src` reports no problems. The full root example suite passes (107 tests), and `eslint packages/` is clean. The three required `chant` checks are unaffected by the new example beyond the test job, which now also exercises L1.

Part of #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)