### PR TITLE
fix(core): lifecycle commands resolve plugins from cwd, build from sourceDir (#252)

### DIFF
--- a/docs/src/content/docs/cli/lifecycle.mdx
+++ b/docs/src/content/docs/cli/lifecycle.mdx
@@ -6,10 +6,10 @@ description: Capture, diff, and plan against deployed infrastructure — the obs
 ## Synopsis
 
 ```
-chant lifecycle snapshot <env> [lexicon]
+chant lifecycle snapshot <env> [lexicon] [--src <dir>]
 chant lifecycle show <env>
-chant lifecycle diff <env> [--live]
-chant lifecycle plan <env> [--json] [--owned]
+chant lifecycle diff <env> [--live] [--src <dir>]
+chant lifecycle plan <env> [--json] [--owned] [--src <dir>]
 chant lifecycle log [env]
 ```
 
@@ -18,6 +18,15 @@ chant lifecycle log [env]
 `chant lifecycle` captures point-in-time snapshots of deployed infrastructure by querying the cloud provider API and saving the result to a git orphan branch. Snapshots enable drift detection — comparing what's currently built against what was last deployed, and (with `--live`) against what's actually in the cloud right now.
 
 The environment name (e.g. `dev`, `staging`, `prod`) must be declared in `chant.config.ts` under `environments`.
+
+`snapshot`, `diff`, and `plan` build your declarations to compare against live state. By default they build the project root (`.`). For a mixed-layout project — chant infrastructure in `src/` alongside application code that has import side effects (starts a server, opens a connection) — set `sourceDir` in `chant.config.ts` so the lifecycle build only synthesizes the infra:
+
+```ts
+// chant.config.ts
+export default { lexicons: ["k8s"], sourceDir: "src" };
+```
+
+The `--src <dir>` flag overrides `sourceDir` for a single invocation. Use the same source root for `snapshot` and `diff` so their build digests stay comparable.
 
 For the conceptual model behind these commands — observational vs. authoritative state, resources vs. artifacts, when drift detection earns its keep — see [Drift Detection](/chant/concepts/drift-detection/).
 

--- a/examples/alert-triage/app/drift-source.ts
+++ b/examples/alert-triage/app/drift-source.ts
@@ -6,11 +6,11 @@
 //   npm run drift            # real: plan the env, triage any drift
 //   npm run drift -- --demo  # inject a sample drift to exercise the pipeline
 //
-// NOTE: the real path needs the env deployed + a snapshot, and `chant lifecycle
-// plan` currently builds the project dir with lexicon auto-detection, which does
-// not yet handle this example's mixed layout (chant src/ alongside app/ +
-// activities/). Until that lands (#252), `--demo` is the reliable demonstration;
-// the real path degrades to "no drift" rather than failing.
+// The real path needs the env deployed + a live cluster to plan against;
+// `chant lifecycle plan` scopes its build to `sourceDir: "src"` (chant.config.ts)
+// so this mixed-layout project (chant src/ alongside app/ + activities/) plans
+// cleanly (#252). With no cluster reachable the plan errors and we degrade to
+// "no drift"; `--demo` is the reliable offline demonstration.
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";

--- a/examples/alert-triage/chant.config.ts
+++ b/examples/alert-triage/chant.config.ts
@@ -1,13 +1,17 @@
 import type { TemporalChantConfig } from "@intentius/chant-lexicon-temporal";
 
-// `lexicons` is read by chant. `ownership` stamps a stack-identity marker on
-// every resource, so the lifecycle dial / drift source can scope to chant-owned
-// resources (cf. the getting-started example). `temporal` profiles are read by
-// the hand-written worker (activities/worker.ts) and the triage client
-// (app/triage-client.ts) — this app is raw Temporal, not a chant Op, so there is
-// no generated Op worker.
+// `lexicons` is read by chant. `sourceDir` scopes lifecycle builds to `src/`
+// (this is a mixed-layout project — chant infra in src/ next to app/ and
+// activities/ that import @temporalio and start servers on load), so
+// `chant lifecycle plan/diff/snapshot` only synthesizes the infra. `ownership`
+// stamps a stack-identity marker on every resource, so the lifecycle dial /
+// drift source can scope to chant-owned resources (cf. the getting-started
+// example). `temporal` profiles are read by the hand-written worker
+// (activities/worker.ts) and the triage client (app/triage-client.ts) — this
+// app is raw Temporal, not a chant Op, so there is no generated Op worker.
 export default {
   lexicons: ["k8s", "temporal"],
+  sourceDir: "src",
   ownership: { stack: "alert-triage", env: "local" },
   temporal: {
     profiles: {

--- a/packages/core/src/cli/handlers/lifecycle.test.ts
+++ b/packages/core/src/cli/handlers/lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import { sep } from "node:path";
 import { createMockPlugin, staticDescribeResources, staticListArtifacts } from "@intentius/chant-test-utils";
 import type { LexiconPlugin, ResourceMetadata } from "../../lexicon";
 import type { BuildResult } from "../../build";
@@ -85,6 +86,8 @@ describe("runLifecycleDiff --live", () => {
     buildMock.mockReset();
     fetchLifecycleMock.mockReset();
     readSnapshotMock.mockReset();
+    loadChantConfigMock.mockReset();
+    loadChantConfigMock.mockResolvedValue({ config: {} });
   });
 
   test("surfaces drift between previous snapshot and live state", async () => {
@@ -122,6 +125,46 @@ describe("runLifecycleDiff --live", () => {
     expect(output).toContain("status:");
     expect(output).toContain("CREATE_COMPLETE");
     expect(output).toContain("UPDATE_COMPLETE");
+  });
+
+  test("builds from config.sourceDir on a mixed-layout project", async () => {
+    buildMock.mockResolvedValue(makeBuildResult({ aws: ["bucket"] }));
+    fetchLifecycleMock.mockResolvedValue(undefined);
+    readSnapshotMock.mockResolvedValue(null);
+    loadChantConfigMock.mockResolvedValue({ config: { sourceDir: "src" } });
+
+    const plugins: LexiconPlugin[] = [
+      createMockPlugin({ name: "aws", describeResources: staticDescribeResources({}) }),
+    ];
+    const exit = await runLifecycleDiff({
+      args: makeArgs({ path: "diff", extraPositional: "prod", extraPositional2: "aws", live: true }),
+      plugins,
+      serializers: plugins.map((p) => p.serializer),
+    });
+
+    expect(exit).toBe(0);
+    const builtPath = buildMock.mock.calls[0][0] as string;
+    expect(builtPath.endsWith(`${sep}src`)).toBe(true);
+  });
+
+  test("--src overrides config.sourceDir for the build root", async () => {
+    buildMock.mockResolvedValue(makeBuildResult({ aws: ["bucket"] }));
+    fetchLifecycleMock.mockResolvedValue(undefined);
+    readSnapshotMock.mockResolvedValue(null);
+    loadChantConfigMock.mockResolvedValue({ config: { sourceDir: "src" } });
+
+    const plugins: LexiconPlugin[] = [
+      createMockPlugin({ name: "aws", describeResources: staticDescribeResources({}) }),
+    ];
+    const exit = await runLifecycleDiff({
+      args: makeArgs({ path: "diff", extraPositional: "prod", extraPositional2: "aws", live: true, src: "infra" }),
+      plugins,
+      serializers: plugins.map((p) => p.serializer),
+    });
+
+    expect(exit).toBe(0);
+    const builtPath = buildMock.mock.calls[0][0] as string;
+    expect(builtPath.endsWith(`${sep}infra`)).toBe(true);
   });
 
   test("warns and skips lexicons without describeResources", async () => {

--- a/packages/core/src/cli/handlers/lifecycle.ts
+++ b/packages/core/src/cli/handlers/lifecycle.ts
@@ -12,6 +12,20 @@ import type { LifecycleSnapshot } from "../../lifecycle/types";
 import type { SerializerResult } from "../../serializer";
 import type { ObservationLexicon, ResourceMetadata, ArtifactMetadata } from "../../lexicon";
 import type { BuildResult } from "../../build";
+import type { ParsedArgs } from "../registry";
+import type { ChantConfig } from "../../config";
+
+/**
+ * Resolve the build root for a lifecycle command. The project root (where
+ * chant.config.ts lives) is always ".", but the *build* can be scoped to a
+ * subdirectory so a mixed-layout project — chant `src/` next to app code with
+ * import side effects — only synthesizes its infra. Precedence: `--src` flag,
+ * then `config.sourceDir`, then "." (the root). Snapshot/diff/plan all use this
+ * so their build digests stay consistent.
+ */
+function resolveBuildRoot(args: ParsedArgs, config: ChantConfig): string {
+  return resolve(args.src ?? config.sourceDir ?? ".");
+}
 
 /**
  * chant lifecycle snapshot <environment> [lexicon]
@@ -44,7 +58,7 @@ export async function runLifecycleSnapshot(ctx: CommandContext): Promise<number>
   const targetSerializers = targetPlugins.map((p) => p.serializer);
 
   // Build first to get entity names and build output
-  const buildResult = await build(projectPath, targetSerializers);
+  const buildResult = await build(resolveBuildRoot(args, config), targetSerializers);
   if (buildResult.errors.length > 0) {
     console.error(formatError({ message: "Build failed — fix errors before taking a snapshot" }));
     return 1;
@@ -149,9 +163,9 @@ export async function runLifecycleDiff(ctx: CommandContext): Promise<number> {
     ? plugins.filter((p) => p.name === lexiconFilter).map((p) => p.serializer)
     : serializers;
 
-  // Build to get current state
-  const projectPath = resolve(".");
-  const buildResult = await build(projectPath, targetSerializers);
+  // Build to get current state (from the configured source root, not necessarily ".")
+  const { config } = await loadChantConfig(resolve("."));
+  const buildResult = await build(resolveBuildRoot(args, config), targetSerializers);
   if (buildResult.errors.length > 0) {
     console.error(formatError({ message: "Build failed — fix errors before diffing" }));
     return 1;
@@ -425,8 +439,8 @@ export async function runLifecyclePlan(ctx: CommandContext): Promise<number> {
     ? plugins.filter((p) => p.name === lexiconFilter).map((p) => p.serializer)
     : serializers;
 
-  const projectPath = resolve(".");
-  const buildResult = await build(projectPath, targetSerializers);
+  const { config } = await loadChantConfig(resolve("."));
+  const buildResult = await build(resolveBuildRoot(args, config), targetSerializers);
   if (buildResult.errors.length > 0) {
     console.error(formatError({ message: "Build failed — fix errors before planning" }));
     return 1;

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -49,6 +49,7 @@ export function parseArgs(args: string[]): ParsedArgs {
     useComposites: false,
     reportFile: undefined,
     skill: undefined,
+    src: undefined,
   };
 
   let i = 0;
@@ -111,6 +112,8 @@ export function parseArgs(args: string[]): ParsedArgs {
       result.useComposites = true;
     } else if (arg === "--skill") {
       result.skill = args[++i];
+    } else if (arg === "--src") {
+      result.src = args[++i];
     } else if (arg === "--local") {
       result.local = true;
     } else if (arg === "--temporal") {
@@ -332,9 +335,14 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // For compound commands (e.g. "run list"), args.path is the subcommand,
-  // so always use "." as the project path. For simple commands, use args.path.
-  const projectPath = match.compound ? (args.extraPositional || ".") : args.path;
+  // For compound commands (e.g. "run list", "lifecycle plan <env>"), the first
+  // positional is a subcommand argument — an environment, op, or lexicon name —
+  // not a project path. Plugins always load from the cwd; the handler reads its
+  // own positionals from args.extraPositional. Using extraPositional as the path
+  // here pointed plugin resolution at e.g. "./local" for `lifecycle plan local`,
+  // which then fell through to import-detection on an empty file set and failed
+  // with "No lexicon detected" even though chant.config.ts lists the lexicons.
+  const projectPath = match.compound ? "." : args.path;
   const plugins = match.def.requiresPlugins
     ? await loadPluginsOrExit(projectPath)
     : [];

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -51,6 +51,8 @@ export interface ParsedArgs {
   owned?: boolean;
   /** `chant import --verbatim` — keep server-defaulted fields in live import */
   verbatim?: boolean;
+  /** `chant lifecycle … --src <dir>` — build root override for lifecycle commands */
+  src?: string;
 }
 
 /**

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -10,6 +10,7 @@ import type { OwnershipMarker } from "./ownership";
 export const ChantConfigSchema = z.object({
   lexicons: z.array(z.string().min(1)).optional(),
   environments: z.array(z.string().min(1)).optional(),
+  sourceDir: z.string().min(1).optional(),
   lint: z.record(z.string(), z.unknown()).optional(),
   ownership: z.object({
     stack: z.string().min(1).optional(),
@@ -29,6 +30,15 @@ export interface ChantConfig {
 
   /** Environment names (e.g. ["staging", "prod"]) */
   environments?: string[];
+
+  /**
+   * Directory (relative to the project root) that holds the chant infrastructure
+   * source. Lifecycle commands (`snapshot`/`diff`/`plan`) build from here instead
+   * of the project root, so a mixed-layout project — chant `src/` alongside app
+   * code that has import side effects — can scope the build to just the infra.
+   * Defaults to "." (the project root). The `--src` flag overrides it.
+   */
+  sourceDir?: string;
 
   /** Lint configuration (rules, extends, overrides, plugins) */
   lint?: LintConfig;


### PR DESCRIPTION
`chant lifecycle plan <env>` failed with **"No lexicon detected"** on a mixed-layout project (chant `src/` alongside app code), even with a lexicon filter and a `chant.config.ts` listing the lexicons. Two root causes:

## 1. Compound-command path resolution
`main.ts` used `args.extraPositional` as the project path for compound commands. But for `lifecycle plan local k8s`, the first positional is the **environment** (`local`), not a path — so plugins resolved from `./local` (nonexistent), fell through to import-detection on an empty file set, and failed. Compound commands now resolve plugins from the cwd (matching the existing comment); handlers already read their own positionals from `extraPositional`.

## 2. Building the whole project root
`snapshot`/`diff`/`plan` built `resolve(".")`, which discovers and **imports app code with side effects** — e.g. `app/webhook.ts` calls `server.listen()` on load. Added an optional **`sourceDir`** to `chant.config.ts` (with a **`--src`** flag override) that scopes the lifecycle build to the infra directory. Defaults to `"."` — no behavior change for flat projects. snapshot/diff/plan share one resolver so digests stay comparable.

`examples/alert-triage` sets `sourceDir: "src"`. Verified:

```
$ cd examples/alert-triage
$ chant lifecycle plan local k8s --json
{ "env": "local", "entries": [ { "name": "webhookDeployment", "action": "create", … } ] }
```

No detection error, no app side effects. The drift event source's real path (#237) now works; its stale NOTE is updated.

## Validation
- `npx tsc --noEmit -p packages/core/tsconfig.json` → clean
- `npx vitest run packages/core/src/cli packages/core/src/config.test.ts packages/core/src/detectLexicon.test.ts examples/examples.test.ts` → 569 passed (new: build-root honors `config.sourceDir` and `--src` override on a mixed layout)
- `npx eslint` changed files → clean
- `npm --prefix docs run build` → complete (lifecycle CLI doc documents `sourceDir`/`--src`)

Closes #252
Refs #74, #216, #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)