### PR TITLE
feat(examples): golden example L2 — deploy Op (local executor) (#216)

### DIFF
--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -10,6 +10,7 @@ import { gitlabSerializer } from "@intentius/chant-lexicon-gitlab";
 import { helmSerializer } from "@intentius/chant-lexicon-helm";
 import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
 import { k8sPlugin } from "@intentius/chant-lexicon-k8s/plugin";
+import deployOp from "./getting-started/deploy.op";
 import { resolve } from "path";
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -72,6 +73,21 @@ describeExample(
     },
   },
 );
+
+// ── Golden teaching example — L2 (deploy Op) ─────────────────────────
+// The deploy Op can't run in CI (no cluster), so this validates that it
+// compiles to a well-formed Op. Running it is a documented local step
+// (k3d + `chant run deploy`).
+
+describe("golden example L2 — deploy Op", () => {
+  test("compiles to a well-formed Op", () => {
+    const props = (deployOp as unknown as {
+      props: { name: string; phases: Array<{ name: string }> };
+    }).props;
+    expect(props.name).toBe("deploy");
+    expect(props.phases.map((p) => p.name)).toEqual(["Build", "Apply"]);
+  });
+});
 
 // ── K8s + AWS EKS microservice (comprehensive) ──────────────────────
 

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -54,6 +54,28 @@ explicit `imagePullPolicy` or a read-only root filesystem). Those are guidance,
 not failures — `chant lint` is the gate. Hardening the workload against them is a
 good exercise.
 
+## L2 — deploy it locally
+
+`deploy.op.ts` wraps the same L1 declarations in an **Op**: a named, phased
+workflow. `chant run deploy` runs it in-process on the local executor — no
+Temporal server — building the manifests and applying them to your current kube
+context. Point that context at a local k3d cluster:
+
+```bash
+# One-time: a throwaway local cluster.
+k3d cluster create getting-started
+
+# Build the manifests, then kubectl apply them — phased, with retries.
+npm run deploy        # → chant run deploy
+```
+
+The Op has two phases: **Build** (`npm run build` → `k8s.yaml`) and **Apply**
+(`kubectl apply -f k8s.yaml`). Same declarations as L1 — L2 only adds how they
+are operated. Gates, schedules, and crash-resume need `--temporal`; that is L3.
+
+This deploy step is not run in CI (there is no cluster there). CI validates that
+the Op *compiles* to a well-formed workflow; running it is this local step.
+
 ## A standalone first taste
 
 If you want to run *something* in under a minute with no cluster and no Docker,

--- a/examples/getting-started/chant.config.ts
+++ b/examples/getting-started/chant.config.ts
@@ -1,2 +1,2 @@
 import type { ChantConfig } from "@intentius/chant";
-export default { lexicons: ["k8s"] } satisfies ChantConfig;
+export default { lexicons: ["k8s", "temporal"] } satisfies ChantConfig;

--- a/examples/getting-started/deploy.op.ts
+++ b/examples/getting-started/deploy.op.ts
@@ -1,0 +1,21 @@
+// L2 — Ops, on the local executor.
+//
+// The same L1 declarations, now wrapped in an Op: a named, phased workflow.
+// `chant run deploy` runs this in-process with no Temporal server — it builds
+// the manifests, then applies them to your current kube context (point that at a
+// local k3d cluster). Phases run in order, and a failing step retries per its
+// profile. Reach for `--temporal` only when you need gates, schedules, or
+// crash-resume (that is L3).
+import { Op, phase, build, kubectlApply } from "@intentius/chant-lexicon-temporal";
+
+export default Op({
+  name: "deploy",
+  overview: "Build the getting-started manifests and apply them to the current kube context",
+  taskQueue: "getting-started-deploy",
+  phases: [
+    // Runs `npm run build` in the example → writes k8s.yaml.
+    phase("Build", [build("examples/getting-started")]),
+    // kubectl apply -f against the current context (e.g. local k3d).
+    phase("Apply", [kubectlApply("examples/getting-started/k8s.yaml")]),
+  ],
+});

--- a/examples/getting-started/package.json
+++ b/examples/getting-started/package.json
@@ -8,10 +8,12 @@
     "lint": "chant lint src",
     "list": "chant list src",
     "dev": "chant build src --lexicon k8s --watch -o k8s.yaml",
+    "deploy": "chant run deploy",
     "test": "npx vitest run"
   },
   "dependencies": {
     "@intentius/chant-lexicon-k8s": "*",
+    "@intentius/chant-lexicon-temporal": "*",
     "@intentius/chant": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
**L2** of the golden teaching example — wraps L1's same declarations in an **Op** (a named, phased workflow), runnable locally.

## What L2 adds

`deploy.op.ts`: `chant run deploy` runs in-process on the **local executor** (no Temporal server), building the manifests and applying them to your current kube context (point it at local k3d). Two phases:

- **Build** — `npm run build` → `k8s.yaml`
- **Apply** — `kubectl apply -f k8s.yaml`

Same declarations as L1; L2 only adds *how they're operated*. Gates / schedules / crash-resume need `--temporal` (that's L3).

- `chant.config.ts` — adds the temporal lexicon
- `package.json` — temporal dep + `deploy` script
- `README` — L2 section with the local k3d run steps

## Validation (build-only, as agreed)

The Op can't run in CI (no cluster). Now that the example-tier tests actually run in CI (#224), a real test validates the Op **compiles to a well-formed workflow** (`name: "deploy"`, phases `[Build, Apply]`). Running the deploy is the documented local step.

```
examples/examples.test.ts → 150 passed | 10 skipped
  ✓ golden example L2 — deploy Op > compiles to a well-formed Op
```

`eslint packages/` clean.

Part of #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)