### PR TITLE
fix(examples): alert-triage agent robustness + proposed-vs-executed boundary (#241 #243)

### DIFF
--- a/docs/src/content/docs/tutorials/alert-triage-local.mdx
+++ b/docs/src/content/docs/tutorials/alert-triage-local.mdx
@@ -9,7 +9,8 @@ The [`alert-triage`](https://github.com/INTENTIUS/chant/tree/main/examples/alert
 example is the capstone (L5) of the [getting-started](https://github.com/INTENTIUS/chant/tree/main/examples/getting-started)
 golden example. It is a Temporal-driven incident-triage app: an alert comes in,
 a phased workflow classifies it, gathers context, proposes a remediation, pauses
-for human approval when the change is risky, then notifies. chant synthesizes the
+for human approval when the change is risky, applies it (a clearly-stubbed step),
+then notifies. chant synthesizes the
 Kubernetes manifests; the triage workflow itself is hand-written Temporal — the
 ["Raw Temporal + chant"](/chant/concepts/deployment-paths/) split.
 
@@ -87,7 +88,7 @@ your own builds of the worker and webhook to run the app in-cluster; the local
 |---|---|
 | `src/` | chant manifests — webhook (`WebApp`) and worker (`WorkerPool`) |
 | `activities/triage.ts` | the triage activities (the agent — stub + Claude opt-in) |
-| `activities/workflow.ts` | the Temporal workflow (classify → context → propose → gate → notify) |
+| `activities/workflow.ts` | the Temporal workflow (classify → context → propose → gate → apply → notify) |
 | `activities/worker.ts` | the worker that registers them |
 | `app/` | the event sources (webhook, drift) and the demo alert |
 

--- a/examples/alert-triage/README.md
+++ b/examples/alert-triage/README.md
@@ -26,8 +26,8 @@ steps, not arbitrary app logic.)
 |---|---|
 | `src/config.ts` | pinned image refs (replace with your own builds) |
 | `src/workloads.ts` | chant manifests — the webhook (`WebApp` → Deployment + Service + Ingress + PDB) and the worker (`WorkerPool` → Deployment + PDB, no RBAC) |
-| `activities/triage.ts` | the triage activities (raw Temporal): `classifyAlert`, `gatherContext`, `proposeRemediation`, `notifyOutcome` |
-| `activities/workflow.ts` | the triage workflow: classify → context → propose → approval gate → notify |
+| `activities/triage.ts` | the triage activities (raw Temporal): `classifyAlert`, `gatherContext`, `proposeRemediation`, `applyRemediation` (stubbed), `notifyOutcome` |
+| `activities/workflow.ts` | the triage workflow: classify → context → propose → approval gate → apply → notify |
 | `activities/worker.ts` | the Temporal worker — registers the activities + workflow, connects via the `local` profile |
 | `app/webhook.ts` | event source #1 — HTTP receiver, `POST /alert` starts a triage workflow |
 | `app/drift-source.ts` | event source #2 — `chant lifecycle plan --json` → triage each drifted resource |
@@ -71,15 +71,22 @@ offline with no key:
 - `proposeRemediation` — **stub by default; real Claude when `ANTHROPIC_API_KEY`
   is set** (and `@anthropic-ai/sdk` is installed). The first run shows chant, not
   an LLM. Override the model with `ANTHROPIC_MODEL` (default `claude-sonnet-4-6`).
+  The agent may only *escalate* risk, never de-escalate: a high/critical alert
+  always routes through the gate even if the model calls it SAFE.
+- `applyRemediation` — **clearly stubbed.** A real build would run the change
+  (kubectl, a runbook, an API call); here it just logs. The workflow calls it
+  only after a remediation clears, so it marks the proposed-vs-executed boundary.
 - `notifyOutcome` — logs the outcome; a real build would post to Slack.
 
 ## The workflow and worker
 
 `activities/workflow.ts` is the triage workflow (raw Temporal): classify →
-gather context → propose → **approval gate** → notify. Safe remediations apply
-directly; risky ones wait on the `approve-remediation` signal (up to 12h, then
-held). `activities/worker.ts` registers the activities and workflow and connects
-using the `local` profile in `chant.config.ts`.
+gather context → propose → **approval gate** → **apply** → notify. Safe
+remediations apply directly; risky ones wait on the `approve-remediation` signal
+(up to 12h, then held — and a held remediation is never applied). The apply step
+is a clearly-stubbed `applyRemediation` activity, so the example never claims to
+have executed a change it didn't. `activities/worker.ts` registers the activities
+and workflow and connects using the `local` profile in `chant.config.ts`.
 
 Run it against a local Temporal:
 

--- a/examples/alert-triage/activities/triage.test.ts
+++ b/examples/alert-triage/activities/triage.test.ts
@@ -3,8 +3,10 @@ import {
   classifyAlert,
   gatherContext,
   proposeRemediation,
+  applyRemediation,
   notifyOutcome,
   parseRemediation,
+  withSeverityFloor,
   type Alert,
 } from "./triage";
 
@@ -52,10 +54,46 @@ describe("triage activities (stub path)", () => {
     expect(r.risky).toBe(false);
   });
 
+  test("applyRemediation (stub) runs without throwing", async () => {
+    await expect(
+      applyRemediation({ alert, remediation: { summary: "x", risky: false } }),
+    ).resolves.toBeUndefined();
+  });
+
   test("notifyOutcome runs without throwing", async () => {
     await expect(
-      notifyOutcome({ alert, remediation: { summary: "x", risky: false }, approved: true }),
+      notifyOutcome({
+        alert,
+        remediation: { summary: "x", risky: false },
+        approved: true,
+        applied: true,
+      }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("withSeverityFloor (agent may escalate, never de-escalate)", () => {
+  test("critical + SAFE reply → still risky (no de-escalation)", () => {
+    const r = withSeverityFloor({ summary: "restart", risky: false }, "critical");
+    expect(r.risky).toBe(true);
+  });
+
+  test("high + SAFE reply → still risky", () => {
+    expect(withSeverityFloor({ summary: "x", risky: false }, "high").risky).toBe(true);
+  });
+
+  test("low + SAFE reply → not risky", () => {
+    expect(withSeverityFloor({ summary: "x", risky: false }, "low").risky).toBe(false);
+  });
+
+  test("low + RISKY reply → risky (agent escalation respected)", () => {
+    expect(withSeverityFloor({ summary: "x", risky: true }, "low").risky).toBe(true);
+  });
+
+  test("preserves the summary", () => {
+    expect(withSeverityFloor({ summary: "drain node", risky: false }, "medium").summary).toBe(
+      "drain node",
+    );
   });
 });
 

--- a/examples/alert-triage/activities/triage.ts
+++ b/examples/alert-triage/activities/triage.ts
@@ -6,6 +6,7 @@
 //
 // The agent is stubbed by default — deterministic, no key, runs in CI and
 // offline. When ANTHROPIC_API_KEY is set, `proposeRemediation` calls Claude.
+import { ApplicationFailure } from "@temporalio/common";
 
 export interface Alert {
   id: string;
@@ -29,6 +30,22 @@ export interface Remediation {
   summary: string;
   /** Risky remediations route through the human-approval gate. */
   risky: boolean;
+}
+
+/** High/critical alerts always route through the gate, whatever the agent says. */
+function severityRisky(severity: Severity): boolean {
+  return severity === "high" || severity === "critical";
+}
+
+/**
+ * Combine the agent's parsed reply with the alert severity. The agent may
+ * *escalate* (call a low-severity alert risky) but never *de-escalate*: a
+ * high/critical alert always routes through the gate even if the model calls it
+ * SAFE. This keeps the agent path gating at least as strictly as the
+ * deterministic stub.
+ */
+export function withSeverityFloor(parsed: Remediation, severity: Severity): Remediation {
+  return { summary: parsed.summary, risky: parsed.risky || severityRisky(severity) };
 }
 
 /** Classify severity. Deterministic stub: keyword heuristic. */
@@ -66,13 +83,24 @@ export async function proposeRemediation(input: {
   if (process.env.ANTHROPIC_API_KEY) {
     return proposeWithClaude(input);
   }
-  const risky =
-    input.classification.severity === "high" ||
-    input.classification.severity === "critical";
   return {
     summary: `Proposed (stub): mitigate "${input.alert.title}" [${input.classification.severity}]`,
-    risky,
+    risky: severityRisky(input.classification.severity),
   };
+}
+
+/**
+ * Apply the remediation. Clearly stubbed — a real build would run the change
+ * (kubectl, a runbook, an API call). The workflow calls this only once the
+ * remediation is cleared (safe directly, risky after approval), so a held
+ * remediation is never applied. This is the proposed-vs-executed boundary the
+ * capstone is built to show.
+ */
+export async function applyRemediation(input: {
+  alert: Alert;
+  remediation: Remediation;
+}): Promise<void> {
+  console.log(`[alert-triage] ${input.alert.id}: applying (stub) — ${input.remediation.summary}`);
 }
 
 /** Post the outcome. Stub logs; a real build would post to Slack. */
@@ -80,23 +108,33 @@ export async function notifyOutcome(input: {
   alert: Alert;
   remediation: Remediation;
   approved: boolean;
+  /** Whether `applyRemediation` actually ran (false → held at the gate). */
+  applied: boolean;
 }): Promise<void> {
-  const status = input.remediation.risky
-    ? input.approved
+  const status = input.applied
+    ? input.remediation.risky
       ? "applied after approval"
-      : "held — not approved"
-    : "applied";
+      : "applied"
+    : "held — not approved";
   console.log(`[alert-triage] ${input.alert.id}: ${input.remediation.summary} — ${status}`);
 }
 
 // ── Real-agent path (opt-in) ──────────────────────────────────────────────────
 
+interface AnthropicRequest {
+  model: string;
+  max_tokens: number;
+  messages: Array<{ role: "user" | "assistant"; content: string }>;
+}
+
+interface AnthropicResponse {
+  content: Array<{ type: string; text?: string }>;
+  stop_reason?: string | null;
+}
+
 interface MinimalAnthropic {
   messages: {
-    create(body: unknown): Promise<{
-      content: Array<{ type: string; text?: string }>;
-      stop_reason?: string | null;
-    }>;
+    create(body: AnthropicRequest): Promise<AnthropicResponse>;
   };
 }
 
@@ -125,10 +163,16 @@ async function proposeWithClaude(input: {
   let Anthropic: new () => MinimalAnthropic;
   try {
     Anthropic = ((await import(pkg)) as { default: new () => MinimalAnthropic }).default;
-  } catch {
-    throw new Error(
-      "ANTHROPIC_API_KEY is set but @anthropic-ai/sdk is not installed — run `npm i @anthropic-ai/sdk`.",
-    );
+  } catch (err) {
+    // Only "module not found" means the optional dep is absent. Any other import
+    // error (the package is present but fails to load) must surface its real cause.
+    const code = (err as { code?: string }).code;
+    if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") {
+      throw new Error(
+        "ANTHROPIC_API_KEY is set but @anthropic-ai/sdk is not installed — run `npm i @anthropic-ai/sdk`.",
+      );
+    }
+    throw err;
   }
   const client = new Anthropic();
   const model = process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-6";
@@ -136,11 +180,26 @@ async function proposeWithClaude(input: {
     `Alert: ${input.alert.title}\nSeverity: ${input.classification.severity}\n` +
     `Context: ${input.context.signals.join("; ")}\n\n` +
     `Propose a one-line remediation. End with RISKY or SAFE.`;
-  const res = await client.messages.create({
-    model,
-    max_tokens: 512,
-    messages: [{ role: "user", content: prompt }],
-  });
+  let res: AnthropicResponse;
+  try {
+    res = await client.messages.create({
+      model,
+      max_tokens: 512,
+      messages: [{ role: "user", content: prompt }],
+    });
+  } catch (err) {
+    // 4xx (bad key, bad model, malformed request) will never succeed on retry —
+    // fail the activity non-retryably so Temporal stops instead of masking the
+    // cause as doomed retries. 5xx / network errors fall through to normal retry.
+    const status = (err as { status?: number }).status;
+    if (typeof status === "number" && status >= 400 && status < 500) {
+      throw ApplicationFailure.nonRetryable(
+        `Anthropic API rejected the request (${status}): ${(err as Error).message}`,
+        "AnthropicClientError",
+      );
+    }
+    throw err;
+  }
   const text = res.content.map((b) => b.text ?? "").join("");
-  return parseRemediation(text, res.stop_reason);
+  return withSeverityFloor(parseRemediation(text, res.stop_reason), input.classification.severity);
 }

--- a/examples/alert-triage/activities/workflow.test.ts
+++ b/examples/alert-triage/activities/workflow.test.ts
@@ -22,7 +22,10 @@ afterAll(async () => {
   await env?.teardown();
 });
 
-function mockActivities(risky: boolean, record: { approved?: boolean; calls: string[] }) {
+function mockActivities(
+  risky: boolean,
+  record: { approved?: boolean; applied?: boolean; calls: string[] },
+) {
   return {
     classifyAlert: async (): Promise<Classification> => {
       record.calls.push("classify");
@@ -36,15 +39,19 @@ function mockActivities(risky: boolean, record: { approved?: boolean; calls: str
       record.calls.push("propose");
       return { summary: "mock fix", risky };
     },
-    notifyOutcome: async (input: { approved: boolean }): Promise<void> => {
+    applyRemediation: async (): Promise<void> => {
+      record.calls.push("apply");
+    },
+    notifyOutcome: async (input: { approved: boolean; applied: boolean }): Promise<void> => {
       record.calls.push("notify");
       record.approved = input.approved;
+      record.applied = input.applied;
     },
   };
 }
 
 async function runTriage(opts: { risky: boolean; signal?: boolean }) {
-  const record: { approved?: boolean; calls: string[] } = { calls: [] };
+  const record: { approved?: boolean; applied?: boolean; calls: string[] } = { calls: [] };
   const taskQueue = `alert-triage-test-${counter++}`;
   const worker = await Worker.create({
     connection: env.nativeConnection,
@@ -69,23 +76,28 @@ async function runTriage(opts: { risky: boolean; signal?: boolean }) {
 }
 
 describe("alert-triage workflow", () => {
-  test("safe remediation auto-approves and skips the gate", async () => {
+  test("safe remediation auto-approves, applies, and skips the gate", async () => {
     const { record, durationMs } = await runTriage({ risky: false });
-    expect(record.calls).toEqual(["classify", "context", "propose", "notify"]);
+    expect(record.calls).toEqual(["classify", "context", "propose", "apply", "notify"]);
     expect(record.approved).toBe(true);
+    expect(record.applied).toBe(true);
     expect(durationMs).toBeLessThan(60 * 60 * 1000); // no 12h wait
   }, 120_000);
 
-  test("risky remediation proceeds once the approval signal arrives", async () => {
+  test("risky remediation applies once the approval signal arrives", async () => {
     const { record, durationMs } = await runTriage({ risky: true, signal: true });
     expect(record.approved).toBe(true);
-    expect(record.calls).toContain("notify");
+    expect(record.applied).toBe(true);
+    expect(record.calls).toEqual(["classify", "context", "propose", "apply", "notify"]);
     expect(durationMs).toBeLessThan(60 * 60 * 1000); // signal short-circuits the gate
   }, 120_000);
 
-  test("risky remediation without approval waits out the gate and is held", async () => {
+  test("risky remediation without approval waits out the gate and is never applied", async () => {
     const { record, durationMs } = await runTriage({ risky: true });
     expect(record.approved).toBe(false);
+    expect(record.applied).toBe(false);
+    expect(record.calls).not.toContain("apply");
+    expect(record.calls).toContain("notify");
     expect(durationMs).toBeGreaterThan(11 * 60 * 60 * 1000); // ~12h gate timeout
   }, 120_000);
 });

--- a/examples/alert-triage/activities/workflow.ts
+++ b/examples/alert-triage/activities/workflow.ts
@@ -9,7 +9,7 @@ import { proxyActivities, defineSignal, setHandler, condition } from "@temporali
 import type * as activities from "./triage";
 import type { Alert } from "./triage";
 
-const { classifyAlert, gatherContext, proposeRemediation, notifyOutcome } =
+const { classifyAlert, gatherContext, proposeRemediation, applyRemediation, notifyOutcome } =
   proxyActivities<typeof activities>({ startToCloseTimeout: "1 minute" });
 
 /** Approve a risky remediation. */
@@ -31,5 +31,13 @@ export async function alertTriage(alert: Alert): Promise<void> {
     await condition(() => approved, "12h");
   }
 
-  await notifyOutcome({ alert, remediation, approved });
+  // The proposed-vs-executed boundary: apply only when the remediation is
+  // cleared. A held (unapproved) remediation is never executed.
+  let applied = false;
+  if (approved) {
+    await applyRemediation({ alert, remediation });
+    applied = true;
+  }
+
+  await notifyOutcome({ alert, remediation, approved, applied });
 }

--- a/examples/alert-triage/app/drift-source.ts
+++ b/examples/alert-triage/app/drift-source.ts
@@ -13,6 +13,7 @@
 // the real path degrades to "no drift" rather than failing.
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
 import { startTriage } from "./triage-client.js";
 import { alertFromDrift, type DriftEntry } from "./parse.js";
 
@@ -31,7 +32,7 @@ async function detectDrift(): Promise<DriftEntry[]> {
   const { stdout } = await execFileAsync(
     "chant",
     ["lifecycle", "plan", env, "k8s", "--json"],
-    { cwd: new URL("..", import.meta.url).pathname },
+    { cwd: fileURLToPath(new URL("..", import.meta.url)) },
   );
   const plan = JSON.parse(stdout) as {
     entries?: Array<{ name: string; type?: string; action: string }>;

--- a/examples/alert-triage/package.json
+++ b/examples/alert-triage/package.json
@@ -18,6 +18,7 @@
     "@intentius/chant-lexicon-k8s": "*",
     "@intentius/chant-lexicon-temporal": "*",
     "@intentius/chant": "*",
+    "@temporalio/common": "^1.17.2",
     "@temporalio/workflow": "^1.17.2",
     "@temporalio/worker": "^1.17.2",
     "@temporalio/client": "^1.17.2"


### PR DESCRIPTION
Tier-3 fixes from the golden-example review.

## #241 — agent path robustness (`activities/triage.ts`, `app/drift-source.ts`)
- **No de-escalation.** The Claude path derived `risky` only from the RISKY/SAFE suffix, ignoring severity — so a critical alert the model called SAFE skipped the gate, gating *less* strictly than the deterministic stub. Extracted exported `withSeverityFloor(parsed, severity)`: the agent may escalate but never de-escalate. Unit-tested.
- **API errors.** 4xx Anthropic responses (bad key/model/request) throw a non-retryable `ApplicationFailure` instead of masking the cause as doomed Temporal retries; 5xx/network fall through to normal retry.
- **Import errors.** Only `MODULE_NOT_FOUND`/`ERR_MODULE_NOT_FOUND` map to the "not installed" message; any other load error rethrows its real cause.
- **Typed request/response** for the minimal Anthropic client.
- **Windows-safe cwd** in drift-source (`fileURLToPath`, matching `worker.ts`).

## #243 — proposed-vs-executed boundary
`notifyOutcome` logged "applied" though nothing was applied. Added a clearly-stubbed `applyRemediation` activity the workflow calls **only once a remediation clears** (safe directly, risky after approval) — a held remediation is never applied. `notifyOutcome` takes an `applied` flag. README + tutorial updated to the `… → gate → apply → notify` shape.

## Validation
- `npx vitest run examples/alert-triage` → 23 passed (new: withSeverityFloor ×5, applyRemediation, workflow apply-ordering + held-never-applied)
- `npx vitest run examples/examples.test.ts` → 164 passed
- `npx eslint examples/alert-triage` → clean
- `npm --prefix docs run build` → complete

Closes #241
Closes #243
Refs #74, #216, #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)