### PR TITLE
chant-v0.1.17

### DIFF
--- a/lexicons/aws/package.json
+++ b/lexicons/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-aws",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "AWS CloudFormation lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/azure/package.json
+++ b/lexicons/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-azure",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Azure lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/docker/package.json
+++ b/lexicons/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-docker",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Docker lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/gcp/package.json
+++ b/lexicons/gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-gcp",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Google Cloud lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/github/package.json
+++ b/lexicons/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-github",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "GitHub Actions lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/gitlab/package.json
+++ b/lexicons/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-gitlab",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "GitLab CI lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/helm/package.json
+++ b/lexicons/helm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-helm",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Helm chart lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/k8s/package.json
+++ b/lexicons/k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-k8s",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Kubernetes lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/lexicons/temporal/package.json
+++ b/lexicons/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-temporal",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Temporal lexicon for chant — server deployment, namespaces, search attributes, and schedules",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Declarative infrastructure-as-code toolkit — TypeScript on Node.js",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",


### PR DESCRIPTION
Release 0.1.17 — version bump for `@intentius/chant` + the 9 published lexicons (test-utils private, unchanged). After merge I'll tag `chant-v0.1.17` to trigger the OIDC `publish.yml`.

## Notable since 0.1.16
- **feat(cli)** `chant describe <component>` — read-only, offline projection of the effective resolved config for one named declarable or composite instance (#204).
- **feat** layered-configuration guide + `lexicons/k8s/examples/layered-config` (one composite, many environments via plain object spread) (#203).

🤖 Generated with [Claude Code](https://claude.com/claude-code)