### PR TITLE
fix(k8s lexicon): WK8301 exempts port-less worker Deployments (#244)

### DIFF
--- a/lexicons/k8s/src/codegen/docs.ts
+++ b/lexicons/k8s/src/codegen/docs.ts
@@ -393,7 +393,7 @@ Post-synth checks run against the serialized YAML after build.
 | Rule | Description |
 |------|-------------|
 | WK8201 | Container missing resource limits |
-| WK8301 | Container missing health probes (skips Jobs/CronJobs) |
+| WK8301 | Port-serving container missing health probes (skips Jobs/CronJobs and port-less workers) |
 | WK8302 | Single replica Deployment |
 | WK8303 | HA Deployment without PodDisruptionBudget |
 

--- a/lexicons/k8s/src/lint/post-synth/post-synth.test.ts
+++ b/lexicons/k8s/src/lint/post-synth/post-synth.test.ts
@@ -854,7 +854,7 @@ spec:
 // ── WK8301: Probes required ────────────────────────────────────────
 
 describe("WK8301: Probes required", () => {
-  test("flags container without probes", () => {
+  test("flags port-serving container without probes", () => {
     const ctx = makeCtx(JSON.stringify({
       apiVersion: "apps/v1",
       kind: "Deployment",
@@ -862,7 +862,9 @@ describe("WK8301: Probes required", () => {
       spec: {
         template: {
           spec: {
-            containers: [{ name: "app", image: "app:1.0" }],
+            containers: [
+              { name: "app", image: "app:1.0", ports: [{ containerPort: 8080 }] },
+            ],
           },
         },
       },
@@ -870,6 +872,24 @@ describe("WK8301: Probes required", () => {
     const diags = wk8301.check(ctx);
     expect(diags.length).toBeGreaterThanOrEqual(1);
     expect(diags[0].checkId).toBe("WK8301");
+  });
+
+  test("skips port-less worker Deployment (no inbound traffic to probe)", () => {
+    const ctx = makeCtx(JSON.stringify({
+      apiVersion: "apps/v1",
+      kind: "Deployment",
+      metadata: { name: "worker" },
+      spec: {
+        template: {
+          spec: {
+            // A queue/Temporal worker — long-running, no port, no probes by design.
+            containers: [{ name: "worker", image: "worker:1.0" }],
+          },
+        },
+      },
+    }));
+    const diags = wk8301.check(ctx);
+    expect(diags.length).toBe(0);
   });
 
   test("passes with both probes", () => {
@@ -884,6 +904,7 @@ describe("WK8301: Probes required", () => {
               {
                 name: "app",
                 image: "app:1.0",
+                ports: [{ containerPort: 8080 }],
                 livenessProbe: { httpGet: { path: "/healthz", port: 8080 } },
                 readinessProbe: { httpGet: { path: "/readyz", port: 8080 } },
               },

--- a/lexicons/k8s/src/lint/post-synth/wk8301.ts
+++ b/lexicons/k8s/src/lint/post-synth/wk8301.ts
@@ -1,9 +1,14 @@
 /**
  * WK8301: Probes Required
  *
- * Containers should have both livenessProbe and readinessProbe configured.
- * Without probes, Kubernetes cannot detect unhealthy containers or know
- * when a container is ready to receive traffic.
+ * Containers that expose a port should have both livenessProbe and
+ * readinessProbe configured. Without probes, Kubernetes cannot detect
+ * unhealthy containers or know when a container is ready to receive traffic.
+ *
+ * Containers that declare no port (queue/Temporal workers, batch consumers)
+ * are exempt: they take no inbound traffic, so there is no endpoint to
+ * HTTP-probe and no readiness signal for a Service to gate on. Flagging them
+ * would force a placeholder exec probe on a correct, port-less pattern.
  */
 
 import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
@@ -29,6 +34,9 @@ export const wk8301: PostSynthCheck = {
         const resourceName = manifest.metadata?.name ?? manifest.kind;
 
         for (const container of containers) {
+          // No declared port → no inbound traffic → nothing to HTTP-probe.
+          if (!container.ports || container.ports.length === 0) continue;
+
           const missing: string[] = [];
           if (!container.livenessProbe) missing.push("livenessProbe");
           if (!container.readinessProbe) missing.push("readinessProbe");


### PR DESCRIPTION
## Problem
`WK8301` (missing liveness/readiness probes) only exempted `Job`/`CronJob`, so every long-running worker `Deployment` tripped it — including ones that **deliberately** declare no port. A queue/Temporal worker (e.g. the golden capstone's `WorkerPool`) takes no inbound traffic, so there is no endpoint to HTTP-probe and no readiness signal for a Service to gate on. The toolchain contradicted a correct pattern with a permanent, unsuppressable build advisory.

## Fix
Scope WK8301 to containers that declare at least one port (option 1 from the issue — the most general fix). A port-less container has nothing to HTTP-probe.

- `lexicons/k8s/src/lint/post-synth/wk8301.ts` — skip containers with no `ports`.
- Rule docs table updated.
- Tests: port-less worker is exempt; port-serving Deployment with no probes still trips; Job/CronJob still exempt.

## Validation
- `npx vitest run lexicons/k8s/.../post-synth.test.ts` → 87 passed
- `npm run --prefix lexicons/k8s prepack` → packaged, all validation passed
- `examples/alert-triage` build: WK8301 on `alert-worker` is gone; the 4 remaining advisories (imagePullPolicy ×2, readOnlyRootFilesystem ×2) are unaffected.

Closes #244
Refs #74, #216, #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)