### PR TITLE
fix(examples): golden-example runtime breaks — deploy paths, worker SA, drift command (#235 #236 #237)

### DIFF
--- a/docs/src/content/docs/tutorials/alert-triage-local.mdx
+++ b/docs/src/content/docs/tutorials/alert-triage-local.mdx
@@ -54,7 +54,7 @@ npm run drift -- --demo  # a drift event (the WatchOp/lifecycle counterpart)
 ```
 
 The webhook is the receiver the `WebApp` manifest deploys. The drift source runs
-`chant lifecycle diff --live` and triages each drifted resource — out-of-band
+`chant lifecycle plan --json` and triages each drifted resource — out-of-band
 cluster changes go through the same triage as external alerts. `--demo` injects a
 sample drift so you can see the pipeline without making a real change.
 

--- a/examples/alert-triage/README.md
+++ b/examples/alert-triage/README.md
@@ -25,12 +25,12 @@ steps, not arbitrary app logic.)
 | File | What it is |
 |---|---|
 | `src/config.ts` | pinned image refs (replace with your own builds) |
-| `src/workloads.ts` | chant manifests — the webhook (`WebApp` → Deployment + Service + Ingress + PDB) and the worker (`WorkerPool` → Deployment) |
+| `src/workloads.ts` | chant manifests — the webhook (`WebApp` → Deployment + Service + Ingress + PDB) and the worker (`WorkerPool` → Deployment + PDB, no RBAC) |
 | `activities/triage.ts` | the triage activities (raw Temporal): `classifyAlert`, `gatherContext`, `proposeRemediation`, `notifyOutcome` |
 | `activities/workflow.ts` | the triage workflow: classify → context → propose → approval gate → notify |
 | `activities/worker.ts` | the Temporal worker — registers the activities + workflow, connects via the `local` profile |
 | `app/webhook.ts` | event source #1 — HTTP receiver, `POST /alert` starts a triage workflow |
-| `app/drift-source.ts` | event source #2 — `chant lifecycle diff --live` → triage each drifted resource |
+| `app/drift-source.ts` | event source #2 — `chant lifecycle plan --json` → triage each drifted resource |
 | `app/demo.ts` | a synthetic alert (`npm run alert`) |
 | `chant.config.ts` | k8s + temporal lexicons, and a local Temporal profile |
 
@@ -99,7 +99,7 @@ Both start the same triage workflow:
 - **Webhook** (`app/webhook.ts`, `npm run webhook`) — `POST /alert` with a
   Datadog/PagerDuty-shaped body. This is what the `WebApp` manifest deploys.
 - **Drift** (`app/drift-source.ts`, `npm run drift`) — runs
-  `chant lifecycle diff --live` and triages each drifted resource, so out-of-band
+  `chant lifecycle plan --json` and triages each drifted resource, so out-of-band
   cluster changes get the same triage as external alerts (the runtime counterpart
   of a scheduled `WatchOp`). `npm run drift -- --demo` injects a sample drift.
 

--- a/examples/alert-triage/app/drift-source.ts
+++ b/examples/alert-triage/app/drift-source.ts
@@ -1,10 +1,16 @@
-// Drift source — event source #2. Runs `chant lifecycle diff --live` and starts
-// a triage workflow for each drifted resource, so out-of-band cluster changes go
-// through the same triage as external alerts. This is the runtime counterpart of
-// a WatchOp (which schedules the same diff on a cron).
+// Drift source — event source #2. Runs `chant lifecycle plan --json` and starts
+// a triage workflow for each non-noop change-set entry, so out-of-band cluster
+// changes go through the same triage as external alerts. The runtime counterpart
+// of a WatchOp (which schedules the same check on a cron).
 //
-//   npm run drift            # real: diff the env, triage any drift
+//   npm run drift            # real: plan the env, triage any drift
 //   npm run drift -- --demo  # inject a sample drift to exercise the pipeline
+//
+// NOTE: the real path needs the env deployed + a snapshot, and `chant lifecycle
+// plan` currently builds the project dir with lexicon auto-detection, which does
+// not yet handle this example's mixed layout (chant src/ alongside app/ +
+// activities/). Until that lands (#252), `--demo` is the reliable demonstration;
+// the real path degrades to "no drift" rather than failing.
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { startTriage } from "./triage-client.js";
@@ -19,13 +25,20 @@ async function detectDrift(): Promise<DriftEntry[]> {
     // real out-of-band change. The real path below runs an actual live diff.
     return [{ name: "alert-webhook", type: "Deployment", category: "drifted" }];
   }
+  // `lifecycle plan --json` emits a typed ChangeSet ({ env, entries: [...] }).
+  // (`lifecycle diff` has no --json.) Every non-noop entry is something the live
+  // system and the declared source disagree on — triage each.
   const { stdout } = await execFileAsync(
     "chant",
-    ["lifecycle", "diff", env, "--live", "--json"],
+    ["lifecycle", "plan", env, "k8s", "--json"],
     { cwd: new URL("..", import.meta.url).pathname },
   );
-  const report = JSON.parse(stdout) as { drifted?: DriftEntry[] };
-  return report.drifted ?? [];
+  const plan = JSON.parse(stdout) as {
+    entries?: Array<{ name: string; type?: string; action: string }>;
+  };
+  return (plan.entries ?? [])
+    .filter((e) => e.action !== "noop")
+    .map((e) => ({ name: e.name, type: e.type, category: e.action }));
 }
 
 async function main(): Promise<void> {

--- a/examples/alert-triage/src/workloads.ts
+++ b/examples/alert-triage/src/workloads.ts
@@ -33,10 +33,14 @@ export const webhookService = webhook.service;
 export const webhookIngress = webhook.ingress!;
 export const webhookPdb = webhook.pdb!;
 
-// Temporal worker — Deployment only (no Service); runs the triage activities.
+// Temporal worker — Deployment + PDB (no Service). A Temporal worker talks to
+// Temporal, not the K8s API, so `rbacRules: []` suppresses the ServiceAccount /
+// Role / RoleBinding (and the pod's serviceAccountName) WorkerPool would
+// otherwise create — those weren't exported, leaving a dangling SA reference.
 const worker = WorkerPool({
   name: "alert-worker",
   image: workerImage,
+  rbacRules: [],
   replicas: 2,
   minAvailable: 1,
   cpuRequest: "100m",

--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -146,11 +146,20 @@ describeExample(
   },
   {
     checks: (output) => {
-      const kinds = parseK8sDocs(output).map((d) => d.kind);
+      const docs = parseK8sDocs(output);
+      const kinds = docs.map((d) => d.kind);
       // webhook (WebApp) + worker (WorkerPool)
       expect(kinds.filter((k) => k === "Deployment")).toHaveLength(2);
       expect(kinds).toContain("Service");
       expect(kinds).toContain("Ingress");
+      // No dangling ServiceAccount reference: every serviceAccountName a pod
+      // sets must have a matching ServiceAccount doc (regression guard, #236).
+      const saNames = new Set(
+        docs.filter((d) => d.kind === "ServiceAccount").map((d) => d.name),
+      );
+      for (const m of output.matchAll(/serviceAccountName:\s*(\S+)/g)) {
+        expect(saNames.has(m[1])).toBe(true);
+      }
     },
   },
 );

--- a/examples/getting-started/deploy-gated.op.ts
+++ b/examples/getting-started/deploy-gated.op.ts
@@ -17,18 +17,19 @@ export default Op({
   overview: "Build, pause for human approval, then apply — durable on Temporal",
   taskQueue: "getting-started-deploy",
   phases: [
-    phase("Build", [build("examples/getting-started")]),
+    // Paths are relative to the example dir (where `chant run` is invoked).
+    phase("Build", [build(".")]),
     phase("Approve", [
       gate("approve-deploy", {
         timeout: "24h",
         description: "Approve applying the getting-started manifests to the cluster",
       }),
     ]),
-    phase("Apply", [kubectlApply("examples/getting-started/k8s.yaml")]),
+    phase("Apply", [kubectlApply("k8s.yaml")]),
   ],
   onFailure: [
     phase("Rollback", [
-      shell("kubectl delete -f examples/getting-started/k8s.yaml --ignore-not-found"),
+      shell("kubectl delete -f k8s.yaml --ignore-not-found"),
     ]),
   ],
 });

--- a/examples/getting-started/deploy.op.ts
+++ b/examples/getting-started/deploy.op.ts
@@ -13,9 +13,10 @@ export default Op({
   overview: "Build the getting-started manifests and apply them to the current kube context",
   taskQueue: "getting-started-deploy",
   phases: [
-    // Runs `npm run build` in the example → writes k8s.yaml.
-    phase("Build", [build("examples/getting-started")]),
+    // Runs `npm run build` in this example dir → writes k8s.yaml. Paths are
+    // relative to where `chant run` is invoked (the example dir), hence `.`.
+    phase("Build", [build(".")]),
     // kubectl apply -f against the current context (e.g. local k3d).
-    phase("Apply", [kubectlApply("examples/getting-started/k8s.yaml")]),
+    phase("Apply", [kubectlApply("k8s.yaml")]),
   ],
 });


### PR DESCRIPTION
The three high-severity runtime breaks the multi-lens review found in the just-shipped golden example.

## #235 — deploy Op paths (validated live on k3d)
`deploy.op.ts` / `deploy-gated.op.ts` used repo-root paths (`build("examples/getting-started")`), so `npm run deploy` from the example dir built `examples/getting-started/examples/getting-started` and failed. Now `build(".")` / `kubectlApply("k8s.yaml")`.
Live: `chant run deploy --local` from the example dir → Build (`chantBuild(path=.)`) → Apply (web Deployment/Service/PDB created). ✓

## #236 — worker ServiceAccount
`WorkerPool` created an SA/Role/RoleBinding + set `serviceAccountName`, but only `deployment`+`pdb` were exported → dangling `serviceAccountName`, worker couldn't start. Pass `rbacRules: []` (a Temporal worker needs no K8s RBAC). Build now emits **0 `serviceAccountName` refs / 0 SA docs**; added a harness guard that every `serviceAccountName` has a matching ServiceAccount.

## #237 — drift command
`drift-source.ts` ran `lifecycle diff --live --json` — `diff` has no `--json`, so `JSON.parse` threw on text and it always reported "no drift". Now `lifecycle plan <env> k8s --json` (typed `{ env, entries }`), mapping non-noop entries. README/tutorial wording updated.

**Caveat (separate issue):** validating #237 surfaced a deeper blocker — `lifecycle plan` builds `resolve(".")` with auto-detection that fails on this example's mixed layout (chant `src/` + `app/`/`activities/`). Filed as **#252**; until that lands, the real drift path degrades to "no drift" and `--demo` is the demonstration. The flag/shape defect #237 reported is fixed here.

## Validation
`examples` suite **204 passed** (incl. the new SA guard); `eslint` + docs build clean; **#235 validated live on k3d**.

Closes #235, #236, #237. Refs #252.