### PR TITLE
feat(examples): alert-triage L5 — Temporal workflow + worker (#231)

### DIFF
--- a/examples/alert-triage/README.md
+++ b/examples/alert-triage/README.md
@@ -13,10 +13,11 @@ This is chant's documented "Raw Temporal + chant" path, the same split as
 `temporal-crdb-deploy`. (chant Ops are for infra-deploy workflows over pre-built
 steps, not arbitrary app logic.)
 
-> **Status:** so far this ships the app's **Kubernetes manifests** and the
-> **triage activities** (the agent — stubbed by default, real Claude when
-> `ANTHROPIC_API_KEY` is set). The Temporal **workflow + worker** wiring, a
-> webhook source, and a `WatchOp` drift source land in follow-ups. See
+> **Status:** this ships the app's **Kubernetes manifests**, the **triage
+> activities** (the agent — stubbed by default, real Claude when
+> `ANTHROPIC_API_KEY` is set), and the Temporal **workflow + worker**. A webhook
+> source, a `WatchOp` drift source, and a local `npm run dev` + tutorial land in
+> follow-ups ([#232](https://github.com/INTENTIUS/chant/issues/232)). See
 > [#74](https://github.com/INTENTIUS/chant/issues/74).
 
 ## What's here now
@@ -26,6 +27,8 @@ steps, not arbitrary app logic.)
 | `src/config.ts` | pinned image refs (replace with your own builds) |
 | `src/workloads.ts` | chant manifests — the webhook (`WebApp` → Deployment + Service + Ingress + PDB) and the worker (`WorkerPool` → Deployment) |
 | `activities/triage.ts` | the triage activities (raw Temporal): `classifyAlert`, `gatherContext`, `proposeRemediation`, `notifyOutcome` |
+| `activities/workflow.ts` | the triage workflow: classify → context → propose → approval gate → notify |
+| `activities/worker.ts` | the Temporal worker — registers the activities + workflow, connects via the `local` profile |
 | `chant.config.ts` | k8s + temporal lexicons, and a local Temporal profile |
 
 ```bash
@@ -33,7 +36,7 @@ npm install
 npm run build      # → k8s.yaml (plain Kubernetes)
 npm run lint       # clean
 npm run list       # what you declared
-npm test           # unit-tests the triage activities
+npm test           # unit-tests the activities + a time-skipping workflow test
 ```
 
 ## The triage activities
@@ -50,10 +53,28 @@ offline with no key:
   an LLM. Override the model with `ANTHROPIC_MODEL` (default `claude-sonnet-4-6`).
 - `notifyOutcome` — logs the outcome; a real build would post to Slack.
 
+## The workflow and worker
+
+`activities/workflow.ts` is the triage workflow (raw Temporal): classify →
+gather context → propose → **approval gate** → notify. Safe remediations apply
+directly; risky ones wait on the `approve-remediation` signal (up to 12h, then
+held). `activities/worker.ts` registers the activities and workflow and connects
+using the `local` profile in `chant.config.ts`.
+
+Run it against a local Temporal:
+
+```bash
+temporal server start-dev        # separate terminal
+npm run worker                   # polls the task queue
+```
+
+A time-skipping test (`activities/workflow.test.ts`) covers the workflow in CI:
+phase order, the gate clearing on the signal, the safe path skipping the gate,
+and an unapproved risky remediation waiting out the 12h gate.
+
 ## Coming in follow-ups
 
-- The raw Temporal **workflow** (classify → context → propose → approval gate →
-  notify) and the **worker** that registers these activities.
 - A webhook source, and a `WatchOp` that turns drift on the deployed namespace
   into a second event source.
-- A local k3d + Temporal `npm run dev` and a tutorial.
+- A local k3d + Temporal `npm run dev` and a tutorial
+  ([#232](https://github.com/INTENTIUS/chant/issues/232)).

--- a/examples/alert-triage/activities/worker.ts
+++ b/examples/alert-triage/activities/worker.ts
@@ -1,0 +1,37 @@
+// The Temporal worker — registers the triage activities and workflow, and
+// connects using the `local` profile from chant.config.ts. Run it locally
+// against `temporal server start-dev`:
+//
+//   npx tsx activities/worker.ts
+import { Worker, NativeConnection } from "@temporalio/worker";
+import { fileURLToPath } from "node:url";
+import * as activities from "./triage";
+import chantConfig from "../chant.config.js";
+
+async function run(): Promise<void> {
+  const profileName = process.env.TEMPORAL_PROFILE ?? chantConfig.temporal.defaultProfile ?? "local";
+  const profile = chantConfig.temporal.profiles[profileName];
+  if (!profile) {
+    throw new Error(`Unknown Temporal profile "${profileName}"`);
+  }
+
+  const connection = await NativeConnection.connect({ address: profile.address });
+  try {
+    const worker = await Worker.create({
+      connection,
+      namespace: profile.namespace,
+      taskQueue: profile.taskQueue,
+      workflowsPath: fileURLToPath(new URL("./workflow.ts", import.meta.url)),
+      activities,
+    });
+    console.log(`alert-triage worker polling ${profile.taskQueue} on ${profile.address}`);
+    await worker.run();
+  } finally {
+    await connection.close();
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/alert-triage/activities/workflow.test.ts
+++ b/examples/alert-triage/activities/workflow.test.ts
@@ -1,0 +1,91 @@
+// Time-skipping test for the triage workflow (modeled on the temporal lexicon's
+// #161 runtime harness). Runs the real workflow on a Temporal test server with
+// mocked activities, and proves: safe remediations skip the gate, risky ones
+// wait for the approval signal (and proceed on it), and an unsignalled risky one
+// waits out the gate and is held (not approved).
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import { fileURLToPath } from "node:url";
+import type { Alert, Classification, TriageContext, Remediation } from "./triage";
+
+const WF_PATH = fileURLToPath(new URL("./workflow.ts", import.meta.url));
+
+let env: TestWorkflowEnvironment;
+let counter = 0;
+
+beforeAll(async () => {
+  env = await TestWorkflowEnvironment.createTimeSkipping();
+}, 120_000);
+
+afterAll(async () => {
+  await env?.teardown();
+});
+
+function mockActivities(risky: boolean, record: { approved?: boolean; calls: string[] }) {
+  return {
+    classifyAlert: async (): Promise<Classification> => {
+      record.calls.push("classify");
+      return { severity: risky ? "critical" : "low", rationale: "mock" };
+    },
+    gatherContext: async (): Promise<TriageContext> => {
+      record.calls.push("context");
+      return { signals: ["mock"] };
+    },
+    proposeRemediation: async (): Promise<Remediation> => {
+      record.calls.push("propose");
+      return { summary: "mock fix", risky };
+    },
+    notifyOutcome: async (input: { approved: boolean }): Promise<void> => {
+      record.calls.push("notify");
+      record.approved = input.approved;
+    },
+  };
+}
+
+async function runTriage(opts: { risky: boolean; signal?: boolean }) {
+  const record: { approved?: boolean; calls: string[] } = { calls: [] };
+  const taskQueue = `alert-triage-test-${counter++}`;
+  const worker = await Worker.create({
+    connection: env.nativeConnection,
+    namespace: env.namespace,
+    taskQueue,
+    workflowsPath: WF_PATH,
+    activities: mockActivities(opts.risky, record),
+  });
+  const alert: Alert = { id: "a1", title: "test alert" };
+  const handle = await env.client.workflow.start("alertTriage", {
+    taskQueue,
+    workflowId: `${taskQueue}-wf`,
+    args: [alert],
+  });
+  if (opts.signal) await handle.signal("approve-remediation");
+  await worker.runUntil(handle.result());
+
+  const desc = await handle.describe();
+  const durationMs =
+    desc.closeTime && desc.startTime ? desc.closeTime.getTime() - desc.startTime.getTime() : 0;
+  return { record, durationMs };
+}
+
+describe("alert-triage workflow", () => {
+  test("safe remediation auto-approves and skips the gate", async () => {
+    const { record, durationMs } = await runTriage({ risky: false });
+    expect(record.calls).toEqual(["classify", "context", "propose", "notify"]);
+    expect(record.approved).toBe(true);
+    expect(durationMs).toBeLessThan(60 * 60 * 1000); // no 12h wait
+  }, 120_000);
+
+  test("risky remediation proceeds once the approval signal arrives", async () => {
+    const { record, durationMs } = await runTriage({ risky: true, signal: true });
+    expect(record.approved).toBe(true);
+    expect(record.calls).toContain("notify");
+    expect(durationMs).toBeLessThan(60 * 60 * 1000); // signal short-circuits the gate
+  }, 120_000);
+
+  test("risky remediation without approval waits out the gate and is held", async () => {
+    const { record, durationMs } = await runTriage({ risky: true });
+    expect(record.approved).toBe(false);
+    expect(durationMs).toBeGreaterThan(11 * 60 * 60 * 1000); // ~12h gate timeout
+  }, 120_000);
+});

--- a/examples/alert-triage/activities/workflow.ts
+++ b/examples/alert-triage/activities/workflow.ts
@@ -1,0 +1,35 @@
+// The triage workflow — raw Temporal (workflow-sandbox-safe).
+//
+// One alert in, a phased triage out: classify, gather context, propose a
+// remediation, gate on human approval when it's risky, then notify. The
+// activities (./triage) run in the worker; here they're called through
+// `proxyActivities`. `import type` keeps the activity module out of the
+// deterministic workflow bundle.
+import { proxyActivities, defineSignal, setHandler, condition } from "@temporalio/workflow";
+import type * as activities from "./triage";
+import type { Alert } from "./triage";
+
+const { classifyAlert, gatherContext, proposeRemediation, notifyOutcome } =
+  proxyActivities<typeof activities>({ startToCloseTimeout: "1 minute" });
+
+/** Approve a risky remediation. */
+export const approveRemediation = defineSignal("approve-remediation");
+
+export async function alertTriage(alert: Alert): Promise<void> {
+  const classification = await classifyAlert(alert);
+  const context = await gatherContext(alert);
+  const remediation = await proposeRemediation({ alert, classification, context });
+
+  // Safe remediations apply directly; risky ones wait for a human signal.
+  let approved = !remediation.risky;
+  if (remediation.risky) {
+    setHandler(approveRemediation, () => {
+      approved = true;
+    });
+    // Resolves immediately on the signal; otherwise times out after 12h and
+    // `approved` stays false (the remediation is held, not applied).
+    await condition(() => approved, "12h");
+  }
+
+  await notifyOutcome({ alert, remediation, approved });
+}

--- a/examples/alert-triage/package.json
+++ b/examples/alert-triage/package.json
@@ -7,14 +7,18 @@
     "build": "chant build src --lexicon k8s -o k8s.yaml",
     "lint": "chant lint src",
     "list": "chant list src",
+    "worker": "tsx activities/worker.ts",
     "test": "npx vitest run"
   },
   "dependencies": {
     "@intentius/chant-lexicon-k8s": "*",
     "@intentius/chant-lexicon-temporal": "*",
-    "@intentius/chant": "*"
+    "@intentius/chant": "*",
+    "@temporalio/workflow": "^1.17.2",
+    "@temporalio/worker": "^1.17.2"
   },
   "devDependencies": {
+    "@temporalio/testing": "^1.17.2",
     "typescript": "*"
   }
 }


### PR DESCRIPTION
Closes #231. Wires the triage activities (#230) into a runnable **raw Temporal** workflow + worker, with a **time-skipping test** — the last L5 piece that carries a genuine CI check.

## Changes

- `activities/workflow.ts` — the triage workflow: **classify → gather context → propose → approval gate → notify**. Safe remediations apply directly; risky ones wait on the `approve-remediation` signal (`condition`, 12h) then are held. `import type` keeps the activity module out of the deterministic workflow bundle.
- `activities/worker.ts` — registers the activities + workflow; connects via the `local` profile in `chant.config.ts` (`npm run worker`).
- `activities/workflow.test.ts` — `TestWorkflowEnvironment` (time-skipping), modeled on the temporal lexicon's #161 harness.
- `package.json` — `@temporalio/{workflow,worker,testing}` + a `worker` script.
- README — workflow/worker section + local run.

## Validation (a real CI check)

The workflow test runs in CI (the temporal lexicon already runs `TestWorkflowEnvironment` in CI, so the test server is available):

```
examples/alert-triage/activities/workflow.test.ts → 3 passed
  ✓ safe remediation auto-approves and skips the gate
  ✓ risky remediation proceeds once the approval signal arrives
  ✓ risky remediation without approval waits out the gate and is held (~12h, time-skipped)
```

Full examples suite **200 passed**; `chant lint` + `eslint packages/` clean.

## Follow-up

Webhook source, `WatchOp` second source, local `npm run dev` + tutorial — **#232**.

Part of #74 / #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)