### PR TITLE
docs(examples): alert-triage advisory honesty + stale comments/file map (#242 #245)

### DIFF
--- a/examples/alert-triage/README.md
+++ b/examples/alert-triage/README.md
@@ -29,6 +29,8 @@ steps, not arbitrary app logic.)
 | `activities/triage.ts` | the triage activities (raw Temporal): `classifyAlert`, `gatherContext`, `proposeRemediation`, `applyRemediation` (stubbed), `notifyOutcome` |
 | `activities/workflow.ts` | the triage workflow: classify → context → propose → approval gate → apply → notify |
 | `activities/worker.ts` | the Temporal worker — registers the activities + workflow, connects via the `local` profile |
+| `app/triage-client.ts` | shared Temporal client — `startTriage()` launches the workflow; used by both event sources |
+| `app/parse.ts` | pure event→`Alert` mappers (webhook body and drift entry), unit-tested in `app/parse.test.ts` |
 | `app/webhook.ts` | event source #1 — HTTP receiver, `POST /alert` starts a triage workflow |
 | `app/drift-source.ts` | event source #2 — `chant lifecycle plan --json` → triage each drifted resource |
 | `app/demo.ts` | a synthetic alert (`npm run alert`) |
@@ -52,12 +54,17 @@ See the [Alert Triage (local) tutorial](/chant/tutorials/alert-triage-local/) fo
 the full walk-through. Other scripts:
 
 ```bash
-npm run build      # → k8s.yaml (plain Kubernetes)
-npm run lint       # clean
+npm run build      # → k8s.yaml — also prints post-synth hardening advisories
+npm run lint       # the gate — clean
 npm run alert      # send another alert via the webhook
 npm run drift -- --demo   # the drift event source
 npm test           # unit tests + a time-skipping workflow test
 ```
+
+`npm run build` prints a few post-synth **advisories** (imagePullPolicy and
+`readOnlyRootFilesystem` on the two workloads). Those are guidance, not failures
+— `npm run lint` is the gate, and it is clean. Hardening the workloads against
+the advisories is a good exercise.
 
 ## The triage activities
 

--- a/examples/alert-triage/src/workloads.ts
+++ b/examples/alert-triage/src/workloads.ts
@@ -2,7 +2,10 @@
 //
 // Two workloads: a webhook receiver that accepts incoming alerts over HTTP, and
 // a Temporal worker that runs the triage workflow's activities. Both use
-// composites so the output carries production defaults and lints clean.
+// composites for sensible defaults and lint clean. `chant build` still prints a
+// few post-synth hardening advisories (imagePullPolicy, readOnlyRootFilesystem)
+// — those are guidance, not failures; lint is the gate. Hardening against them
+// is a good exercise.
 import { WebApp, WorkerPool } from "@intentius/chant-lexicon-k8s";
 import { webhookImage, workerImage } from "./config";
 

--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -132,9 +132,12 @@ describe("golden example L4 — lifecycle dial", () => {
 });
 
 // ── Golden teaching example — L5 capstone: alert-triage (#74) ────────
-// The app's chant-synthesized k8s manifests. The triage workflow itself is raw
-// Temporal (custom agent activities); its activities are unit-tested separately
-// under examples/alert-triage/activities/. Workflow + worker land in follow-ups.
+// This block validates the app's chant-synthesized k8s manifests. The triage
+// workflow itself is raw Temporal (custom agent activities); its workflow,
+// worker, and activities have their own CI coverage under
+// examples/alert-triage/: a time-skipping workflow test (activities/
+// workflow.test.ts — gate behaviour), activity unit tests (activities/
+// triage.test.ts), and the event→Alert mappers (app/parse.test.ts).
 
 describeExample(
   "alert-triage",
@@ -163,9 +166,6 @@ describeExample(
     },
   },
 );
-
-// The triage workflow is raw Temporal (custom agent activities), not a chant Op.
-// Its activities are unit-tested in examples/alert-triage/activities/.
 
 // ── K8s + AWS EKS microservice (comprehensive) ──────────────────────
 


### PR DESCRIPTION
Tier-3 doc fixes from the golden-example review.

## #242 — advisory honesty
The README annotated `npm run lint # clean` and `src/workloads.ts` said the output "lints clean", but `chant build` prints post-synth advisories (imagePullPolicy and `readOnlyRootFilesystem` on both workloads). A reader running `npm run build` saw that contradicted.

Mirror the getting-started framing: the build prints advisories as **guidance**, and **lint is the gate** (clean). (WK8301's worker-probe advisory was already removed in #244, so only the imagePullPolicy/readOnlyRootFilesystem advisories remain.)

## #245 — stale teaching artifacts
- `examples.test.ts` comments claimed the workflow + worker "land in follow-ups" and only activities are tested. They exist and are covered — the comment now points to the time-skipping workflow test, activity unit tests, and parse tests.
- The README file map omitted `app/triage-client.ts` (the shared client whose `startTriage()` launches the workflow) and `app/parse.ts` (the unit-tested event→Alert mappers), both imported by every `app/` entrypoint. Added rows.

## Validation
- `npx vitest run examples/examples.test.ts examples/alert-triage` → 187 passed
- `npx eslint examples/alert-triage` → clean
- `npm --prefix docs run build` → complete
- `examples/alert-triage` build confirmed: 4 advisories (imagePullPolicy ×2, readOnlyRootFilesystem ×2), matching the doc.

Closes #242
Closes #245
Refs #74, #216, #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)