### PR TITLE
feat(examples): golden example L4 — the lifecycle dial (#216)

### DIFF
--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -12,7 +12,15 @@ import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
 import { k8sPlugin } from "@intentius/chant-lexicon-k8s/plugin";
 import deployOp from "./getting-started/deploy.op";
 import deployGatedOp from "./getting-started/deploy-gated.op";
+import observeOp from "./getting-started/observe.op";
+import reconcileOp from "./getting-started/reconcile.op";
+import applyOp from "./getting-started/apply.op";
 import { resolve } from "path";
+
+/** Read an Op default export's name. */
+function opName(op: unknown): string {
+  return (op as { props: { name: string } }).props.name;
+}
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -108,6 +116,18 @@ describe("golden example L3 — gated deploy Op", () => {
     const approve = props.phases.find((p) => p.name === "Approve");
     expect(approve?.steps.some((s) => s.kind === "gate")).toBe(true);
     expect(props.onFailure?.map((p) => p.name)).toEqual(["Rollback"]);
+  });
+});
+
+// ── Golden teaching example — L4 (the lifecycle dial) ────────────────
+// observe → reconcile → authoritative, as three composite-generated Ops.
+// Validated by compilation; running them needs a cluster (local step).
+
+describe("golden example L4 — lifecycle dial", () => {
+  test("observe / reconcile / apply Ops all compile", () => {
+    expect(opName(observeOp)).toBe("observe");
+    expect(opName(reconcileOp)).toBe("reconcile");
+    expect(opName(applyOp)).toBe("apply");
   });
 });
 

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -7,7 +7,7 @@ whole arc is Kubernetes, and every level runs on a laptop.
 
 Start here if you are new to chant. Stop at whatever level answers your question.
 
-> **Status:** L1–L3 are here now. L4–L5 land in follow-up work — see
+> **Status:** L1–L4 are here now. L5 lands in follow-up work — see
 > [#216](https://github.com/INTENTIUS/chant/issues/216). The level plan below is
 > the target shape, not a claim that every level already exists.
 
@@ -99,6 +99,29 @@ chant run signal deploy-gated approve-deploy
 Phases: **Build → Approve (gate) → Apply**, with an `onFailure` **Rollback**.
 The Temporal connection comes from the `local` profile in `chant.config.ts`.
 As with L2, CI validates the Op compiles; the gated run is this local step.
+
+## L4 — the lifecycle dial
+
+Same declarations, three positions on one dial — `observe → reconcile →
+authoritative` — each a composite-generated Op. `chant.config.ts` sets an
+`ownership` marker so reconcile and apply can scope to chant-owned resources.
+
+| Op | Direction | What it does |
+|---|---|---|
+| `observe.op.ts` (`WatchOp`) | — | snapshot + live diff on a schedule; reports drift, changes nothing |
+| `reconcile.op.ts` (`ReconcileOp`) | cloud → code | on drift, regenerate the affected TypeScript and open a PR |
+| `apply.op.ts` (`ApplyOp`) | code → cloud | apply via `kubectl`; deletes are owned-only (marker-scoped prune) |
+
+```bash
+chant run observe --temporal     # scheduled drift detection (needs Temporal)
+chant run reconcile              # pull live drift back into source as a PR
+chant run apply                  # push declared source to the cluster
+```
+
+You turn the dial up per environment as trust allows. chant hosts no state
+file — authority stays with `kubectl`; ownership is read from the marker on each
+live resource. As with the other levels, CI validates these Ops compile; running
+them needs the cluster.
 
 ## A standalone first taste
 

--- a/examples/getting-started/apply.op.ts
+++ b/examples/getting-started/apply.op.ts
@@ -1,0 +1,21 @@
+// L4 — the lifecycle dial, position 3: authoritative (code → cloud).
+//
+// ApplyOp builds, plans, and applies your declarations to the cluster via the
+// target's native mechanism (here kubectl). Deletes are owned-only: the prune is
+// scoped to the chant ownership marker, so a resource you didn't declare is never
+// touched. This is the authoritative end of the dial — chant pushes source into
+// the live system. chant hosts no state file; authority stays with kubectl.
+//
+//   chant run apply
+import { ApplyOp } from "@intentius/chant-lexicon-temporal";
+
+const apply = ApplyOp({
+  name: "apply",
+  env: "local",
+  target: "kubectl",
+  path: "examples/getting-started",
+  output: "examples/getting-started/k8s.yaml",
+  delete: "owned-only",
+});
+
+export default apply.op;

--- a/examples/getting-started/chant.config.ts
+++ b/examples/getting-started/chant.config.ts
@@ -1,9 +1,12 @@
 import type { TemporalChantConfig } from "@intentius/chant-lexicon-temporal";
 
 // `lexicons` is read by chant; `temporal` is read by the generated Op worker
-// when you run an Op with `--temporal` (L3+). L1/L2 need nothing here at runtime.
+// when you run an Op with `--temporal` (L3+). `ownership` stamps a marker on each
+// resource so the L4 dial (reconcile/apply) can scope to chant-owned resources.
+// L1/L2 need nothing here at runtime.
 export default {
   lexicons: ["k8s", "temporal"],
+  ownership: { stack: "getting-started", env: "local" },
   temporal: {
     profiles: {
       local: {

--- a/examples/getting-started/observe.op.ts
+++ b/examples/getting-started/observe.op.ts
@@ -1,0 +1,18 @@
+// L4 — the lifecycle dial, position 1: observe.
+//
+// WatchOp pairs a snapshot+diff Op with a Temporal schedule, so chant checks the
+// live cluster against your declarations on a cron and reports drift. It changes
+// nothing — this is the read-only end of the dial. Schedules need Temporal.
+//
+//   chant build && chant run observe --temporal
+import { WatchOp } from "@intentius/chant-lexicon-temporal";
+
+const watch = WatchOp({
+  name: "observe",
+  env: "local",
+  schedule: "0 * * * *", // hourly
+  live: true, // query the cluster, not just a digest
+});
+
+export default watch.op;
+export const schedule = watch.schedule;

--- a/examples/getting-started/reconcile.op.ts
+++ b/examples/getting-started/reconcile.op.ts
@@ -1,0 +1,18 @@
+// L4 — the lifecycle dial, position 2: reconcile (cloud → code).
+//
+// ReconcileOp snapshots, plans against live, and when the cluster has drifted
+// from your declarations it regenerates the affected TypeScript and opens a PR.
+// It pulls reality back into source; it never writes to the cluster. Scoped to
+// chant-owned resources. One-shot on the local executor (no schedule here).
+//
+//   chant run reconcile
+import { ReconcileOp } from "@intentius/chant-lexicon-temporal";
+
+const reconcile = ReconcileOp({
+  name: "reconcile",
+  env: "local",
+  onDrift: "pull-request",
+  scope: { owned: true },
+});
+
+export default reconcile.op;


### PR DESCRIPTION
**L4** of the golden teaching example — the `observe → reconcile → authoritative` dial, over the same L1 declarations.

## What L4 adds

Three composite-generated Ops, one per dial position:

| Op | Direction | What it does |
|---|---|---|
| `observe.op.ts` (`WatchOp`) | — | scheduled snapshot + live diff; reports drift, changes nothing |
| `reconcile.op.ts` (`ReconcileOp`) | cloud → code | on drift, regenerate the affected TypeScript and open a PR |
| `apply.op.ts` (`ApplyOp`) | code → cloud | apply via `kubectl`; deletes are owned-only (marker-scoped prune) |

`chant.config.ts` gains an `ownership` marker (`stack: getting-started`) so reconcile/apply can scope to chant-owned resources. No state file — authority stays with `kubectl`; ownership is read from the live marker.

README gains an L4 section; status note now **L1–L4**.

## Validation (build-only, as agreed)

Running these needs a cluster, so CI validates they **compile** to well-formed Ops:

```
examples/examples.test.ts → 152 passed | 10 skipped
  ✓ golden example L4 — lifecycle dial > observe / reconcile / apply Ops all compile
```

L1 `getting-started` still green with the ownership config; `eslint packages/` clean.

Part of #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)