### PR TITLE
fix(docker): depends_on supports the long-form condition map (#246)

### DIFF
--- a/lexicons/docker/package.json
+++ b/lexicons/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-docker",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Docker lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/docker/src/serializer.test.ts
+++ b/lexicons/docker/src/serializer.test.ts
@@ -119,6 +119,31 @@ describe("dockerSerializer.serialize — single service", () => {
     const output = dockerSerializer.serialize(entities) as string;
     expect(output).not.toContain("restart:");
   });
+
+  test("emits short-form depends_on (list)", () => {
+    const entities = new Map<string, Declarable>();
+    entities.set("api", new MockService({ image: "nginx", depends_on: ["db"] }));
+
+    const output = dockerSerializer.serialize(entities) as string;
+    expect(output).toContain("depends_on:");
+    expect(output).toContain("- db");
+  });
+
+  test("emits long-form depends_on with a wait condition", () => {
+    const entities = new Map<string, Declarable>();
+    entities.set(
+      "api",
+      new MockService({
+        image: "nginx",
+        depends_on: { db: { condition: "service_healthy" } },
+      }),
+    );
+
+    const output = dockerSerializer.serialize(entities) as string;
+    expect(output).toContain("depends_on:");
+    expect(output).toContain("db:");
+    expect(output).toContain("condition: service_healthy");
+  });
 });
 
 // ── Multi-resource ────────────────────────────────────────────────

--- a/lexicons/docker/src/spec/parse-compose.ts
+++ b/lexicons/docker/src/spec/parse-compose.ts
@@ -46,7 +46,13 @@ export function parseComposeSpec(_data: Buffer): ComposeParseResult[] {
         { name: "ports", type: "string[]", description: "Published ports" },
         { name: "volumes", type: "string[]", description: "Volume mounts" },
         { name: "networks", type: "string[]", description: "Networks to attach" },
-        { name: "depends_on", type: "string[]", description: "Service dependencies" },
+        {
+          name: "depends_on",
+          // Compose `depends_on` is a oneOf: short list-form, or long form with a
+          // wait condition (service_started/healthy/completed_successfully).
+          type: 'string[] | Record<string, { condition: "service_started" | "service_healthy" | "service_completed_successfully"; restart?: boolean; required?: boolean }>',
+          description: "Service dependencies (short list-form, or long form with a wait condition)",
+        },
         { name: "restart", type: "string", description: "Restart policy" },
         { name: "labels", type: "Record<string, string>", description: "Container labels" },
         { name: "healthcheck", type: "object", description: "Health check configuration" },


### PR DESCRIPTION
Closes #246.

Compose `depends_on` is a `oneOf` — short list-form (`string[]`) and long form with a wait condition. The generator flattened it to `string[]`, so the typed API couldn't express a healthy/completed-gated chain (short-form only waits for *started*).

## Fix

- `parse-compose.ts`: widen the `depends_on` type to `string[] | Record<string, { condition: "service_started" | "service_healthy" | "service_completed_successfully"; restart?: boolean; required?: boolean }>`. Regenerated `generated/index.d.ts` carries the union.
- **No serializer change** — it's a generic prop pass-through, so a long-form map already serialized correctly; the gap was purely the narrow type (corrected from the original report, which suspected serializer normalization).
- `serializer.test.ts`: assert both short-form and long-form (`condition: service_healthy`) emit.
- Bump `@intentius/chant-lexicon-docker` **0.1.14 → 0.1.15** (will publish via the `lexicon-docker-v0.1.15` tag after merge).

## Validation

```
npm run --prefix lexicons/docker prepack   # generate + bundle + validate (types-compile) ✓
npx vitest run lexicons/docker             # 159 passed (incl. new depends_on tests)
generated/index.d.ts:13                     # depends_on?: string[] | Record<…condition…>
```