### PR TITLE
feat(lint): environment-aware organizational policy as project-authored checks (#201)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -52,6 +52,7 @@ export default defineConfig({
 						{ label: 'Presets', slug: 'guide/presets' },
 						{ label: 'Layered Configuration', slug: 'guide/layered-configuration' },
 						{ label: 'Linting & Type-Checking', slug: 'guide/linting' },
+						{ label: 'Organizational Policy', slug: 'guide/organizational-policy' },
 						{ label: 'Building', slug: 'guide/building' },
 						{ label: 'Ops', slug: 'guide/ops' },
 						{ label: 'Local vs Temporal', slug: 'guide/local-vs-temporal' },

--- a/docs/src/content/docs/guide/organizational-policy.mdx
+++ b/docs/src/content/docs/guide/organizational-policy.mdx
@@ -1,0 +1,78 @@
+---
+title: Organizational Policy
+description: Enforce org-specific rules ("no public buckets in prod", "every workload has a cost-center tag") as project-authored, environment-aware checks.
+---
+
+import { Code } from '@astrojs/starlight/components';
+import policySrc from '../../../../../lexicons/k8s/examples/org-policy/policies/org.ts?raw';
+import configSrc from '../../../../../lexicons/k8s/examples/org-policy/chant.config.ts?raw';
+
+Lexicon lint answers "is this a coherent resource for its domain." It does not
+express **organizational policy** — "no public load balancers in prod," "every
+workload carries a cost-center tag," "instance types from this allowlist." Those
+are cross-cutting, org-specific, and often need to branch on environment.
+
+chant does not add a separate policy language for this. Organizational policy is
+**project-authored [post-synth checks](/chant/lexicon-authoring/post-synth-checks/),
+run by the existing engine, with the current environment in context** — the same
+`PostSynthCheck` shape lexicons ship as domain rules, authored by your org.
+
+## Writing a policy
+
+A policy reads the resolved resources and returns diagnostics. A diagnostic with
+`severity: "error"` fails `chant build` — that is the gate. The check receives
+`ctx.env`, so a rule can branch on the environment.
+
+<Code code={policySrc} lang="typescript" title="policies/org.ts" />
+
+`ORG-COST-CENTER` runs in every environment; `ORG-PROD-TLS` only fires when the
+build is for `prod`.
+
+## Registering it
+
+Add the policy file(s) to `lint.policies` in `chant.config.ts`. This is distinct
+from `lint.plugins` (declarative lint rules) by authorship and phase — policies
+reason about the **resolved** resources during build — but it is the same engine.
+
+<Code code={configSrc} lang="typescript" title="chant.config.ts" />
+
+## Running it
+
+Policy runs during `chant build`. Pass the environment with `--env` (or set
+`ownership.env` in the config):
+
+```bash
+chant build src                 # cost-center enforced; prod-only rules dormant
+chant build src --env dev       # same — ORG-PROD-TLS skipped
+chant build src --env prod      # ORG-PROD-TLS now enforced
+```
+
+For the example above, the `prod` build fails:
+
+```
+error: [policy:ORG-PROD-TLS] [storefront] Ingress "storefront" must terminate TLS in prod
+```
+
+Policy evaluates the **synthesized artifact**, offline — it never touches the
+cloud. Live checks are [`chant lifecycle`](/chant/cli/lifecycle/), not this.
+
+## Why not a separate engine
+
+chant already has the machinery: a [post-synth phase](/chant/lexicon-authoring/post-synth-checks/)
+that reasons about resolved resources, project-authored rule loading, and the
+[Op gate model](/chant/guide/ops/) for the apply side. A separate policy language
+(Rego/OPA-style) would duplicate the lint engine and break "TypeScript is the one
+language." Org policy is post-synth checks the org authors — nothing more.
+
+## Gating an apply
+
+Build-time policy fails fast, before anything is applied. Gating an *apply*
+through a policy pass — run the policy, then block or pause for a signed,
+audited override before `ApplyOp` — slots into the existing
+[gate / `onFailure`](/chant/guide/ops/) model and is tracked as a follow-on.
+
+## Try it
+
+The full example is
+[`lexicons/k8s/examples/org-policy`](https://github.com/INTENTIUS/chant/tree/main/lexicons/k8s/examples/org-policy)
+— it is exercised in CI (clean in dev, blocked in prod).

--- a/lexicons/k8s/examples/examples.test.ts
+++ b/lexicons/k8s/examples/examples.test.ts
@@ -1,6 +1,9 @@
-import { expect } from "vitest";
+import { describe, test, expect } from "vitest";
 import { describeAllExamples } from "@intentius/chant-test-utils/example-harness";
-import { k8sSerializer } from "@intentius/chant-lexicon-k8s";
+import { buildCommand } from "@intentius/chant/cli/commands/build";
+import { k8sSerializer, k8sPlugin } from "@intentius/chant-lexicon-k8s";
+import { resolve, join } from "path";
+import { tmpdir } from "os";
 
 describeAllExamples(
   {
@@ -78,3 +81,33 @@ describeAllExamples(
     },
   },
 );
+
+// ── org-policy: environment-aware organizational policy (#201) ──────────────
+// describeAllExamples (above) builds + lints the example like any other; this
+// block exercises the *policy enforcement*, which only runs via buildCommand
+// (it loads chant.config's `lint.policies`). The TLS policy is env-gated.
+
+describe("org-policy example — environment-aware organizational policy", () => {
+  const src = resolve(import.meta.dirname, "org-policy", "src");
+  const out = join(tmpdir(), "chant-org-policy.yaml");
+  const buildEnv = (env?: string) =>
+    buildCommand({ path: src, output: out, format: "yaml", serializers: [k8sSerializer], plugins: [k8sPlugin], env });
+
+  test("builds clean with no env and in dev (prod-only policy dormant)", async () => {
+    expect((await buildEnv(undefined)).success).toBe(true);
+    expect((await buildEnv("dev")).success).toBe(true);
+  });
+
+  test("fails in prod — ORG-PROD-TLS blocks the TLS-less ingress", async () => {
+    const r = await buildEnv("prod");
+    expect(r.success).toBe(false);
+    expect(r.errors.join("\n")).toContain("ORG-PROD-TLS");
+  });
+
+  test("cost-center policy is enforced in every environment (compliant here)", async () => {
+    // The workload carries the cost-center label, so ORG-COST-CENTER passes
+    // even with no env — proving the always-on policy ran and was satisfied.
+    const r = await buildEnv(undefined);
+    expect(r.errors.join("\n")).not.toContain("ORG-COST-CENTER");
+  });
+});

--- a/lexicons/k8s/examples/org-policy/.gitignore
+++ b/lexicons/k8s/examples/org-policy/.gitignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+.chant/
+k8s.yaml

--- a/lexicons/k8s/examples/org-policy/chant.config.ts
+++ b/lexicons/k8s/examples/org-policy/chant.config.ts
@@ -1,0 +1,11 @@
+import type { ChantConfig } from "@intentius/chant";
+
+// `lint.policies` registers project-authored organizational policy checks. They
+// run during `chant build` over the resolved resources, with `--env` in
+// context, and fail the build on violation. Distinct from `plugins` (declarative
+// lint rules) by authorship and phase — same engine.
+export default {
+  lexicons: ["k8s"],
+  ownership: { stack: "storefront" },
+  lint: { policies: ["policies/org.ts"] },
+} satisfies ChantConfig;

--- a/lexicons/k8s/examples/org-policy/package.json
+++ b/lexicons/k8s/examples/org-policy/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "k8s-org-policy-example",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "chant build src --lexicon k8s -o k8s.yaml",
+    "build:prod": "chant build src --lexicon k8s --env prod -o k8s.yaml",
+    "lint": "chant lint src"
+  },
+  "dependencies": {
+    "@intentius/chant": "*",
+    "@intentius/chant-lexicon-k8s": "*"
+  },
+  "devDependencies": {
+    "typescript": "*"
+  }
+}

--- a/lexicons/k8s/examples/org-policy/package.standalone.json
+++ b/lexicons/k8s/examples/org-policy/package.standalone.json
@@ -1,0 +1,18 @@
+{
+  "name": "k8s-org-policy-example",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "chant build src --lexicon k8s -o k8s.yaml",
+    "build:prod": "chant build src --lexicon k8s --env prod -o k8s.yaml",
+    "lint": "chant lint src"
+  },
+  "dependencies": {
+    "@intentius/chant": "^0.1.18",
+    "@intentius/chant-lexicon-k8s": "^0.1.18"
+  },
+  "devDependencies": {
+    "typescript": "^0.1.18"
+  }
+}

--- a/lexicons/k8s/examples/org-policy/policies/org.ts
+++ b/lexicons/k8s/examples/org-policy/policies/org.ts
@@ -1,0 +1,84 @@
+// Organizational policy — project-authored post-synth checks.
+//
+// These are the same `PostSynthCheck` shape lexicons ship as domain rules, but
+// authored by *your org* and registered via `lint.policies` in chant.config.ts.
+// They run during `chant build` over the resolved resources, with the current
+// `--env` in context, so a policy can branch on environment. A check returning
+// `severity: "error"` fails the build — the gate.
+import {
+  getPrimaryOutput,
+  type PostSynthCheck,
+  type PostSynthContext,
+  type PostSynthDiagnostic,
+} from "@intentius/chant/lint/post-synth";
+import { parseYAML } from "@intentius/chant/yaml";
+
+interface Manifest {
+  kind?: string;
+  metadata?: { name?: string; labels?: Record<string, string> };
+  spec?: { tls?: unknown[] };
+}
+
+/** Parse every lexicon's serialized output into flat Kubernetes manifests. */
+function manifests(ctx: PostSynthContext): Manifest[] {
+  const out: Manifest[] = [];
+  for (const [, output] of ctx.outputs) {
+    for (const doc of getPrimaryOutput(output).split(/\n---\n/)) {
+      const trimmed = doc.trim();
+      if (!trimmed) continue;
+      try {
+        const m = parseYAML(trimmed);
+        if (m && typeof m === "object") out.push(m as Manifest);
+      } catch {
+        // skip unparseable documents
+      }
+    }
+  }
+  return out;
+}
+
+const COST_CENTER = "acme.io/cost-center";
+
+/** Every workload must be attributable to a cost center — in every environment. */
+export const costCenterRequired: PostSynthCheck = {
+  id: "ORG-COST-CENTER",
+  description: "every Deployment must carry an acme.io/cost-center label",
+  check(ctx): PostSynthDiagnostic[] {
+    const diags: PostSynthDiagnostic[] = [];
+    for (const m of manifests(ctx)) {
+      if (m.kind !== "Deployment") continue;
+      if (!m.metadata?.labels?.[COST_CENTER]) {
+        diags.push({
+          checkId: "ORG-COST-CENTER",
+          severity: "error",
+          message: `Deployment "${m.metadata?.name}" is missing the ${COST_CENTER} label`,
+          entity: m.metadata?.name,
+        });
+      }
+    }
+    return diags;
+  },
+};
+
+/** Production ingress must terminate TLS. Lower environments may skip it. */
+export const tlsRequiredInProd: PostSynthCheck = {
+  id: "ORG-PROD-TLS",
+  description: "in prod, every Ingress must terminate TLS",
+  check(ctx): PostSynthDiagnostic[] {
+    if (ctx.env !== "prod") return []; // the environment-aware branch
+    const diags: PostSynthDiagnostic[] = [];
+    for (const m of manifests(ctx)) {
+      if (m.kind !== "Ingress") continue;
+      const tls = m.spec?.tls;
+      if (!Array.isArray(tls) || tls.length === 0) {
+        diags.push({
+          checkId: "ORG-PROD-TLS",
+          severity: "error",
+          message: `Ingress "${m.metadata?.name}" must terminate TLS in prod`,
+          entity: m.metadata?.name,
+        });
+      }
+    }
+    return diags;
+  },
+};

--- a/lexicons/k8s/examples/org-policy/src/infra.ts
+++ b/lexicons/k8s/examples/org-policy/src/infra.ts
@@ -1,0 +1,23 @@
+// A web app, attributed to a cost center (satisfies ORG-COST-CENTER), exposed
+// via an Ingress with NO TLS. That builds fine in dev/staging, but
+// ORG-PROD-TLS rejects it under `chant build --env prod`.
+import { WebApp } from "@intentius/chant-lexicon-k8s";
+
+const app = WebApp({
+  name: "storefront",
+  image: "ghcr.io/acme/storefront:1.4.0",
+  port: 8080,
+  replicas: 2,
+  ingressHost: "storefront.acme.example",
+  // The cost-center label every workload must carry (org policy).
+  labels: { "acme.io/cost-center": "retail-web" },
+  securityContext: {
+    runAsNonRoot: true,
+    runAsUser: 1000,
+    readOnlyRootFilesystem: true,
+    allowPrivilegeEscalation: false,
+    capabilities: { drop: ["ALL"] },
+  },
+});
+
+export const { deployment, service, ingress } = app;

--- a/lexicons/k8s/examples/org-policy/tsconfig.json
+++ b/lexicons/k8s/examples/org-policy/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/core/src/cli/commands/build.ts
+++ b/packages/core/src/cli/commands/build.ts
@@ -2,7 +2,7 @@ import { build } from "../../build";
 import { loadChantConfig, resolveOwnershipMarker } from "../../config";
 import type { Serializer, SerializerResult } from "../../serializer";
 import type { LexiconPlugin } from "../../lexicon";
-import { runPostSynthChecks } from "../../lint/post-synth";
+import { runPostSynthChecks, isPostSynthCheck } from "../../lint/post-synth";
 import type { PostSynthCheck } from "../../lint/post-synth";
 import { sortedJsonReplacer } from "../../utils";
 import { formatError, formatWarning, formatSuccess, formatBold, formatInfo } from "../format";
@@ -26,6 +26,32 @@ export interface BuildOptions {
   plugins?: LexiconPlugin[];
   /** Print summary to stderr */
   verbose?: boolean;
+  /**
+   * Environment/stack to evaluate policy against (`--env`). Falls back to the
+   * project's `ownership.env`. Passed into post-synth checks so organizational
+   * policy can branch on environment.
+   */
+  env?: string;
+}
+
+/** Load project-authored policy checks from `lint.policies` file paths. */
+async function loadPolicyChecks(paths: string[], configDir: string): Promise<PostSynthCheck[]> {
+  const checks: PostSynthCheck[] = [];
+  for (const p of paths) {
+    const resolved = resolve(configDir, p);
+    let mod: Record<string, unknown>;
+    try {
+      mod = (await import(resolved)) as Record<string, unknown>;
+    } catch (err) {
+      throw new Error(
+        `Failed to load policy "${p}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    for (const value of Object.values(mod)) {
+      if (isPostSynthCheck(value)) checks.push(value);
+    }
+  }
+  return checks;
 }
 
 /**
@@ -56,10 +82,20 @@ export async function buildCommand(options: BuildOptions): Promise<BuildResult> 
 
   // Resolve opt-in ownership marking from project config (search the infra dir
   // and its parent, where chant.config.* usually lives).
-  const { config } = await loadChantConfig(infraPath).then((r) =>
+  const loaded = await loadChantConfig(infraPath).then((r) =>
     r.configPath ? r : loadChantConfig(dirname(infraPath)),
   );
+  const config = loaded.config;
   const ownership = resolveOwnershipMarker(config);
+
+  // Environment for policy evaluation: explicit --env wins, else ownership.env.
+  const env = options.env ?? config.ownership?.env;
+  // Project-authored organizational policy checks (lint.policies), run over the
+  // resolved resources during build. Resolve paths relative to the config dir.
+  const configDir = loaded.configPath ? dirname(loaded.configPath) : infraPath;
+  const policyChecks = config.lint?.policies?.length
+    ? await loadPolicyChecks(config.lint.policies, configDir)
+    : [];
 
   // Run the build
   const result = await build(infraPath, options.serializers, undefined, { ownership });
@@ -96,7 +132,7 @@ export async function buildCommand(options: BuildOptions): Promise<BuildResult> 
       }
 
       const scopedResult = { ...result, outputs: scopedOutputs };
-      const postDiags = runPostSynthChecks(checks, scopedResult);
+      const postDiags = runPostSynthChecks(checks, scopedResult, env);
       for (const diag of postDiags) {
         const prefix = diag.entity ? `[${diag.entity}] ` : "";
         const lexiconSuffix = diag.lexicon ? ` (${diag.lexicon})` : "";
@@ -105,6 +141,19 @@ export async function buildCommand(options: BuildOptions): Promise<BuildResult> 
         } else {
           warnings.push(formatWarning({ message: `${prefix}${diag.message}${lexiconSuffix}` }));
         }
+      }
+    }
+
+    // Project-authored organizational policy — cross-cutting, so it sees every
+    // lexicon's output at once (not scoped per-plugin), with the current env.
+    if (policyChecks.length > 0) {
+      const policyDiags = runPostSynthChecks(policyChecks, result, env);
+      for (const diag of policyDiags) {
+        const prefix = diag.entity ? `[${diag.entity}] ` : "";
+        const where = diag.lexicon ? ` (${diag.lexicon})` : "";
+        const msg = `[policy:${diag.checkId}] ${prefix}${diag.message}${where}`;
+        if (diag.severity === "error") errors.push(formatError({ message: msg }));
+        else warnings.push(formatWarning({ message: msg }));
       }
     }
   }

--- a/packages/core/src/cli/handlers/build.ts
+++ b/packages/core/src/cli/handlers/build.ts
@@ -44,6 +44,7 @@ export async function runBuild(ctx: CommandContext): Promise<number> {
     serializers,
     plugins,
     verbose: args.verbose,
+    env: args.env,
   });
 
   // When --lexicon filters to a subset, suppress "No serializer" warnings for excluded lexicons

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -51,6 +51,7 @@ export function parseArgs(args: string[]): ParsedArgs {
     reportFile: undefined,
     skill: undefined,
     src: undefined,
+    env: undefined,
   };
 
   let i = 0;
@@ -115,6 +116,8 @@ export function parseArgs(args: string[]): ParsedArgs {
       result.skill = args[++i];
     } else if (arg === "--src") {
       result.src = args[++i];
+    } else if (arg === "--env") {
+      result.env = args[++i];
     } else if (arg === "--local") {
       result.local = true;
     } else if (arg === "--temporal") {
@@ -201,6 +204,7 @@ Options:
                         - list: text (default) or json
                         - lint: stylish (default), json, or sarif
   -d, --lexicon <name>  Build only the specified lexicon (e.g. aws, gitlab)
+      --env <name>      Environment for organizational policy evaluation (build)
   -t, --template <name> Init template (e.g. node-pipeline, docker-build)
   --skill <name>        Init: install only this skill from the lexicon
   --fix                 Auto-fix fixable issues (lint command)

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -53,6 +53,8 @@ export interface ParsedArgs {
   verbatim?: boolean;
   /** `chant lifecycle … --src <dir>` — build root override for lifecycle commands */
   src?: string;
+  /** `chant build --env <name>` — environment for organizational policy evaluation */
+  env?: string;
 }
 
 /**

--- a/packages/core/src/lint/config.ts
+++ b/packages/core/src/lint/config.ts
@@ -29,6 +29,7 @@ export const LintConfigSchema = z.object({
     rules: z.record(z.string(), RuleConfigSchema),
   })).optional(),
   plugins: z.array(z.string()).optional(),
+  policies: z.array(z.string()).optional(),
 });
 
 /**
@@ -149,6 +150,14 @@ export interface LintConfig {
   overrides?: LintOverride[];
   /** Array of plugin file paths to load custom rules from (project-local, not inherited) */
   plugins?: string[];
+  /**
+   * Array of file paths to load project-authored organizational policy checks
+   * from — each exporting one or more {@link PostSynthCheck} objects. They run
+   * during `chant build` over the resolved resources, with the current `env` in
+   * context. Distinct from `plugins` (declarative lint rules) by authorship and
+   * phase; same engine.
+   */
+  policies?: string[];
 }
 
 /**

--- a/packages/core/src/lint/post-synth.test.ts
+++ b/packages/core/src/lint/post-synth.test.ts
@@ -111,3 +111,33 @@ describe("post-synth checks", () => {
     expect(diags).toHaveLength(0);
   });
 });
+
+describe("environment-aware checks (#201)", () => {
+  // A policy that only fires in prod — the new env-branching primitive.
+  const prodOnly: PostSynthCheck = {
+    id: "ENV-PROD",
+    description: "fires only in prod",
+    check(ctx) {
+      return ctx.env === "prod"
+        ? [{ checkId: "ENV-PROD", severity: "error", message: "blocked in prod" }]
+        : [];
+    },
+  };
+
+  test("env is threaded into the context", () => {
+    expect(runPostSynthChecks([prodOnly], createBuildResult(), "prod")).toHaveLength(1);
+    expect(runPostSynthChecks([prodOnly], createBuildResult(), "dev")).toHaveLength(0);
+    expect(runPostSynthChecks([prodOnly], createBuildResult())).toHaveLength(0); // env undefined
+  });
+});
+
+describe("isPostSynthCheck", () => {
+  test("accepts a well-formed check and rejects others", async () => {
+    const { isPostSynthCheck } = await import("./post-synth");
+    expect(isPostSynthCheck({ id: "X", description: "d", check: () => [] })).toBe(true);
+    expect(isPostSynthCheck({ id: "X", description: "d" })).toBe(false); // no check fn
+    expect(isPostSynthCheck({ check: () => [] })).toBe(false); // no id/description
+    expect(isPostSynthCheck(null)).toBe(false);
+    expect(isPostSynthCheck("nope")).toBe(false);
+  });
+});

--- a/packages/core/src/lint/post-synth.ts
+++ b/packages/core/src/lint/post-synth.ts
@@ -10,6 +10,12 @@ export interface PostSynthContext {
   outputs: Map<string, string | SerializerResult>;
   /** Map of entity name to Declarable entity */
   entities: Map<string, Declarable>;
+  /**
+   * The environment/stack being built, if known (from `--env` or the project's
+   * `ownership.env`). Lets an organizational policy branch on environment —
+   * e.g. "no public buckets in prod". Undefined when no environment is set.
+   */
+  env?: string;
   /** Raw build result object */
   buildResult: {
     outputs: Map<string, string | SerializerResult>;
@@ -44,7 +50,9 @@ export interface PostSynthDiagnostic {
 }
 
 /**
- * A post-synthesis check that validates build output.
+ * A post-synthesis check that validates build output. Lexicons ship these as
+ * domain rules; projects author them as organizational policy (see the
+ * `lint.policies` config and the Organizational Policy guide).
  */
 export interface PostSynthCheck {
   /** Unique identifier for this check */
@@ -55,16 +63,30 @@ export interface PostSynthCheck {
   check(ctx: PostSynthContext): PostSynthDiagnostic[];
 }
 
+/** Structural type guard — used to collect project-authored policy checks. */
+export function isPostSynthCheck(value: unknown): value is PostSynthCheck {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as PostSynthCheck).id === "string" &&
+    typeof (value as PostSynthCheck).description === "string" &&
+    typeof (value as PostSynthCheck).check === "function"
+  );
+}
+
 /**
- * Run a set of post-synthesis checks against a build result.
+ * Run a set of post-synthesis checks against a build result. `env` is threaded
+ * into the context so a check can branch on the current environment/stack.
  */
 export function runPostSynthChecks(
   checks: PostSynthCheck[],
   buildResult: PostSynthContext["buildResult"],
+  env?: string,
 ): PostSynthDiagnostic[] {
   const ctx: PostSynthContext = {
     outputs: buildResult.outputs,
     entities: buildResult.entities,
+    env,
     buildResult,
   };
 


### PR DESCRIPTION
Implements the **core of #201 (deliverable A)** — organizational policy as project-authored, environment-aware post-synth checks, run by the existing lint engine. **Not a new policy language.** The apply-gate Op step (T4) is a tracked follow-up.

## T1 — audit (the two gaps)
- `PostSynthContext` carried no env/stack — so a check couldn't branch on environment.
- Projects could author declarative `LintRule`s (`lint.plugins`) but **not** post-synth checks — `build` only ran lexicon `plugin.postSynthChecks()`.

Decision: extend lint (no separate engine) — chant already has the post-synth phase, project rule loading, and the Op gate model.

## T2 — environment context
- `PostSynthContext` gains `env`; `runPostSynthChecks(checks, result, env)` threads it.
- `chant build --env <name>` sets it (falls back to `ownership.env`). A policy branches on it: `if (ctx.env !== "prod") return []`.

## T3 — project policy authoring
- New `lint.policies` config: file paths exporting `PostSynthCheck` objects (collected via `isPostSynthCheck`).
- `buildCommand` loads them and runs them **cross-cutting** over every lexicon's output, with `env`. An **error-severity** diagnostic fails the build — the gate.

## T5 — example + guide
- `lexicons/k8s/examples/org-policy`: a compliant workload + a policy pack — `ORG-COST-CENTER` (all envs) and `ORG-PROD-TLS` (prod-only). Builds clean in dev; `chant build --env prod` **fails** on the TLS-less ingress:
  ```
  error: [policy:ORG-PROD-TLS] [storefront] Ingress "storefront" must terminate TLS in prod
  ```
- Guide: `guide/organizational-policy`.

## Deferred (T4)
The apply-gate Op step (run the policy pack and block / pause for a signed, audited override before `ApplyOp`) is the apply-side extension — more speculative (override audit). Tracked as a follow-up on #201; build-time enforcement lands here.

## Validation
- `npx vitest run packages/core/src/lint packages/core/src/cli lexicons/k8s/examples/examples.test.ts` → 804 passed (new: env threading + `isPostSynthCheck`; policy enforcement end-to-end — clean no-env/dev, fails prod with `ORG-PROD-TLS`, cost-center satisfied).
- `tsc` clean; `eslint` clean; `npm --prefix docs run build` → 115 pages.

Refs #201, #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)