### PR TITLE
fix(azure): pin Microsoft.Authorization so roleAssignments generates (#223)

### DIFF
--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -480,11 +480,8 @@ describe("k8s-gke-microservice example", () => {
 });
 
 // ── K8s + Azure AKS microservice (comprehensive) ────────────────────
-// QUARANTINED (#223): the Azure lexicon no longer generates
-// Microsoft.Authorization/roleAssignments, so this example's import of
-// `RoleAssignment` fails at build. Un-skip once #223 restores the resource.
 
-describe.skip("k8s-aks-microservice example", () => {
+describe("k8s-aks-microservice example", () => {
   const srcDir = resolve(import.meta.dirname, "k8s-aks-microservice", "src");
 
   test("passes lint", async () => {

--- a/lexicons/azure/src/spec/api-versions.ts
+++ b/lexicons/azure/src/spec/api-versions.ts
@@ -45,7 +45,23 @@ export function parseSchemaPath(
 }
 
 /**
- * Given a set of schema paths, return only the latest API version per provider.
+ * Per-provider API-version pins.
+ *
+ * `latestVersionPerProvider` picks the single newest version per provider, but
+ * Azure spreads resources across versions — a newer version can DROP a resource
+ * an older one defined. Microsoft.Authorization's latest preview no longer
+ * includes the plain `roleAssignments` / `roleDefinitions` resources; they live
+ * in 2022-04-01, the latest stable that still has them. Pin it so those
+ * generate (the naming table maps both). See #223.
+ */
+export const PROVIDER_VERSION_OVERRIDES: Record<string, string> = {
+  "Microsoft.Authorization": "2022-04-01",
+};
+
+/**
+ * Given a set of schema paths, return only the latest API version per provider,
+ * with {@link PROVIDER_VERSION_OVERRIDES} pinning specific providers to a chosen
+ * version (used where "latest" drops resources we depend on).
  *
  * Returns a Map of provider → { path, apiVersion }.
  */
@@ -57,6 +73,15 @@ export function latestVersionPerProvider(
   for (const p of paths) {
     const parsed = parseSchemaPath(p);
     if (!parsed) continue;
+
+    const pinned = PROVIDER_VERSION_OVERRIDES[parsed.provider];
+    if (pinned) {
+      // Only accept the pinned version for an overridden provider.
+      if (parsed.apiVersion === pinned) {
+        best.set(parsed.provider, { path: p, apiVersion: parsed.apiVersion });
+      }
+      continue;
+    }
 
     const existing = best.get(parsed.provider);
     if (!existing || compareApiDates(parsed.apiVersion, existing.apiVersion) > 0) {


### PR DESCRIPTION
## Root cause

The Azure lexicon picks the single **latest API version per provider** (`latestVersionPerProvider`). Azure spreads resources across versions, and `Microsoft.Authorization`'s latest preview versions **dropped the plain `roleAssignments` / `roleDefinitions` resources** — they only exist up to the **2022-04-01** stable. So `RoleAssignment` stopped generating (even though `naming.ts` still maps it), and `k8s-aks-microservice` (which imports `RoleAssignment`) broke at build. This stayed hidden until the example-tier tests were revived in #224.

## Fix

A minimal, targeted override — `PROVIDER_VERSION_OVERRIDES` pins `Microsoft.Authorization` to `2022-04-01` (the latest stable that still defines both `roleAssignments` and `roleDefinitions`). Contained blast radius: nothing in the repo uses the newer-only Authorization resources (PIM schedules, access reviews, etc.).

## Validation

- Regenerated azure → `RoleAssignment` (`Microsoft.Authorization/roleAssignments`) exported again; `prepack` validation (coverage, `types-compile`) passes.
- **Un-quarantined `k8s-aks-microservice`** — its 10 tests pass; the root example suite is now **162 passed, 0 skipped** (was 152 | 10).
- Azure lexicon + example suites: **418 passed**, no regression.

Closes #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)