### PR TITLE
fix(op): profiled steps get their declared timeout, on both executors

### DIFF
--- a/packages/core/src/op/activity-registry.ts
+++ b/packages/core/src/op/activity-registry.ts
@@ -63,10 +63,17 @@ export interface ActivityProfile {
  * Dynamically import the lexicon's `TEMPORAL_ACTIVITY_PROFILES` (pure data, no
  * Temporal SDK). Returns an empty record if the lexicon is absent — the
  * executor then falls back to built-in defaults per step.
+ *
+ * Imports the lexicon's `/config` entry, not its root index. `/config` is a
+ * side-effect-free data module; the root index pulls in the plugin, serializer,
+ * composites, and re-exported Op machinery, any of which could throw on load
+ * and make this silently return `{}` — which would drop every profiled step to
+ * the 5-minute default while the Temporal path (reading the same table) kept the
+ * declared timeout. Importing the narrow module keeps the two executors agreed.
  */
 export async function loadProfiles(): Promise<Record<string, ActivityProfile>> {
   try {
-    const spec = "@intentius/chant-lexicon-temporal";
+    const spec = "@intentius/chant-lexicon-temporal/config";
     const mod = (await import(spec)) as { TEMPORAL_ACTIVITY_PROFILES?: Record<string, ActivityProfile> };
     return mod.TEMPORAL_ACTIVITY_PROFILES ?? {};
   } catch {

--- a/packages/core/src/op/builders.ts
+++ b/packages/core/src/op/builders.ts
@@ -60,36 +60,72 @@ export function gate(
 
 // ── Pre-built activity shortcuts ──────────────────────────────────────────────
 
+/**
+ * Pull an optional `profile` override out of an opts bag, returning the
+ * remaining keys (which become activity args) separately.
+ *
+ * Without this, a `profile` passed in opts would spread into the activity's
+ * **args** rather than set the step's `profile` — a silent no-op on the step's
+ * timeout. The activity then runs under the default profile, so a step the
+ * author tagged `longInfra` (20m) would still get the 5m default. Routing it
+ * here lets every shortcut accept a `profile` override that actually takes.
+ */
+function takeProfile(
+  opts: Record<string, unknown> | undefined,
+): { args: Record<string, unknown>; profile?: ActivityStep["profile"] } {
+  if (!opts) return { args: {} };
+  const { profile, ...args } = opts as { profile?: ActivityStep["profile"] } & Record<string, unknown>;
+  return { args, profile };
+}
+
 /** Run `npm run build` (or `chant build`) in the given project directory. */
-export const build = (path: string, opts?: Record<string, unknown>): ActivityStep =>
-  activity("chantBuild", { path, ...opts });
+export const build = (path: string, opts?: Record<string, unknown>): ActivityStep => {
+  const { args, profile } = takeProfile(opts);
+  return activity("chantBuild", { path, ...args }, profile);
+};
 
-/** Run `kubectl apply -f <manifest>`. Uses `longInfra` profile. */
-export const kubectlApply = (manifest: string, opts?: Record<string, unknown>): ActivityStep =>
-  activity("kubectlApply", { manifest, ...opts }, "longInfra");
+/** Run `kubectl apply -f <manifest>`. Defaults to the `longInfra` profile (override via `opts.profile`). */
+export const kubectlApply = (manifest: string, opts?: Record<string, unknown>): ActivityStep => {
+  const { args, profile } = takeProfile(opts);
+  return activity("kubectlApply", { manifest, ...args }, profile ?? "longInfra");
+};
 
-/** Run `helm upgrade --install`. Uses `longInfra` profile. */
+/** Run `helm upgrade --install`. Defaults to the `longInfra` profile (override via `opts.profile`). */
 export const helmInstall = (
   name: string,
   chart: string,
-  opts?: { values?: string; namespace?: string; [k: string]: unknown },
-): ActivityStep => activity("helmInstall", { name, chart, ...opts }, "longInfra");
+  opts?: { values?: string; namespace?: string; profile?: ActivityStep["profile"]; [k: string]: unknown },
+): ActivityStep => {
+  const { args, profile } = takeProfile(opts);
+  return activity("helmInstall", { name, chart, ...args }, profile ?? "longInfra");
+};
 
-/** Poll for stack readiness (kubectl rollout, CloudFormation complete, etc). Uses `k8sWait` profile. */
-export const waitForStack = (name: string, opts?: Record<string, unknown>): ActivityStep =>
-  activity("waitForStack", { name, ...opts }, "k8sWait");
+/** Poll for stack readiness (kubectl rollout, CloudFormation complete, etc). Defaults to the `k8sWait` profile (override via `opts.profile`). */
+export const waitForStack = (name: string, opts?: Record<string, unknown>): ActivityStep => {
+  const { args, profile } = takeProfile(opts);
+  return activity("waitForStack", { name, ...args }, profile ?? "k8sWait");
+};
 
-/** Trigger and wait for a GitLab CI pipeline to complete. Uses `longInfra` profile. */
-export const gitlabPipeline = (name: string, opts?: Record<string, unknown>): ActivityStep =>
-  activity("gitlabPipeline", { name, ...opts }, "longInfra");
+/** Trigger and wait for a GitLab CI pipeline to complete. Defaults to the `longInfra` profile (override via `opts.profile`). */
+export const gitlabPipeline = (name: string, opts?: Record<string, unknown>): ActivityStep => {
+  const { args, profile } = takeProfile(opts);
+  return activity("gitlabPipeline", { name, ...args }, profile ?? "longInfra");
+};
 
 /** Take a chant lifecycle snapshot for the given environment. */
 export const lifecycleSnapshot = (env: string): ActivityStep =>
   activity("lifecycleSnapshot", { env });
 
-/** Run an arbitrary shell command. */
-export const shell = (cmd: string, opts?: { env?: Record<string, string> }): ActivityStep =>
-  activity("shellCmd", { cmd, ...opts });
+/**
+ * Run an arbitrary shell command. Tag long-running commands with a `profile`
+ * (e.g. `longInfra` for a multi-GB image push) so they get the right
+ * start-to-close timeout under both the local executor and Temporal.
+ */
+export const shell = (
+  cmd: string,
+  opts?: { env?: Record<string, string>; profile?: ActivityStep["profile"] },
+): ActivityStep =>
+  activity("shellCmd", { cmd, ...(opts?.env ? { env: opts.env } : {}) }, opts?.profile);
 
 /** Run `chant teardown` in the given project directory. Uses `longInfra` profile. */
 export const teardown = (path: string): ActivityStep =>

--- a/packages/core/src/op/local-executor.test.ts
+++ b/packages/core/src/op/local-executor.test.ts
@@ -110,6 +110,22 @@ describe("runOpLocally — retry + timeout", () => {
     const config = op({ phases: [{ name: "P", steps: [{ kind: "activity", fn: "always" }] }] });
     await expect(runOpLocally(config, new Map([["always", always]]), PROFILES)).rejects.toBeInstanceOf(OpRunFailure);
   });
+
+  test("honors a step's non-default profile timeout (not the default)", async () => {
+    // The default profile would time out at 50ms; the step is tagged longInfra,
+    // which gives it room. Guards the bug where a profiled step silently got the
+    // default cap (local vs --temporal disagreement).
+    const slow: ActivityFn = async () => { await new Promise((r) => setTimeout(r, 150)); return "done"; };
+    const profiles = {
+      fastIdempotent: { startToCloseTimeout: "50ms", retry: { maximumAttempts: 1 } },
+      longInfra: { startToCloseTimeout: "5m", retry: { maximumAttempts: 1 } },
+    };
+    const config = op({
+      phases: [{ name: "P", steps: [{ kind: "activity", fn: "slow", profile: "longInfra" }] }],
+    });
+    const result = await runOpLocally(config, new Map([["slow", slow]]), profiles);
+    expect(result.records[0].status).toBe("ok");
+  });
 });
 
 describe("runOpLocally — cancellation", () => {

--- a/packages/core/src/op/op.test.ts
+++ b/packages/core/src/op/op.test.ts
@@ -197,3 +197,40 @@ describe("pre-built shortcuts", () => {
     expect(a.profile).toBe("longInfra");
   });
 });
+
+describe("profile routing (opts.profile sets the step profile, never leaks into args)", () => {
+  it("shell() routes profile to the step, keeps env in args", () => {
+    const a = shell("docker compose push", { env: { TAG: "v1" }, profile: "longInfra" });
+    expect(a.profile).toBe("longInfra");
+    expect(a.args?.cmd).toBe("docker compose push");
+    expect(a.args?.env).toEqual({ TAG: "v1" });
+    // The footgun this fixes: profile must NOT end up as an activity arg.
+    expect("profile" in (a.args ?? {})).toBe(false);
+  });
+
+  it("shell() without profile leaves the step unprofiled (defaults apply downstream)", () => {
+    const a = shell("echo hi", { env: { A: "1" } });
+    expect("profile" in a).toBe(false);
+    expect(a.args?.env).toEqual({ A: "1" });
+  });
+
+  it("build() accepts a profile override and does not leak it into args", () => {
+    const a = build("./p", { profile: "longInfra" });
+    expect(a.profile).toBe("longInfra");
+    expect(a.args?.path).toBe("./p");
+    expect("profile" in (a.args ?? {})).toBe(false);
+  });
+
+  it("kubectlApply() lets opts.profile override the longInfra default", () => {
+    const a = kubectlApply("dist/infra.yaml", { profile: "k8sWait" });
+    expect(a.profile).toBe("k8sWait");
+    expect(a.args?.manifest).toBe("dist/infra.yaml");
+    expect("profile" in (a.args ?? {})).toBe(false);
+  });
+
+  it("waitForStack() supports the argoSync profile", () => {
+    const a = waitForStack("argo-app", { profile: "argoSync" });
+    expect(a.profile).toBe("argoSync");
+    expect("profile" in (a.args ?? {})).toBe(false);
+  });
+});

--- a/packages/core/src/op/types.ts
+++ b/packages/core/src/op/types.ts
@@ -45,7 +45,7 @@ export interface ActivityStep {
    * Key from TEMPORAL_ACTIVITY_PROFILES controlling timeout + retry.
    * Default: "fastIdempotent"
    */
-  profile?: "fastIdempotent" | "longInfra" | "k8sWait" | "humanGate";
+  profile?: "fastIdempotent" | "longInfra" | "k8sWait" | "humanGate" | "argoSync";
   /**
    * Surface this activity's return value as a workflow search attribute.
    *


### PR DESCRIPTION
## Bug
A step tagged with an activity profile — e.g. a multi-GB image push as `shell("docker compose … push", { profile: "longInfra" })` — silently ran under the **5-minute default** on the local executor (`chant run`), even though `--temporal` honored the declared 20m. Net effect: the `{ profile: … }` annotation was a no-op locally, so every long step (image push, slow CFN create, long rollout) failed with a misleading `timed out after 300000ms` despite being correctly tagged. The two executors quietly disagreed.

## Root causes (three, all fixed)

1. **`shell()` couldn't carry a profile.** Its opts were `{ env? }`. Passing `{ profile }` spread it into the activity **args** (`{ cmd, profile }`), never setting `step.profile` — so the step fell to the default. `shell()` now takes `profile` and routes it to the step (env stays in args). The same footgun (a `profile` in opts leaking into args instead of overriding the step profile) is closed across `build`/`kubectlApply`/`helmInstall`/`waitForStack`/`gitlabPipeline` via a shared `takeProfile()` helper — each shortcut now accepts a profile override that actually takes.

2. **`argoSync` was missing** from the `ActivityStep["profile"]` union though it exists in `TEMPORAL_ACTIVITY_PROFILES`. Added.

3. **`loadProfiles()` imported the lexicon root index**, which pulls in the plugin, serializer, composites, and Op machinery — any of which could throw on load and make it silently return `{}`, dropping every profiled step to the 5m default while `--temporal` (reading the same table) kept the declared timeout. It now imports the side-effect-free `/config` module, so both executors read the same data.

The executor's per-step resolution (`profiles[step.profile] → startToCloseTimeout`) was already correct; these fixes make sure the profile actually reaches it.

## Tests
- Builder routing: `profile` sets the step and never leaks into args; opts override the shortcut defaults; `argoSync` accepted.
- Local executor: a step tagged with a non-default profile is honored end-to-end (a step that would time out under the default succeeds under `longInfra`).

## Validation
- `npx vitest run packages/core/src/op` → 59 passed
- `npx vitest run lexicons/temporal/src/op` → 71 passed
- `npx tsc --noEmit -p packages/core/tsconfig.json` → clean
- `eslint` changed files → clean
- Confirmed `@intentius/chant-lexicon-temporal/config` resolves and returns all five profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)