### PR TITLE
feat(examples): L5 capstone — alert-triage app skeleton (#74)

### DIFF
--- a/examples/alert-triage/.gitignore
+++ b/examples/alert-triage/.gitignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+.chant/
+k8s.yaml

--- a/examples/alert-triage/README.md
+++ b/examples/alert-triage/README.md
@@ -1,0 +1,50 @@
+# alert-triage — L5, the golden example capstone
+
+A Temporal-driven incident-triage app, and the final level (L5) of the
+[golden teaching example](../getting-started/). Where L1–L4 take the same small
+workload from synthesis up through the lifecycle dial, L5 graduates to a real
+app: a webhook receives alerts, a Temporal worker runs a phased triage workflow
+over each, and a human approves anything risky before it is applied.
+
+> **Status:** this first slice ships the app's **Kubernetes manifests** and the
+> **triage Op skeleton**. The worker, the triage activities (the agent — stubbed
+> by default, real Claude when `ANTHROPIC_API_KEY` is set), and a `WatchOp` drift
+> source as a second event source land in follow-ups. See
+> [#74](https://github.com/INTENTIUS/chant/issues/74).
+
+## What's here now
+
+| File | What it declares |
+|---|---|
+| `src/config.ts` | pinned image refs (replace with your own builds) |
+| `src/workloads.ts` | the webhook (`WebApp` → Deployment + Service + Ingress + PDB) and the worker (`WorkerPool` → Deployment) |
+| `alert-triage.op.ts` | the triage Op: **Classify → Context → Propose → Approve (gate) → Notify** |
+| `chant.config.ts` | k8s + temporal lexicons, and a local Temporal profile |
+
+```bash
+npm install
+npm run build      # → k8s.yaml (plain Kubernetes)
+npm run lint       # clean
+npm run list       # what you declared
+```
+
+## The triage workflow
+
+One alert in, a phased triage out. Each non-gate phase is an activity run by the
+worker; the `Approve` gate pauses for a human, which makes the Op Temporal-bound:
+
+```bash
+chant run alert-triage --temporal              # pauses at "Approve"
+chant run signal alert-triage approve-remediation
+```
+
+The activities run the agent — **stubbed by default** (no key, runs anywhere),
+and a real Claude call when `ANTHROPIC_API_KEY` is set. The first run shows
+chant, not an LLM.
+
+## Coming in follow-ups
+
+- The worker and the triage activities (classify / gather context / propose / notify).
+- The agent: deterministic stub by default, real Anthropic opt-in.
+- A `WatchOp` that turns drift on the deployed namespace into a second event source.
+- A local k3d + Temporal `npm run dev` and a tutorial.

--- a/examples/alert-triage/alert-triage.op.ts
+++ b/examples/alert-triage/alert-triage.op.ts
@@ -1,0 +1,32 @@
+// The triage workflow — L5 capstone of the golden example.
+//
+// One alert in, a phased triage out: classify severity, gather context with
+// tools, propose a remediation, gate on human approval when it's risky, then
+// notify. Each non-gate phase is an activity implemented by the worker (later
+// PRs); the activities run the agent — stubbed by default, real Claude when
+// ANTHROPIC_API_KEY is set. The gate makes this Temporal-bound.
+//
+//   chant run alert-triage --temporal
+//   chant run signal alert-triage approve-remediation
+//
+// This PR ships the Op skeleton and the app's manifests; the worker, the
+// activities, and the WatchOp drift source land in follow-ups.
+import { Op, phase, activity, gate } from "@intentius/chant-lexicon-temporal";
+
+export default Op({
+  name: "alert-triage",
+  overview: "Triage an alert: classify, gather context, propose a fix, gate on approval, notify",
+  taskQueue: "alert-triage",
+  phases: [
+    phase("Classify", [activity("classifyAlert")]),
+    phase("Context", [activity("gatherContext")]),
+    phase("Propose", [activity("proposeRemediation")]),
+    phase("Approve", [
+      gate("approve-remediation", {
+        timeout: "12h",
+        description: "Approve the proposed remediation before it is applied",
+      }),
+    ]),
+    phase("Notify", [activity("notifyOutcome")]),
+  ],
+});

--- a/examples/alert-triage/chant.config.ts
+++ b/examples/alert-triage/chant.config.ts
@@ -1,0 +1,18 @@
+import type { TemporalChantConfig } from "@intentius/chant-lexicon-temporal";
+
+// `lexicons` is read by chant; `temporal` is read by the generated Op worker
+// when you run the triage Op with `--temporal` (the gate makes it Temporal-bound).
+export default {
+  lexicons: ["k8s", "temporal"],
+  temporal: {
+    profiles: {
+      local: {
+        address: "localhost:7233",
+        namespace: "default",
+        taskQueue: "alert-triage",
+        autoStart: true,
+      },
+    },
+    defaultProfile: "local",
+  } satisfies TemporalChantConfig,
+};

--- a/examples/alert-triage/package.json
+++ b/examples/alert-triage/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "alert-triage-example",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "chant build src --lexicon k8s -o k8s.yaml",
+    "lint": "chant lint src",
+    "list": "chant list src",
+    "test": "npx vitest run"
+  },
+  "dependencies": {
+    "@intentius/chant-lexicon-k8s": "*",
+    "@intentius/chant-lexicon-temporal": "*",
+    "@intentius/chant": "*"
+  },
+  "devDependencies": {
+    "typescript": "*"
+  }
+}

--- a/examples/alert-triage/src/config.ts
+++ b/examples/alert-triage/src/config.ts
@@ -1,0 +1,5 @@
+// Static config for the alert-triage app — plain consts, resolved at synthesis.
+// Replace the image refs with your own builds; they are pinned (chant lint flags
+// `:latest`).
+export const webhookImage = "ghcr.io/intentius/alert-webhook:0.1.0";
+export const workerImage = "ghcr.io/intentius/alert-worker:0.1.0";

--- a/examples/alert-triage/src/workloads.ts
+++ b/examples/alert-triage/src/workloads.ts
@@ -1,0 +1,50 @@
+// The alert-triage app's Kubernetes surface — typed, synthesized to plain YAML.
+//
+// Two workloads: a webhook receiver that accepts incoming alerts over HTTP, and
+// a Temporal worker that runs the triage workflow's activities. Both use
+// composites so the output carries production defaults and lints clean.
+import { WebApp, WorkerPool } from "@intentius/chant-lexicon-k8s";
+import { webhookImage, workerImage } from "./config";
+
+const secureContext = {
+  runAsNonRoot: true,
+  runAsUser: 1000,
+  allowPrivilegeEscalation: false,
+  capabilities: { drop: ["ALL"] },
+};
+
+// Webhook receiver — Deployment + Service + Ingress + PodDisruptionBudget.
+const webhook = WebApp({
+  name: "alert-webhook",
+  image: webhookImage,
+  port: 8080,
+  replicas: 2,
+  minAvailable: 1,
+  ingressHost: "alerts.example.com",
+  cpuRequest: "50m",
+  memoryRequest: "64Mi",
+  cpuLimit: "200m",
+  memoryLimit: "256Mi",
+  securityContext: secureContext,
+});
+
+export const webhookDeployment = webhook.deployment;
+export const webhookService = webhook.service;
+export const webhookIngress = webhook.ingress!;
+export const webhookPdb = webhook.pdb!;
+
+// Temporal worker — Deployment only (no Service); runs the triage activities.
+const worker = WorkerPool({
+  name: "alert-worker",
+  image: workerImage,
+  replicas: 2,
+  minAvailable: 1,
+  cpuRequest: "100m",
+  memoryRequest: "128Mi",
+  cpuLimit: "500m",
+  memoryLimit: "256Mi",
+  securityContext: secureContext,
+});
+
+export const workerDeployment = worker.deployment;
+export const workerPdb = worker.pdb!;

--- a/examples/alert-triage/tsconfig.json
+++ b/examples/alert-triage/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -15,6 +15,7 @@ import deployGatedOp from "./getting-started/deploy-gated.op";
 import observeOp from "./getting-started/observe.op";
 import reconcileOp from "./getting-started/reconcile.op";
 import applyOp from "./getting-started/apply.op";
+import alertTriageOp from "./alert-triage/alert-triage.op";
 import { resolve } from "path";
 
 /** Read an Op default export's name. */
@@ -128,6 +129,47 @@ describe("golden example L4 — lifecycle dial", () => {
     expect(opName(observeOp)).toBe("observe");
     expect(opName(reconcileOp)).toBe("reconcile");
     expect(opName(applyOp)).toBe("apply");
+  });
+});
+
+// ── Golden teaching example — L5 capstone: alert-triage (#74) ────────
+// First slice: the app's k8s manifests + the triage Op skeleton. Worker,
+// activities, and WatchOp source land in follow-ups.
+
+describeExample(
+  "alert-triage",
+  {
+    lexicon: "k8s",
+    serializer: k8sSerializer,
+    outputKey: "k8s",
+    examplesDir: import.meta.dirname,
+  },
+  {
+    checks: (output) => {
+      const kinds = parseK8sDocs(output).map((d) => d.kind);
+      // webhook (WebApp) + worker (WorkerPool)
+      expect(kinds.filter((k) => k === "Deployment")).toHaveLength(2);
+      expect(kinds).toContain("Service");
+      expect(kinds).toContain("Ingress");
+    },
+  },
+);
+
+describe("alert-triage L5 — triage Op", () => {
+  test("compiles with the triage phases and an approval gate", () => {
+    const props = (alertTriageOp as unknown as {
+      props: { name: string; phases: Array<{ name: string; steps: Array<{ kind: string }> }> };
+    }).props;
+    expect(props.name).toBe("alert-triage");
+    expect(props.phases.map((p) => p.name)).toEqual([
+      "Classify",
+      "Context",
+      "Propose",
+      "Approve",
+      "Notify",
+    ]);
+    const approve = props.phases.find((p) => p.name === "Approve");
+    expect(approve?.steps.some((s) => s.kind === "gate")).toBe(true);
   });
 });
 

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -19,7 +19,7 @@ Start here if you are new to chant. Stop at whatever level answers your question
 | **L2 — Ops, local** | wrap the declarations in an Op that `kubectl apply`s to a local k3d cluster | k3d (Docker) |
 | **L3 — gate + Temporal** | a human-approval gate before apply | a local Temporal (Docker) |
 | **L4 — the lifecycle dial** | observe drift, reconcile, apply against the cluster | the k3d cluster |
-| **L5 — capstone** | the alert-triage app ([#74](https://github.com/INTENTIUS/chant/issues/74)) | the full local stack |
+| **L5 — capstone** | the [alert-triage app](../alert-triage/) ([#74](https://github.com/INTENTIUS/chant/issues/74)) — manifests + triage Op so far | the full local stack |
 
 ## L1 — what is here
 


### PR DESCRIPTION
First slice of the golden example's **L5 capstone** — the alert-triage app's Kubernetes manifests and the triage Op skeleton. Synthesis/compile-validated like L1–L4; worker, activities, and a `WatchOp` source land in follow-ups.

## What's here

- `src/workloads.ts` — the **webhook** (`WebApp` → Deployment + Service + Ingress + PDB) and the **worker** (`WorkerPool` → Deployment), via composites so the output lints clean.
- `src/config.ts` — pinned image refs.
- `alert-triage.op.ts` — the triage Op: **Classify → Context → Propose → Approve (gate) → Notify**. Activities are implemented later — the agent is **stubbed by default, real Claude when `ANTHROPIC_API_KEY` is set**.
- `chant.config.ts` — k8s + temporal lexicons + a local Temporal profile.
- `examples.test.ts` — `describeExample` (manifests build/lint) + an Op compile check.
- getting-started README — L5 row now links the example.

## Validation

`build` clean (the worker has no probes by design — advisory, not a failure); `lint` clean; the Op compiles to the expected phases with a real gate in `Approve`.

```
examples/examples.test.ts → 165 passed
  ✓ k8s alert-triage example > passes lint / build succeeds
  ✓ alert-triage L5 — triage Op > compiles with the triage phases and an approval gate
```

`eslint packages/` clean.

## Follow-ups (#74)

Worker + triage activities; the agent (stub default, Anthropic opt-in); a `WatchOp` drift source as a second event source; local k3d + Temporal `npm run dev` and a tutorial.

Part of #74 / #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)