### PR TITLE
docs(concepts): add the "Owning less" smaller-surface argument (#207)

### DIFF
--- a/docs/src/content/docs/concepts/comparison.mdx
+++ b/docs/src/content/docs/concepts/comparison.mdx
@@ -25,6 +25,14 @@ The lifecycle is still there when you want it. You write your own. Ops are decla
 
 Decoupled first. Durable when you ask.
 
+## Owning less
+
+A pure synthesis core also owns less *machinery*. Because the build path makes no API calls, holds no state, and emits native spec, it needs little of the apparatus a full lifecycle pulls in at plan time — no provider SDKs, no state backend, no credentials, no network. What runs to turn source into output is a type-checker, an evaluator over a [static subset of TypeScript](/chant/concepts/typescript-as-data/), and the lexicon packages for the formats you target. That is the whole of it.
+
+A smaller build-time surface is a smaller thing to audit, and a smaller blast radius if something upstream is compromised: fewer packages execute during synthesis, and none of them reach the network or your cloud credentials. This is a property of the architecture, not a security feature — it falls out of synthesis being side-effect-free. The same boundary is described value-by-value in [Where Values Come From](/chant/concepts/where-values-come-from/).
+
+The scope is exact. This is the **build path**. The apply side is whatever lifecycle you brought — the CloudFormation CLI, a CI pipeline, an agent, [Temporal](/chant/concepts/durable-workflows/) — and it carries its own dependencies and its own surface. chant shrinks the build-time surface; it does not remove the apply-time one. Owning less is a build-time property, and only that.
+
 ## Design decisions and their consequences
 
 These tools make different design decisions. Each decision has consequences — some favorable for certain workflows, some not. This isn't a feature matrix; it's a comparison of architectural choices.

--- a/docs/src/content/docs/concepts/philosophy.mdx
+++ b/docs/src/content/docs/concepts/philosophy.mdx
@@ -42,7 +42,7 @@ This means walk-away cost is zero. The output is standard CloudFormation, standa
 
 ## What chant Doesn't Do
 
-`chant build` produces artifacts — it doesn't deploy them, call cloud APIs, or manage state. Synthesis is pure and deterministic: same source in, same output out, zero side effects. This is a deliberate scope boundary, not a limitation.
+`chant build` produces artifacts — it doesn't deploy them, call cloud APIs, or manage state. Synthesis is pure and deterministic: same source in, same output out, zero side effects. This is a deliberate scope boundary, not a limitation. A pure core also owns less machinery — no provider SDKs, state backend, or network at build time — which means a smaller surface to audit; see [Owning less](/chant/concepts/comparison/#owning-less).
 
 The deployment and operational layer is increasingly handled by agents, CI pipelines, and platform tooling. chant's job is to make the synthesis step typed, linted, and deterministic — then hand off a native artifact that any deployment mechanism can consume.
 


### PR DESCRIPTION
Positioning task — the *smaller-surface* half of the own-less stance. The no-lock-in half is already argued (comparison's "Nobody sells you a lifecycle", governance's state-cost spectrum); the smaller-surface argument was made nowhere. No new mechanism — docs only.

## What's added
A new **"Owning less"** section in `comparison.mdx`, beside "Nobody sells you a lifecycle":
- A pure synthesis core owns less *build-time* machinery — no provider SDKs, state backend, credentials, or network at build time; just a type-checker, the EVL evaluator, and the lexicon packages. Smaller surface to audit, smaller blast radius if an upstream build-time dep is compromised.
- **Architecture property, not a security feature.** Abstract — no competitor or incident named, per the issue's discipline.
- **Scope is explicit:** this is the BUILD path only. The apply side carries the lifecycle you brought and its own surface. Owning less is build-time only — the honest scoping the issue requires.

## Consistency pass (T4)
- New section cross-links → `where-values-come-from`, `typescript-as-data`, `durable-workflows`.
- `philosophy.mdx` "What chant Doesn't Do" → links to the new section.
- Left `governance.mdx` "Blast radius at scale" untouched on purpose: it's the apply/change axis, and linking it here would conflate it with the build-time surface (the exact overclaim the issue warns against). It already links to comparison.

## Validation
- `npm --prefix docs run build` → 111 pages, complete.
- Confirmed in built HTML: `#owning-less` anchor exists and the philosophy cross-link resolves to it.

Closes #207
Refs #198, #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)