### PR TITLE
chore(release): bump core + lexicons to 0.1.15

### DIFF
--- a/lexicons/aws/package.json
+++ b/lexicons/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-aws",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "AWS CloudFormation lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/azure/package.json
+++ b/lexicons/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-azure",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Azure lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/gcp/package.json
+++ b/lexicons/gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-gcp",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Google Cloud lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/github/package.json
+++ b/lexicons/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-github",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "GitHub Actions lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/gitlab/package.json
+++ b/lexicons/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-gitlab",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "GitLab CI lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/helm/package.json
+++ b/lexicons/helm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-helm",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Helm chart lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/k8s/package.json
+++ b/lexicons/k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-k8s",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Kubernetes lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/temporal/package.json
+++ b/lexicons/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-temporal",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Temporal lexicon for chant — server deployment, namespaces, search attributes, and schedules",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Declarative infrastructure-as-code toolkit — TypeScript on Node.js",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",


### PR DESCRIPTION
npm has been stuck at **0.1.14** (published 2026-05-23) while `main` accumulated ~2 weeks of work that never shipped — the versions were never bumped, so `publish.yml`'s version guards kept skipping every package. Most consequentially, the **no-server local Op executor** isn't published:
- `@intentius/chant`: `packages/core/src/op/local-executor.ts` + `cli/handlers/run.ts`
- `@intentius/chant-lexicon-temporal`: `op/activities/heartbeat.ts` (run activities with no `@temporalio/activity`)

So published `chant run` is Temporal-backed only — an Op like `ops/up.op.ts` (synthesize → up → smoke, `onFailure → down -v`) can't run in-process against 0.1.14.

## Change
Bump `@intentius/chant` + all 9 lexicons `0.1.14 → 0.1.15` (docker was already 0.1.15). After merge, dispatching `publish.yml` ships them all via OIDC (proven working — docker 0.1.15 just published that way).

## Result
- `chant run ops/up.op.ts` runs no-server (local executor shipped).
- npm matches main across core + all lexicons.

Validation: version-only diffs (9 × one line); CI runs every lexicon prepack + the full test suite.