### PR TITLE
fix(examples): tier-2 golden-review fixes (#238 #239 #240)

### DIFF
--- a/docs/src/content/docs/contributing/examples.mdx
+++ b/docs/src/content/docs/contributing/examples.mdx
@@ -9,13 +9,13 @@ chant's examples do three different jobs. This page names the three tiers, says 
 
 | Tier | Job | Home | Audience |
 |---|---|---|---|
-| **Golden teaching example** | Teach chant from the core up, as one leveled example | a reserved subtree under `examples/` (planned — see [#216](https://github.com/INTENTIUS/chant/issues/216)) | everyone — the first thing a new user runs |
+| **Golden teaching example** | Teach chant from the core up, as one leveled example | `examples/getting-started` (L1–L4) and `examples/alert-triage` (L5) — see [#216](https://github.com/INTENTIUS/chant/issues/216) | everyone — the first thing a new user runs |
 | **Feature examples** | One concept, in isolation, exhaustively, CI-tested | `lexicons/*/examples/` | reference lookup for a single feature |
 | **Reference deployments** | Real-world, substrate-specific, production-shaped stacks | `examples/` | a starting point to adapt for production |
 
 The tiers are distinguished by job and by where they live, not by being different kinds of file. All three run under the same `describeAllExamples` CI harness, so every tier is type-checked and built on every change.
 
-There is no fourth directory. `examples/` stays the single home for top-level examples. The golden teaching example is a reserved, labeled subtree within it, not a parallel tree.
+There is no fourth directory. `examples/` stays the single home for top-level examples. The golden teaching example is two labeled directories within it — `getting-started` (L1–L4) and `alert-triage` (L5) — not a parallel tree.
 
 ## Feature examples — `lexicons/*/examples/`
 
@@ -27,7 +27,9 @@ These are the large, deployable, substrate-specific stacks. Most are paired with
 
 | Example | Tier |
 |---|---|
-| `examples/local-op-quickstart` | Golden (seed — becomes L1–L2 of the golden example, [#216](https://github.com/INTENTIUS/chant/issues/216)) |
+| `examples/getting-started` | Golden (L1–L4 — synthesis, local Op, gate, lifecycle dial) |
+| `examples/alert-triage` | Golden (L5 — the capstone app) |
+| `examples/local-op-quickstart` | Standalone first taste (smallest one-step Op, no cluster) |
 | `examples/argo-cd-gke` | Reference deployment |
 | `examples/cockroachdb-multi-region-gke` | Reference deployment |
 | `examples/fargate-lucene-efs` | Reference deployment |
@@ -48,9 +50,14 @@ Everything under `lexicons/*/examples/` is the feature tier and is not listed in
 
 ## The golden teaching example
 
-The golden tier does not exist yet. It is one example that teaches chant in ordered levels — synthesis and lint first, then Ops, then a gate, then the lifecycle dial, then a full app — over the same declarations. `examples/local-op-quickstart` is the seed of its first levels, and the alert-triage app ([#74](https://github.com/INTENTIUS/chant/issues/74)) is the final level. See [#216](https://github.com/INTENTIUS/chant/issues/216) for the design.
+The golden tier teaches chant in ordered levels — synthesis and lint first, then Ops, then a gate, then the lifecycle dial, then a full app — over the same declarations. It lives in two directories:
 
-When the golden example lands, the getting-started docs point new users at it, and each reference deployment links back to it as the place to start.
+- `examples/getting-started` holds **L1–L4**. L1 is pure synthesis and lint, L2 wraps the same declarations in a local Op, L3 adds an approval gate on Temporal, L4 turns the lifecycle dial (observe → reconcile → authoritative). Each level adds one capability without rewriting the declarations.
+- `examples/alert-triage` is **L5**, the capstone: chant manifests plus a raw-Temporal triage workflow, a worker, two event sources, and a local dev stack ([#74](https://github.com/INTENTIUS/chant/issues/74)).
+
+`examples/local-op-quickstart` is a separate, standalone first taste — the smallest possible Op, runnable in under a minute with no cluster. It is not part of the leveled arc.
+
+The getting-started docs point new users at the golden example, and reference deployments link back to it as the place to start. See [#216](https://github.com/INTENTIUS/chant/issues/216) for the design.
 
 ## Adding an example — which tier?
 

--- a/examples/alert-triage/activities/triage.test.ts
+++ b/examples/alert-triage/activities/triage.test.ts
@@ -4,6 +4,7 @@ import {
   gatherContext,
   proposeRemediation,
   notifyOutcome,
+  parseRemediation,
   type Alert,
 } from "./triage";
 
@@ -55,5 +56,33 @@ describe("triage activities (stub path)", () => {
     await expect(
       notifyOutcome({ alert, remediation: { summary: "x", risky: false }, approved: true }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("parseRemediation (agent reply, fail-safe)", () => {
+  test("explicit SAFE on a complete reply → not risky", () => {
+    const r = parseRemediation("Restart the pod. SAFE", "end_turn");
+    expect(r.risky).toBe(false);
+    expect(r.summary).toBe("Restart the pod.");
+  });
+
+  test("explicit RISKY → risky", () => {
+    const r = parseRemediation("Drop and recreate the table. RISKY", "end_turn");
+    expect(r.risky).toBe(true);
+    expect(r.summary).toBe("Drop and recreate the table.");
+  });
+
+  test("no suffix → risky (ambiguous never skips the gate)", () => {
+    const r = parseRemediation("Scale the deployment to 3 replicas.", "end_turn");
+    expect(r.risky).toBe(true);
+  });
+
+  test("SAFE but truncated → risky (truncation never skips the gate)", () => {
+    const r = parseRemediation("Restart the pod. SAFE", "max_tokens");
+    expect(r.risky).toBe(true);
+  });
+
+  test("empty reply → risky", () => {
+    expect(parseRemediation("", "end_turn").risky).toBe(true);
   });
 });

--- a/examples/alert-triage/activities/triage.ts
+++ b/examples/alert-triage/activities/triage.ts
@@ -93,8 +93,26 @@ export async function notifyOutcome(input: {
 
 interface MinimalAnthropic {
   messages: {
-    create(body: unknown): Promise<{ content: Array<{ type: string; text?: string }> }>;
+    create(body: unknown): Promise<{
+      content: Array<{ type: string; text?: string }>;
+      stop_reason?: string | null;
+    }>;
   };
+}
+
+/**
+ * Parse the model's reply into a Remediation. Fails safe: a remediation is
+ * `risky` (routes through the approval gate) unless the model explicitly ends
+ * with SAFE *and* the response was not truncated. A truncated reply
+ * (`stop_reason === "max_tokens"`) or any reply that does not clearly end in
+ * SAFE is treated as risky — we never skip the gate on an ambiguous answer.
+ */
+export function parseRemediation(text: string, stopReason?: string | null): Remediation {
+  const trimmed = text.trim();
+  const summary = trimmed.replace(/\b(RISKY|SAFE)\s*$/i, "").trim();
+  const truncated = stopReason === "max_tokens";
+  const endsSafe = /\bSAFE\s*$/i.test(trimmed);
+  return { summary: summary || trimmed, risky: truncated || !endsSafe };
 }
 
 async function proposeWithClaude(input: {
@@ -123,6 +141,6 @@ async function proposeWithClaude(input: {
     max_tokens: 512,
     messages: [{ role: "user", content: prompt }],
   });
-  const text = res.content.map((b) => b.text ?? "").join("").trim();
-  return { summary: text.replace(/\b(RISKY|SAFE)\s*$/i, "").trim(), risky: /RISKY\s*$/i.test(text) };
+  const text = res.content.map((b) => b.text ?? "").join("");
+  return parseRemediation(text, res.stop_reason);
 }

--- a/examples/alert-triage/chant.config.ts
+++ b/examples/alert-triage/chant.config.ts
@@ -1,9 +1,14 @@
 import type { TemporalChantConfig } from "@intentius/chant-lexicon-temporal";
 
-// `lexicons` is read by chant; `temporal` is read by the generated Op worker
-// when you run the triage Op with `--temporal` (the gate makes it Temporal-bound).
+// `lexicons` is read by chant. `ownership` stamps a stack-identity marker on
+// every resource, so the lifecycle dial / drift source can scope to chant-owned
+// resources (cf. the getting-started example). `temporal` profiles are read by
+// the hand-written worker (activities/worker.ts) and the triage client
+// (app/triage-client.ts) — this app is raw Temporal, not a chant Op, so there is
+// no generated Op worker.
 export default {
   lexicons: ["k8s", "temporal"],
+  ownership: { stack: "alert-triage", env: "local" },
   temporal: {
     profiles: {
       local: {

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -7,9 +7,9 @@ whole arc is Kubernetes, and every level runs on a laptop.
 
 Start here if you are new to chant. Stop at whatever level answers your question.
 
-> **Status:** L1–L4 are here now. L5 lands in follow-up work — see
-> [#216](https://github.com/INTENTIUS/chant/issues/216). The level plan below is
-> the target shape, not a claim that every level already exists.
+> **Status:** L1–L5 are all here. L1–L4 live in this directory; L5 is the
+> [alert-triage app](../alert-triage/). See
+> [#216](https://github.com/INTENTIUS/chant/issues/216) for the design.
 
 ## The levels
 
@@ -19,7 +19,7 @@ Start here if you are new to chant. Stop at whatever level answers your question
 | **L2 — Ops, local** | wrap the declarations in an Op that `kubectl apply`s to a local k3d cluster | k3d (Docker) |
 | **L3 — gate + Temporal** | a human-approval gate before apply | a local Temporal (Docker) |
 | **L4 — the lifecycle dial** | observe drift, reconcile, apply against the cluster | the k3d cluster |
-| **L5 — capstone** | the [alert-triage app](../alert-triage/) ([#74](https://github.com/INTENTIUS/chant/issues/74)) — manifests + triage activities so far | the full local stack |
+| **L5 — capstone** | the [alert-triage app](../alert-triage/) ([#74](https://github.com/INTENTIUS/chant/issues/74)) — chant manifests + a raw-Temporal triage workflow, worker, two event sources (webhook + drift), and an `npm run dev` local stack | the full local stack |
 
 ## L1 — what is here
 


### PR DESCRIPTION
Tier-2 fixes from the golden-example multi-lens review.

## #238 — doc drift
The taxonomy page claimed the golden tier "does not exist yet". It does:
- `contributing/examples.mdx` rewritten to present tense — getting-started is L1–L4, alert-triage is L5; local-op-quickstart retagged as a standalone first taste.
- alert-triage `chant.config.ts` comment corrected (raw Temporal, not a chant Op).
- getting-started `README.md` status block + L5 row updated.

## #239 — ownership marker
alert-triage `chant.config.ts` now stamps `ownership: { stack: "alert-triage", env: "local" }` so the drift source / lifecycle dial can scope to chant-owned resources.

## #240 — fail-safe approval gate
The Claude path computed `risky` with `/RISKY\s*$/`, so any reply that did not end in `RISKY` (truncated, reworded, empty) skipped the human gate — fail-open.
- Extracted exported `parseRemediation(text, stopReason)`: risky unless the reply explicitly ends in `SAFE` **and** was not truncated (`stop_reason === "max_tokens"`).
- Added `stop_reason` to the minimal SDK interface.
- 5 unit tests covering SAFE/RISKY/no-suffix/truncated/empty.

## Validation
- `npx vitest run examples/alert-triage` → 17 passed
- `npx eslint examples/alert-triage` → clean
- `npm --prefix docs run build` → 111 pages, complete

Closes #238
Closes #239
Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)