### PR TITLE
feat(examples): alert-triage L5 — event sources, local dev, tutorial (#232)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -66,6 +66,7 @@ export default defineConfig({
 				{
 					label: 'Tutorials',
 					items: [
+						{ label: 'Alert Triage (local)', slug: 'tutorials/alert-triage-local' },
 						{ label: 'GCP GKE + Kubernetes', slug: 'tutorials/gke-kubernetes' },
 						{ label: 'GKE Composites', link: '/lexicons/k8s/gke-composites/' },
 						{ label: 'AWS EKS + Kubernetes', slug: 'tutorials/eks-kubernetes' },

--- a/docs/src/content/docs/tutorials/alert-triage-local.mdx
+++ b/docs/src/content/docs/tutorials/alert-triage-local.mdx
@@ -1,0 +1,96 @@
+---
+title: Alert Triage (local)
+description: Run the alert-triage capstone locally — a Temporal-driven incident-triage app with a human-approval gate and an optional agent, on nothing but a Temporal dev server.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The [`alert-triage`](https://github.com/INTENTIUS/chant/tree/main/examples/alert-triage)
+example is the capstone (L5) of the [getting-started](https://github.com/INTENTIUS/chant/tree/main/examples/getting-started)
+golden example. It is a Temporal-driven incident-triage app: an alert comes in,
+a phased workflow classifies it, gathers context, proposes a remediation, pauses
+for human approval when the change is risky, then notifies. chant synthesizes the
+Kubernetes manifests; the triage workflow itself is hand-written Temporal — the
+["Raw Temporal + chant"](/chant/concepts/deployment-paths/) split.
+
+This tutorial runs the whole thing locally with no cloud and no cluster — just a
+Temporal dev server.
+
+## Prerequisites
+
+- Node.js and `npm`.
+- The [Temporal CLI](https://docs.temporal.io/cli) (`temporal`) for the dev server.
+
+## Run it
+
+```bash
+cd examples/alert-triage
+npm install
+npm run dev
+```
+
+`npm run dev` starts a Temporal dev server, the triage worker, and the webhook
+receiver, then sends one demo alert. Open the Temporal UI at
+**http://localhost:8233** — you'll see an `alertTriage` workflow. The demo alert
+is high-severity, so it's **risky** and pauses at the approval gate.
+
+Approve it:
+
+```bash
+temporal workflow signal -n default \
+  --query "WorkflowType='alertTriage'" --name approve-remediation
+```
+
+The workflow completes, and the worker logs the outcome (`… — applied after
+approval`). A low-severity alert skips the gate and applies directly.
+
+## Two event sources
+
+Both feed the same triage workflow:
+
+```bash
+npm run alert            # external alert via the webhook (POST /alert)
+npm run drift -- --demo  # a drift event (the WatchOp/lifecycle counterpart)
+```
+
+The webhook is the receiver the `WebApp` manifest deploys. The drift source runs
+`chant lifecycle diff --live` and triages each drifted resource — out-of-band
+cluster changes go through the same triage as external alerts. `--demo` injects a
+sample drift so you can see the pipeline without making a real change.
+
+## The agent (optional)
+
+`proposeRemediation` is a deterministic stub by default — no key, runs offline.
+Set `ANTHROPIC_API_KEY` (and `npm i @anthropic-ai/sdk`) to have it call Claude;
+override the model with `ANTHROPIC_MODEL` (default `claude-sonnet-4-6`). The first
+run shows chant, not an LLM.
+
+## Deploy the manifests
+
+The app's Kubernetes surface is typed chant in `src/`:
+
+```bash
+npm run build      # → k8s.yaml (plain Kubernetes)
+npm run lint
+kubectl apply -f k8s.yaml   # e.g. to a local k3d cluster
+```
+
+<Aside type="note">
+The manifests reference placeholder images (`ghcr.io/intentius/alert-*`). Swap in
+your own builds of the worker and webhook to run the app in-cluster; the local
+`npm run dev` above runs them from source without images.
+</Aside>
+
+## How it fits together
+
+| Piece | What it is |
+|---|---|
+| `src/` | chant manifests — webhook (`WebApp`) and worker (`WorkerPool`) |
+| `activities/triage.ts` | the triage activities (the agent — stub + Claude opt-in) |
+| `activities/workflow.ts` | the Temporal workflow (classify → context → propose → gate → notify) |
+| `activities/worker.ts` | the worker that registers them |
+| `app/` | the event sources (webhook, drift) and the demo alert |
+
+A time-skipping test (`activities/workflow.test.ts`) covers the gate behaviour in
+CI. See the [example README](https://github.com/INTENTIUS/chant/tree/main/examples/alert-triage)
+for the full layout.

--- a/examples/alert-triage/README.md
+++ b/examples/alert-triage/README.md
@@ -13,11 +13,11 @@ This is chant's documented "Raw Temporal + chant" path, the same split as
 `temporal-crdb-deploy`. (chant Ops are for infra-deploy workflows over pre-built
 steps, not arbitrary app logic.)
 
-> **Status:** this ships the app's **Kubernetes manifests**, the **triage
-> activities** (the agent — stubbed by default, real Claude when
-> `ANTHROPIC_API_KEY` is set), and the Temporal **workflow + worker**. A webhook
-> source, a `WatchOp` drift source, and a local `npm run dev` + tutorial land in
-> follow-ups ([#232](https://github.com/INTENTIUS/chant/issues/232)). See
+> **Status:** complete and runnable locally — chant manifests, triage activities
+> (the agent — stubbed by default, real Claude when `ANTHROPIC_API_KEY` is set),
+> the Temporal workflow + worker, two event sources (webhook + drift), and an
+> `npm run dev` local stack. See the
+> [tutorial](/chant/tutorials/alert-triage-local/) and
 > [#74](https://github.com/INTENTIUS/chant/issues/74).
 
 ## What's here now
@@ -29,14 +29,34 @@ steps, not arbitrary app logic.)
 | `activities/triage.ts` | the triage activities (raw Temporal): `classifyAlert`, `gatherContext`, `proposeRemediation`, `notifyOutcome` |
 | `activities/workflow.ts` | the triage workflow: classify → context → propose → approval gate → notify |
 | `activities/worker.ts` | the Temporal worker — registers the activities + workflow, connects via the `local` profile |
+| `app/webhook.ts` | event source #1 — HTTP receiver, `POST /alert` starts a triage workflow |
+| `app/drift-source.ts` | event source #2 — `chant lifecycle diff --live` → triage each drifted resource |
+| `app/demo.ts` | a synthetic alert (`npm run alert`) |
 | `chant.config.ts` | k8s + temporal lexicons, and a local Temporal profile |
+
+## Run it locally
 
 ```bash
 npm install
+npm run dev        # Temporal dev server + worker + webhook + a demo alert
+```
+
+Open the Temporal UI at **http://localhost:8233**. The demo alert is risky, so it
+pauses at the approval gate; release it with:
+
+```bash
+temporal workflow signal -n default --query "WorkflowType='alertTriage'" --name approve-remediation
+```
+
+See the [Alert Triage (local) tutorial](/chant/tutorials/alert-triage-local/) for
+the full walk-through. Other scripts:
+
+```bash
 npm run build      # → k8s.yaml (plain Kubernetes)
 npm run lint       # clean
-npm run list       # what you declared
-npm test           # unit-tests the activities + a time-skipping workflow test
+npm run alert      # send another alert via the webhook
+npm run drift -- --demo   # the drift event source
+npm test           # unit tests + a time-skipping workflow test
 ```
 
 ## The triage activities
@@ -72,9 +92,20 @@ A time-skipping test (`activities/workflow.test.ts`) covers the workflow in CI:
 phase order, the gate clearing on the signal, the safe path skipping the gate,
 and an unapproved risky remediation waiting out the 12h gate.
 
-## Coming in follow-ups
+## Two event sources
 
-- A webhook source, and a `WatchOp` that turns drift on the deployed namespace
-  into a second event source.
-- A local k3d + Temporal `npm run dev` and a tutorial
-  ([#232](https://github.com/INTENTIUS/chant/issues/232)).
+Both start the same triage workflow:
+
+- **Webhook** (`app/webhook.ts`, `npm run webhook`) — `POST /alert` with a
+  Datadog/PagerDuty-shaped body. This is what the `WebApp` manifest deploys.
+- **Drift** (`app/drift-source.ts`, `npm run drift`) — runs
+  `chant lifecycle diff --live` and triages each drifted resource, so out-of-band
+  cluster changes get the same triage as external alerts (the runtime counterpart
+  of a scheduled `WatchOp`). `npm run drift -- --demo` injects a sample drift.
+
+## Deploying the manifests
+
+`src/` is typed chant — `npm run build` emits plain `k8s.yaml` you can
+`kubectl apply` to any cluster (e.g. local k3d). The manifests reference
+placeholder images; swap in your own worker/webhook builds to run in-cluster. The
+`npm run dev` flow above runs them from source without images.

--- a/examples/alert-triage/app/demo.ts
+++ b/examples/alert-triage/app/demo.ts
@@ -1,0 +1,34 @@
+// Synthetic alert source — POSTs a demo alert to the webhook if it's reachable,
+// otherwise starts the triage workflow directly. `npm run alert`.
+import { startTriage } from "./triage-client.js";
+import { alertFromWebhook } from "./parse.js";
+
+const demoBody = {
+  id: `demo-${Date.now()}`,
+  title: "API 5xx rate elevated in prod",
+  source: "datadog",
+  body: "Error rate above 5% for 5m on service api.",
+};
+
+const webhookUrl = process.env.WEBHOOK_URL ?? "http://localhost:8080/alert";
+
+async function main(): Promise<void> {
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(demoBody),
+    });
+    if (!res.ok) throw new Error(`webhook returned ${res.status}`);
+    console.log(`sent demo alert to webhook ${webhookUrl}: ${await res.text()}`);
+  } catch {
+    // No webhook running — start the workflow directly so the demo still works.
+    const id = await startTriage(alertFromWebhook(demoBody));
+    console.log(`webhook unavailable; started triage workflow directly: ${id}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/alert-triage/app/drift-source.ts
+++ b/examples/alert-triage/app/drift-source.ts
@@ -1,0 +1,49 @@
+// Drift source — event source #2. Runs `chant lifecycle diff --live` and starts
+// a triage workflow for each drifted resource, so out-of-band cluster changes go
+// through the same triage as external alerts. This is the runtime counterpart of
+// a WatchOp (which schedules the same diff on a cron).
+//
+//   npm run drift            # real: diff the env, triage any drift
+//   npm run drift -- --demo  # inject a sample drift to exercise the pipeline
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { startTriage } from "./triage-client.js";
+import { alertFromDrift, type DriftEntry } from "./parse.js";
+
+const execFileAsync = promisify(execFile);
+const env = process.env.ALERT_TRIAGE_ENV ?? "local";
+
+async function detectDrift(): Promise<DriftEntry[]> {
+  if (process.argv.includes("--demo")) {
+    // Labeled demo input — a sample drift to show the pipeline without needing a
+    // real out-of-band change. The real path below runs an actual live diff.
+    return [{ name: "alert-webhook", type: "Deployment", category: "drifted" }];
+  }
+  const { stdout } = await execFileAsync(
+    "chant",
+    ["lifecycle", "diff", env, "--live", "--json"],
+    { cwd: new URL("..", import.meta.url).pathname },
+  );
+  const report = JSON.parse(stdout) as { drifted?: DriftEntry[] };
+  return report.drifted ?? [];
+}
+
+async function main(): Promise<void> {
+  const drifted = await detectDrift().catch((err) => {
+    console.error(`drift check failed (no snapshot/baseline yet?): ${err}`);
+    return [] as DriftEntry[];
+  });
+  if (drifted.length === 0) {
+    console.log("no drift — nothing to triage");
+    return;
+  }
+  for (const entry of drifted) {
+    const id = await startTriage(alertFromDrift(entry));
+    console.log(`drift on ${entry.name} → started triage ${id}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/alert-triage/app/parse.test.ts
+++ b/examples/alert-triage/app/parse.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "vitest";
+import { alertFromWebhook, alertFromDrift } from "./parse";
+
+describe("alertFromWebhook", () => {
+  test("maps a Datadog-ish body", () => {
+    const a = alertFromWebhook({ id: "dd-1", title: "API outage", source: "datadog", body: "5xx" });
+    expect(a).toEqual({ id: "dd-1", title: "API outage", body: "5xx", source: "datadog" });
+  });
+
+  test("falls back to summary/message and a derived id", () => {
+    const a = alertFromWebhook({ summary: "Disk almost full", message: "92% used" });
+    expect(a.title).toBe("Disk almost full");
+    expect(a.body).toBe("92% used");
+    expect(a.id).toMatch(/^webhook-disk-almost-full/);
+    expect(a.source).toBe("webhook");
+  });
+
+  test("handles an empty body", () => {
+    const a = alertFromWebhook({});
+    expect(a.title).toBe("untitled alert");
+    expect(a.source).toBe("webhook");
+  });
+});
+
+describe("alertFromDrift", () => {
+  test("turns a drift entry into a triage alert", () => {
+    const a = alertFromDrift({ name: "alert-webhook", type: "Deployment", category: "drifted" });
+    expect(a.id).toBe("drift-alert-webhook");
+    expect(a.title).toContain("Deployment alert-webhook");
+    expect(a.title).toContain("drifted");
+    expect(a.source).toBe("watchop");
+  });
+});

--- a/examples/alert-triage/app/parse.ts
+++ b/examples/alert-triage/app/parse.ts
@@ -1,0 +1,42 @@
+// Pure mappers from each event source into the triage `Alert` shape.
+// Kept separate (and free of Temporal/IO) so they're unit-tested in CI.
+import type { Alert } from "../activities/triage";
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/** Normalize an incoming webhook body (Datadog/PagerDuty-ish) into an Alert. */
+export function alertFromWebhook(body: unknown): Alert {
+  const b = (body ?? {}) as Record<string, unknown>;
+  const title =
+    str(b.title) ?? str(b.summary) ?? str((b.alert as Record<string, unknown>)?.title) ?? "untitled alert";
+  return {
+    id: str(b.id) ?? str(b.alert_id) ?? `webhook-${slug(title)}`,
+    title,
+    body: str(b.body) ?? str(b.message) ?? str(b.description),
+    source: str(b.source) ?? "webhook",
+  };
+}
+
+/** A drifted resource from `chant lifecycle diff --json`. */
+export interface DriftEntry {
+  name: string;
+  category?: string;
+  type?: string;
+}
+
+/** Turn a drift entry into an Alert the same triage workflow handles. */
+export function alertFromDrift(entry: DriftEntry): Alert {
+  const what = entry.type ? `${entry.type} ${entry.name}` : entry.name;
+  return {
+    id: `drift-${slug(entry.name)}`,
+    title: `Drift detected: ${what}${entry.category ? ` (${entry.category})` : ""}`,
+    body: `Live state diverged from declared source for ${what}.`,
+    source: "watchop",
+  };
+}
+
+function slug(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "").slice(0, 40) || "alert";
+}

--- a/examples/alert-triage/app/triage-client.ts
+++ b/examples/alert-triage/app/triage-client.ts
@@ -1,0 +1,25 @@
+// Temporal client helper — start a triage workflow for an alert. Shared by both
+// event sources (the webhook and the drift source).
+import { Connection, Client } from "@temporalio/client";
+import chantConfig from "../chant.config.js";
+import type { Alert } from "../activities/triage";
+
+export async function startTriage(alert: Alert): Promise<string> {
+  const profileName = process.env.TEMPORAL_PROFILE ?? chantConfig.temporal.defaultProfile ?? "local";
+  const profile = chantConfig.temporal.profiles[profileName];
+  if (!profile) throw new Error(`Unknown Temporal profile "${profileName}"`);
+
+  const connection = await Connection.connect({ address: profile.address });
+  try {
+    const client = new Client({ connection, namespace: profile.namespace });
+    const workflowId = `alert-triage-${alert.id}-${Date.now()}`;
+    await client.workflow.start("alertTriage", {
+      taskQueue: profile.taskQueue,
+      workflowId,
+      args: [alert],
+    });
+    return workflowId;
+  } finally {
+    await connection.close();
+  }
+}

--- a/examples/alert-triage/app/webhook.ts
+++ b/examples/alert-triage/app/webhook.ts
@@ -1,0 +1,39 @@
+// Webhook receiver — event source #1. POST /alert starts a triage workflow.
+// This is what the WebApp manifest deploys; run it locally with `npm run webhook`.
+import { createServer } from "node:http";
+import { startTriage } from "./triage-client.js";
+import { alertFromWebhook } from "./parse.js";
+
+const port = Number(process.env.PORT ?? 8080);
+
+const server = createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/healthz") {
+    res.writeHead(200);
+    res.end("ok");
+    return;
+  }
+  if (req.method === "POST" && req.url === "/alert") {
+    let data = "";
+    req.on("data", (c) => (data += c));
+    req.on("end", () => {
+      void (async () => {
+        try {
+          const alert = alertFromWebhook(data ? JSON.parse(data) : {});
+          const id = await startTriage(alert);
+          res.writeHead(202, { "content-type": "application/json" });
+          res.end(JSON.stringify({ started: id }));
+        } catch (err) {
+          res.writeHead(500, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: String(err) }));
+        }
+      })();
+    });
+    return;
+  }
+  res.writeHead(404);
+  res.end("not found");
+});
+
+server.listen(port, () => {
+  console.log(`alert-triage webhook listening on :${port} (POST /alert)`);
+});

--- a/examples/alert-triage/package.json
+++ b/examples/alert-triage/package.json
@@ -8,6 +8,10 @@
     "lint": "chant lint src",
     "list": "chant list src",
     "worker": "tsx activities/worker.ts",
+    "webhook": "tsx app/webhook.ts",
+    "alert": "tsx app/demo.ts",
+    "drift": "tsx app/drift-source.ts",
+    "dev": "bash scripts/dev.sh",
     "test": "npx vitest run"
   },
   "dependencies": {
@@ -15,7 +19,8 @@
     "@intentius/chant-lexicon-temporal": "*",
     "@intentius/chant": "*",
     "@temporalio/workflow": "^1.17.2",
-    "@temporalio/worker": "^1.17.2"
+    "@temporalio/worker": "^1.17.2",
+    "@temporalio/client": "^1.17.2"
   },
   "devDependencies": {
     "@temporalio/testing": "^1.17.2",

--- a/examples/alert-triage/scripts/dev.sh
+++ b/examples/alert-triage/scripts/dev.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Bring up the alert-triage stack locally: a Temporal dev server, the triage
+# worker, the webhook receiver, and one demo alert. No cloud, no cluster — just
+# Temporal in-process. Ctrl-C tears it all down.
+set -euo pipefail
+cd "$(cd "$(dirname "$0")/.." && pwd)"
+
+PORT="${PORT:-8080}"
+pids=()
+cleanup() {
+  echo
+  echo "stopping..."
+  for p in "${pids[@]:-}"; do kill "$p" 2>/dev/null || true; done
+}
+trap cleanup EXIT INT TERM
+
+echo "▸ Temporal dev server (UI http://localhost:8233)"
+temporal server start-dev --ip 127.0.0.1 --port 7233 --ui-port 8233 \
+  --namespace default --log-level error &
+pids+=($!)
+for _ in $(seq 1 30); do
+  temporal operator namespace describe -n default >/dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "▸ triage worker"
+npx tsx activities/worker.ts &
+pids+=($!)
+sleep 6
+
+echo "▸ webhook receiver (POST http://localhost:${PORT}/alert)"
+PORT="$PORT" npx tsx app/webhook.ts &
+pids+=($!)
+sleep 3
+
+echo "▸ sending a demo alert"
+WEBHOOK_URL="http://localhost:${PORT}/alert" npx tsx app/demo.ts || true
+
+cat <<EOF
+
+✓ stack up — open the Temporal UI: http://localhost:8233
+
+  send another alert:  npm run alert
+  drift (2nd source):  npm run drift -- --demo
+  approve a held one:  temporal workflow signal -n default \\
+                         --query "WorkflowType='alertTriage'" --name approve-remediation
+
+Ctrl-C to stop.
+EOF
+wait


### PR DESCRIPTION
Closes #232. Completes the L5 capstone (#74 / #216): two event sources, a one-command local stack, and a tutorial. Both sources start the same triage workflow (#231).

## Changes

- `app/webhook.ts` — **event source #1**: HTTP receiver, `POST /alert` → `startTriage`. What the `WebApp` manifest deploys.
- `app/drift-source.ts` — **event source #2**: runs `chant lifecycle diff --live` and triages each drifted resource (runtime counterpart of a scheduled `WatchOp`); `--demo` injects a sample drift.
- `app/triage-client.ts` — shared Temporal client helper.
- `app/parse.ts` (+ `parse.test.ts`) — pure source→`Alert` mappers, **unit-tested in CI**.
- `app/demo.ts` — synthetic alert (`npm run alert`).
- `scripts/dev.sh` (`npm run dev`) — Temporal dev server + worker + webhook + a demo alert in one command (UI at :8233).
- Tutorial `tutorials/alert-triage-local.mdx` (+ sidebar); README/package scripts updated.

App code stays outside `src/` so `chant lint src` is clean.

## Validated live (k3d + Temporal dev server)

- `npm run dev` brings the stack up; demo alert → workflow runs → approval gate → signal → **COMPLETED** (worker logged `… applied after approval`).
- webhook `POST /alert` → workflow started; `drift -- --demo` → workflow started (the second source).
- `chant build` → `kubectl apply` to a k3d cluster: all manifests create cleanly (pods `ImagePullBackOff` only because the images are placeholders).

## CI

```
examples suite → 204 passed (incl. the time-skipping workflow test + parse unit tests)
docs build → 111 pages (tutorial added)
chant lint + eslint → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)