### PR TITLE
feat(examples): golden example L3 — approval gate on Temporal (#216)

### DIFF
--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -11,6 +11,7 @@ import { helmSerializer } from "@intentius/chant-lexicon-helm";
 import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
 import { k8sPlugin } from "@intentius/chant-lexicon-k8s/plugin";
 import deployOp from "./getting-started/deploy.op";
+import deployGatedOp from "./getting-started/deploy-gated.op";
 import { resolve } from "path";
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -86,6 +87,27 @@ describe("golden example L2 — deploy Op", () => {
     }).props;
     expect(props.name).toBe("deploy");
     expect(props.phases.map((p) => p.name)).toEqual(["Build", "Apply"]);
+  });
+});
+
+// ── Golden teaching example — L3 (gate + Temporal) ───────────────────
+// Gated deploy Op — runs on Temporal (--temporal), not the local executor.
+// Validated by compilation; the gated run is a documented local step.
+
+describe("golden example L3 — gated deploy Op", () => {
+  test("compiles with an approval gate and rollback", () => {
+    const props = (deployGatedOp as unknown as {
+      props: {
+        name: string;
+        phases: Array<{ name: string; steps: Array<{ kind: string }> }>;
+        onFailure?: Array<{ name: string }>;
+      };
+    }).props;
+    expect(props.name).toBe("deploy-gated");
+    expect(props.phases.map((p) => p.name)).toEqual(["Build", "Approve", "Apply"]);
+    const approve = props.phases.find((p) => p.name === "Approve");
+    expect(approve?.steps.some((s) => s.kind === "gate")).toBe(true);
+    expect(props.onFailure?.map((p) => p.name)).toEqual(["Rollback"]);
   });
 });
 

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -7,7 +7,7 @@ whole arc is Kubernetes, and every level runs on a laptop.
 
 Start here if you are new to chant. Stop at whatever level answers your question.
 
-> **Status:** L1 is here now. L2–L5 land in follow-up work — see
+> **Status:** L1–L3 are here now. L4–L5 land in follow-up work — see
 > [#216](https://github.com/INTENTIUS/chant/issues/216). The level plan below is
 > the target shape, not a claim that every level already exists.
 
@@ -75,6 +75,30 @@ are operated. Gates, schedules, and crash-resume need `--temporal`; that is L3.
 
 This deploy step is not run in CI (there is no cluster there). CI validates that
 the Op *compiles* to a well-formed workflow; running it is this local step.
+
+## L3 — pause for approval (Temporal)
+
+`deploy-gated.op.ts` is the same deploy with one addition: an **approval gate**
+before the apply, plus a rollback if anything fails. A gate is a durable
+wait-for-signal — it can hold for hours and survives a worker restart — so this
+Op runs on **Temporal**, not the local executor (the local executor errors on a
+gate, by design). L2's `deploy` stays the fast local path; this is the gated
+production shape.
+
+```bash
+# A local Temporal in Docker (separate terminal).
+temporal server start-dev
+
+# Run on Temporal — pauses at the "Approve" phase.
+chant run deploy-gated --temporal
+
+# Release the gate when you're ready.
+chant run signal deploy-gated approve-deploy
+```
+
+Phases: **Build → Approve (gate) → Apply**, with an `onFailure` **Rollback**.
+The Temporal connection comes from the `local` profile in `chant.config.ts`.
+As with L2, CI validates the Op compiles; the gated run is this local step.
 
 ## A standalone first taste
 

--- a/examples/getting-started/chant.config.ts
+++ b/examples/getting-started/chant.config.ts
@@ -1,2 +1,18 @@
-import type { ChantConfig } from "@intentius/chant";
-export default { lexicons: ["k8s", "temporal"] } satisfies ChantConfig;
+import type { TemporalChantConfig } from "@intentius/chant-lexicon-temporal";
+
+// `lexicons` is read by chant; `temporal` is read by the generated Op worker
+// when you run an Op with `--temporal` (L3+). L1/L2 need nothing here at runtime.
+export default {
+  lexicons: ["k8s", "temporal"],
+  temporal: {
+    profiles: {
+      local: {
+        address: "localhost:7233",
+        namespace: "default",
+        taskQueue: "getting-started-deploy",
+        autoStart: true,
+      },
+    },
+    defaultProfile: "local",
+  } satisfies TemporalChantConfig,
+};

--- a/examples/getting-started/deploy-gated.op.ts
+++ b/examples/getting-started/deploy-gated.op.ts
@@ -1,0 +1,34 @@
+// L3 — a human-approval gate, on Temporal.
+//
+// Same declarations again. This Op inserts an approval gate before the apply,
+// and adds a rollback that runs if anything fails. A gate is a durable
+// wait-for-signal: it can hold for hours without keeping a process open and
+// survives a worker restart — so this Op needs `--temporal`, not the local
+// executor (the local executor errors on a gate, by design).
+//
+//   chant run deploy-gated --temporal        # pauses at "Approve"
+//   chant run signal deploy-gated approve-deploy   # releases it
+//
+// L2's `deploy` stays the fast local path; this is the gated production shape.
+import { Op, phase, build, kubectlApply, gate, shell } from "@intentius/chant-lexicon-temporal";
+
+export default Op({
+  name: "deploy-gated",
+  overview: "Build, pause for human approval, then apply — durable on Temporal",
+  taskQueue: "getting-started-deploy",
+  phases: [
+    phase("Build", [build("examples/getting-started")]),
+    phase("Approve", [
+      gate("approve-deploy", {
+        timeout: "24h",
+        description: "Approve applying the getting-started manifests to the cluster",
+      }),
+    ]),
+    phase("Apply", [kubectlApply("examples/getting-started/k8s.yaml")]),
+  ],
+  onFailure: [
+    phase("Rollback", [
+      shell("kubectl delete -f examples/getting-started/k8s.yaml --ignore-not-found"),
+    ]),
+  ],
+});


### PR DESCRIPTION
**L3** of the golden teaching example — a human-approval gate, on Temporal.

## What L3 adds

`deploy-gated.op.ts` is L2's deploy with one addition: an **approval gate** before the apply, plus an `onFailure` **rollback**. A gate is a durable wait-for-signal (holds for hours, survives a worker restart), so this Op runs on **Temporal** — the local executor errors on a gate by design. L2's `deploy` stays the fast local path; this is the gated production shape.

```bash
temporal server start-dev                       # local Temporal (Docker)
chant run deploy-gated --temporal               # pauses at "Approve"
chant run signal deploy-gated approve-deploy    # releases it
```

Phases: **Build → Approve (gate) → Apply**, with `onFailure` **Rollback**.

- `deploy-gated.op.ts` — the gated Op
- `chant.config.ts` — typed temporal `local` profile (read by the generated Op worker)
- `README` — L3 section; status note now L1–L3

## Validation (build-only, as agreed)

No cluster/Temporal in CI. A compile test asserts the Op is well-formed — phases `[Build, Approve, Apply]`, an actual `gate` step in Approve, and an `onFailure` `Rollback`. The gated run is the documented local step.

```
examples/examples.test.ts → 151 passed | 10 skipped
  ✓ golden example L3 — gated deploy Op > compiles with an approval gate and rollback
```

`eslint packages/` clean.

Part of #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)