### PR TITLE
feat: expose cross-stack apply-ordering — chant graph --stacks (#200)

### DIFF
--- a/docs/src/content/docs/cli/graph.mdx
+++ b/docs/src/content/docs/cli/graph.mdx
@@ -6,7 +6,7 @@ description: Print the Op dependency graph
 ## Synopsis
 
 ```
-chant graph [path]
+chant graph [path] [--stacks] [--json]
 ```
 
 ## Description
@@ -14,6 +14,26 @@ chant graph [path]
 `chant graph` discovers all `*.op.ts` files under the given path and prints the dependency edges declared via the `depends` field of each Op.
 
 If no Ops declare dependencies the output is `No Op dependencies`. If no `*.op.ts` files are found the output is `No Ops found`.
+
+## `--stacks` — cross-stack apply order
+
+`chant graph --stacks [path]` renders the **cross-stack apply-ordering graph** instead of the Op graph. chant resolves cross-lexicon references during build (a resource in one stack referencing an attribute of a resource in another) and already knows the order — a stack that *exports* a value must apply before the stack that *imports* it. `--stacks` surfaces that as tool-agnostic data for your orchestrator (CI, an Op, a platform tool). chant **exposes** the order; it does not drive the apply.
+
+```bash
+chant graph --stacks ./infra
+chant graph --stacks ./infra --json
+```
+
+The output is the stacks, their dependency edges (consumer → producer), a topological apply **order**, and **waves** — levels whose stacks have no inter-dependency and may apply concurrently. `--json` emits the full graph (`nodes`, `edges`, `order`, `waves`, `cycles`). A dependency cycle is reported and exits non-zero.
+
+```
+Apply order (waves apply top-to-bottom; a wave's stacks are parallel-safe):
+  1. aws
+  2. k8s
+
+Dependencies (consumer → producer):
+  k8s → aws
+```
 
 ## Usage
 
@@ -41,7 +61,7 @@ The format is `<dependency> → <dependent>`, meaning the left Op must complete 
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
-| 1 | Discovery errors |
+| 1 | Discovery errors, or (with `--stacks`) a dependency cycle |
 
 ## See Also
 

--- a/packages/core/src/build.test.ts
+++ b/packages/core/src/build.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { build, partitionByLexicon, detectCrossLexiconRefs, collectLexiconOutputs } from "./build";
+import { build, partitionByLexicon, detectCrossLexiconRefs, collectLexiconOutputs, computeStackGraph } from "./build";
 import { output } from "./lexicon-output";
 import { AttrRef } from "./attrref";
 import { INTRINSIC_MARKER } from "./intrinsic";
@@ -460,5 +460,52 @@ describe("detectCrossLexiconRefs", () => {
     const detected = detectCrossLexiconRefs(entities);
     expect(detected).toHaveLength(1);
     expect(detected[0].outputName).toBe("dataBucket_Endpoint");
+  });
+});
+
+describe("computeStackGraph (#200 — cross-stack apply ordering)", () => {
+  const ent = (lexicon: string, props: Record<string, unknown> = {}): Declarable =>
+    ({ lexicon, entityType: `${lexicon}::X`, [DECLARABLE_MARKER]: true, props }) as unknown as Declarable;
+
+  test("infers a consumer→producer edge from a cross-lexicon AttrRef", () => {
+    const vpc = ent("aws");
+    const svc = ent("k8s", { vpcId: new AttrRef(vpc, "id") });
+    const g = computeStackGraph(new Map([["vpc", vpc], ["svc", svc]]), ["aws", "k8s"]);
+
+    expect(g.edges).toEqual([{ from: "k8s", to: "aws" }]);
+    expect(g.order).toEqual(["aws", "k8s"]); // producer before consumer
+    expect(g.waves).toEqual([["aws"], ["k8s"]]); // separate waves — ordered
+    expect(g.cycles).toEqual([]);
+  });
+
+  test("independent stacks share a wave (parallel-safe)", () => {
+    const g = computeStackGraph(new Map([["a", ent("aws")], ["b", ent("gcp")]]), ["aws", "gcp"]);
+    expect(g.edges).toEqual([]);
+    expect(g.waves).toEqual([["aws", "gcp"]]); // one wave — no inter-dependency
+  });
+
+  test("reports a dependency cycle", () => {
+    const a = ent("x");
+    const b = ent("y", { ref: new AttrRef(a, "out") });
+    // close the loop: a references b
+    (a as unknown as { props: Record<string, unknown> }).props = { ref: new AttrRef(b, "out") };
+    const g = computeStackGraph(new Map([["a", a], ["b", b]]), ["x", "y"]);
+
+    expect(g.edges).toEqual(expect.arrayContaining([{ from: "x", to: "y" }, { from: "y", to: "x" }]));
+    expect(g.cycles).toEqual([["x", "y"]]);
+    expect(g.order).toEqual([]); // nothing is orderable inside a cycle
+  });
+
+  test("a diamond resolves into three waves", () => {
+    // base ← (left, right) ← top
+    const base = ent("base");
+    const left = ent("left", { b: new AttrRef(base, "id") });
+    const right = ent("right", { b: new AttrRef(base, "id") });
+    const top = ent("top", { l: new AttrRef(left, "id"), r: new AttrRef(right, "id") });
+    const g = computeStackGraph(
+      new Map([["base", base], ["left", left], ["right", right], ["top", top]]),
+      ["base", "left", "right", "top"],
+    );
+    expect(g.waves).toEqual([["base"], ["left", "right"], ["top"]]);
   });
 });

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -20,6 +20,115 @@ export interface BuildManifest {
     { source: string; entity: string; attribute: string }
   >;
   deployOrder: string[];
+  /** Cross-stack apply-ordering graph (see {@link computeStackGraph}). */
+  stackGraph: StackGraph;
+}
+
+/**
+ * The cross-stack (cross-lexicon) apply-ordering graph chant already computes
+ * while resolving cross-lexicon references — surfaced as tool-agnostic data for
+ * an orchestrator to consume. chant exposes the order; it does not drive the
+ * apply.
+ */
+export interface StackGraph {
+  /** Stacks (lexicon partitions) in the build. */
+  nodes: string[];
+  /**
+   * Consumer→producer edges: `from` imports a value `to` exports, so `to` must
+   * apply before `from`. Inferred from cross-lexicon references.
+   */
+  edges: Array<{ from: string; to: string }>;
+  /** A flat applicable sequence — every producer before its consumers. */
+  order: string[];
+  /**
+   * Levels: stacks in the same wave have no inter-dependency and may apply
+   * concurrently. `order` flattened with parallelism made explicit.
+   */
+  waves: string[][];
+  /** Dependency cycles, if any (each a list of stacks). Normally empty. */
+  cycles: string[][];
+}
+
+/**
+ * Compute the cross-stack apply-ordering graph from resolved entities. Edges are
+ * inferred from cross-lexicon attribute references (a resource in lexicon A
+ * referencing an attribute of a resource in lexicon B ⇒ A depends on B). Returns
+ * the edge set plus a topological order, parallel-safe waves, and any cycles.
+ */
+export function computeStackGraph(
+  entities: Map<string, Declarable>,
+  lexiconNames: string[],
+): StackGraph {
+  const edges: Array<{ from: string; to: string }> = [];
+  const edgeSet = new Set<string>();
+  const addEdge = (from: string, to: string): void => {
+    if (from === to) return;
+    const key = `${from}\0${to}`;
+    if (edgeSet.has(key)) return;
+    edgeSet.add(key);
+    edges.push({ from, to });
+  };
+
+  const walk = (value: unknown, consumer: string, visited: Set<unknown>): void => {
+    if (value === null || value === undefined || typeof value !== "object") return;
+    if (visited.has(value)) return;
+    visited.add(value);
+    if (value instanceof AttrRef) {
+      const parent = value.parent.deref();
+      const producer = parent ? (parent as Record<string, unknown>).lexicon : undefined;
+      if (typeof producer === "string" && producer !== consumer) addEdge(consumer, producer);
+      return;
+    }
+    if (isLexiconOutput(value)) return;
+    if (Array.isArray(value)) {
+      for (const item of value) walk(item, consumer, visited);
+      return;
+    }
+    for (const val of Object.values(value as Record<string, unknown>)) walk(val, consumer, visited);
+  };
+
+  for (const [, entity] of entities) {
+    const consumer = entity.lexicon;
+    const visited = new Set<unknown>();
+    for (const val of Object.values(entity as unknown as Record<string, unknown>)) {
+      walk(val, consumer, visited);
+    }
+    if ("props" in entity && typeof entity.props === "object" && entity.props !== null) {
+      walk(entity.props, consumer, visited);
+    }
+  }
+
+  // Dependency map: node → producers it depends on.
+  const nodes = lexiconNames.length
+    ? [...lexiconNames]
+    : [...new Set([...entities.values()].map((e) => e.lexicon))];
+  const deps = new Map<string, Set<string>>();
+  for (const n of nodes) deps.set(n, new Set());
+  for (const { from, to } of edges) {
+    if (!deps.has(from)) deps.set(from, new Set());
+    if (!deps.has(to)) deps.set(to, new Set());
+    deps.get(from)!.add(to);
+  }
+
+  // Kahn layering: a node is ready once every producer it depends on is placed.
+  const remaining = new Set(deps.keys());
+  const waves: string[][] = [];
+  const order: string[] = [];
+  while (remaining.size > 0) {
+    const wave = [...remaining]
+      .filter((n) => [...deps.get(n)!].every((d) => !remaining.has(d)))
+      .sort();
+    if (wave.length === 0) break; // remaining nodes form a cycle
+    for (const n of wave) {
+      remaining.delete(n);
+      order.push(n);
+    }
+    waves.push(wave);
+  }
+  const cycles: string[][] = remaining.size > 0 ? [[...remaining].sort()] : [];
+
+  edges.sort((a, b) => `${a.from}\0${a.to}`.localeCompare(`${b.from}\0${b.to}`));
+  return { nodes: [...nodes].sort(), edges, order, waves, cycles };
 }
 
 /**
@@ -288,7 +397,8 @@ function computeDeployOrder(
  */
 function generateManifest(
   lexiconNames: string[],
-  lexiconOutputs: LexiconOutput[]
+  lexiconOutputs: LexiconOutput[],
+  entities: Map<string, Declarable>
 ): BuildManifest {
   const outputsRecord: Record<
     string,
@@ -307,6 +417,7 @@ function generateManifest(
     lexicons: lexiconNames,
     outputs: outputsRecord,
     deployOrder: computeDeployOrder(lexiconNames, lexiconOutputs),
+    stackGraph: computeStackGraph(entities, lexiconNames),
   };
 }
 
@@ -453,7 +564,7 @@ export async function build(
 
   // Step 8: Generate manifest
   const lexiconNames = Array.from(partitions.keys());
-  const manifest = generateManifest(lexiconNames, lexiconOutputs);
+  const manifest = generateManifest(lexiconNames, lexiconOutputs, discoveryResult.entities);
 
   return {
     outputs,

--- a/packages/core/src/cli/handlers/graph.ts
+++ b/packages/core/src/cli/handlers/graph.ts
@@ -1,8 +1,21 @@
+import { resolve } from "node:path";
 import { discoverOps } from "../../op/discover";
-import { formatError } from "../format";
+import { discover } from "../../discovery/index";
+import { partitionByLexicon, computeStackGraph } from "../../build";
+import { formatError, formatWarning, formatBold } from "../format";
 import type { CommandContext } from "../registry";
 
-export async function runGraph(_ctx: CommandContext): Promise<number> {
+/**
+ * `chant graph` — the Op dependency graph by default; `--stacks` renders the
+ * cross-stack apply-ordering graph (edges, order, waves) chant computes from
+ * cross-lexicon references.
+ */
+export async function runGraph(ctx: CommandContext): Promise<number> {
+  if (ctx.args.stacks) return runStackGraph(ctx);
+  return runOpGraph();
+}
+
+async function runOpGraph(): Promise<number> {
   const { ops, errors } = await discoverOps();
   for (const err of errors) console.error(formatError({ message: err }));
 
@@ -19,5 +32,45 @@ export async function runGraph(_ctx: CommandContext): Promise<number> {
     }
   }
   if (!hasEdges) console.log("No Op dependencies");
+  return 0;
+}
+
+async function runStackGraph(ctx: CommandContext): Promise<number> {
+  const projectPath = resolve(ctx.args.path === "." ? "." : ctx.args.path);
+  const result = await discover(projectPath);
+  if (result.errors.length > 0) {
+    for (const e of result.errors) console.error(formatError({ message: e.message }));
+    return 1;
+  }
+
+  const lexicons = [...partitionByLexicon(result.entities).keys()];
+  const graph = computeStackGraph(result.entities, lexicons);
+
+  if (ctx.args.json) {
+    console.log(JSON.stringify(graph, null, 2));
+    return graph.cycles.length > 0 ? 1 : 0;
+  }
+
+  if (graph.nodes.length === 0) {
+    console.log("No stacks found");
+    return 0;
+  }
+
+  console.log(formatBold("Apply order (waves apply top-to-bottom; a wave's stacks are parallel-safe):"));
+  graph.waves.forEach((wave, i) => console.log(`  ${i + 1}. ${wave.join(", ")}`));
+
+  if (graph.edges.length > 0) {
+    console.log(formatBold("\nDependencies (consumer → producer):"));
+    for (const { from, to } of graph.edges) console.log(`  ${from} → ${to}`);
+  } else {
+    console.log("\nNo cross-stack dependencies — all stacks are independent.");
+  }
+
+  if (graph.cycles.length > 0) {
+    for (const cycle of graph.cycles) {
+      console.error(formatWarning({ message: `Dependency cycle among stacks: ${cycle.join(" ↔ ")}` }));
+    }
+    return 1;
+  }
   return 0;
 }

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -118,6 +118,8 @@ export function parseArgs(args: string[]): ParsedArgs {
       result.src = args[++i];
     } else if (arg === "--env") {
       result.env = args[++i];
+    } else if (arg === "--stacks") {
+      result.stacks = true;
     } else if (arg === "--local") {
       result.local = true;
     } else if (arg === "--temporal") {
@@ -172,7 +174,7 @@ Ops:
   run cancel <name>     Cancel the active workflow run (requires --force)
   run log <name>        Show run history for an Op
 
-  graph                 Show Op dependency graph
+  graph                 Show Op dependency graph (--stacks for cross-stack order)
 
 Lifecycle (alias: lc):
   lifecycle snapshot <env>  Query API, save metadata to orphan branch

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -55,6 +55,8 @@ export interface ParsedArgs {
   src?: string;
   /** `chant build --env <name>` — environment for organizational policy evaluation */
   env?: string;
+  /** `chant graph --stacks` — render the cross-stack apply-ordering graph */
+  stacks?: boolean;
 }
 
 /**


### PR DESCRIPTION
chant already computes cross-lexicon ordering while resolving cross-stack references — it just never surfaced it. This exposes it as **tool-agnostic data** for an orchestrator (CI, an Op, a platform tool). chant exposes the order; it does **not** drive the apply (the authoritative role it declines).

## What's added
- **`computeStackGraph(entities, lexicons)`** — infers precise **consumer→producer edges** from cross-lexicon `AttrRef`s (a resource in lexicon A referencing an attribute of one in B ⇒ A depends on B), and derives a topological **`order`**, parallel-safe **`waves`** (levels with no inter-dependency), and a **cycle report**. The existing `deployOrder` over-approximated (every lexicon depended on any producer); it's kept for back-compat, `stackGraph` is the precise data.
- Surfaced on **`BuildManifest.stackGraph`**.
- **`chant graph --stacks [path] [--json]`** — human apply-order/waves view, or the full `{ nodes, edges, order, waves, cycles }` as JSON. A cycle is reported and exits non-zero. The default Op-graph view is unchanged.

## Scope notes (flagged)
- **No on-disk manifest.** The issue suggested extending `manifest.json`, but there is **no on-disk build manifest** today (`manifest.json` is a lexicon-*package* artifact). Inventing one is a separate, larger decision, so v1 exposes the graph via the `graph` command + the in-memory `BuildManifest`. The data shape is the same; only the delivery surface differs.
- **#199 contract:** this is the producer of the cross-stack graph #199 will consume — both edge directions derive from the same edge set.
- **Explicit `dependsOn` (T4):** deferred — inferred edges suffice until a concrete implicit-ordering case surfaces.

## Validation
- `npx vitest run packages/core/src` → 1609 passed (new: `computeStackGraph` — single edge, independent stacks share a wave, a cycle, a diamond → three waves).
- `tsc` clean; `eslint` clean; `npm --prefix docs run build` → 115 pages.
- Smoke: `chant graph --stacks` (text + `--json`) on `k8s-eks-microservice`; default `chant graph` (Op) unchanged.

Closes #200
Refs #198, #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)