### PR TITLE
feat(lifecycle): chant lifecycle affected — selective change-set scoping (#199)

### DIFF
--- a/docs/src/content/docs/cli/lifecycle.mdx
+++ b/docs/src/content/docs/cli/lifecycle.mdx
@@ -10,6 +10,7 @@ chant lifecycle snapshot <env> [lexicon] [--src <dir>]
 chant lifecycle show <env>
 chant lifecycle diff <env> [--live] [--src <dir>]
 chant lifecycle plan <env> [--json] [--owned] [--src <dir>]
+chant lifecycle affected --base <ref> [--head <ref>] [--include-dependents] [--json]
 chant lifecycle log [env]
 ```
 
@@ -166,6 +167,43 @@ hint:  Pull and retry: `git fetch origin chant/lifecycle:chant/lifecycle` && `ch
 ```
 
 Pull the remote ref and re-run — the first snapshot is preserved, the second proceeds against the updated baseline.
+
+### `lifecycle affected`
+
+In a multi-stack project, answer "which stacks does this change affect?" without planning everything. Read-only — it returns the set; fanning `lifecycle plan` / an `ApplyOp` over it is an [Op](/chant/guide/ops/) you compose.
+
+```bash
+chant lifecycle affected --base origin/main
+chant lifecycle affected --base origin/main --include-dependents --json
+```
+
+"Affected" is two distinct things, because chant serializes cross-stack references symbolically:
+
+- **Directly changed** — the stack's built artifact differs between base and head. Caught by **artifact diff** over deterministic builds, so a comment-only or refactor-with-no-output-change edit is correctly excluded.
+- **Operationally affected (dependents)** — a stack whose own artifact is *unchanged* but which consumes an upstream export whose value changed. Its bytes don't move, yet it may need re-apply. Caught by walking the [cross-stack graph](/chant/cli/graph/) (`chant graph --stacks`) from the directly-changed set, with `--include-dependents`.
+
+A stack whose inputs come from outside synthesis (deploy-time parameters) cannot be judged from a source diff — it is reported as **indeterminate** ("external-input — cannot confirm from source"), not silently included or excluded.
+
+Builds are obtained lazily: **head** is the in-place build of the working tree (or `--head <ref>`); **base** is built from `--base <ref>` in a single throwaway worktree (auto-removed), or skipped entirely if you supply pre-built sources via the library. Because `build` is deterministic, a cached or supplied base is as trustworthy as a rebuild.
+
+`--json` emits `{ changed, dependents, indeterminate }`. The same logic is exported as `affectedStacks()` for programmatic use.
+
+**Composing it.** chant returns the set; you drive the fan-out. For example, plan only the affected stacks in CI:
+
+```bash
+chant lifecycle affected --base "$BASE_SHA" --include-dependents --json \
+  | jq -r '.changed + .dependents | unique[]' \
+  | while read stack; do chant lifecycle plan "$ENV" "$stack"; done
+```
+
+The same shape works from an Op you write — `affected` is the primitive; the fan-out (plan, gate, apply) is yours to compose. chant never blindly applies the set.
+
+| Flag | Meaning |
+|---|---|
+| `--base <ref>` | Base git ref to diff against (required). |
+| `--head <ref>` | Head ref (default: the working tree). |
+| `--include-dependents` | Add downstream consumers of changed stacks. |
+| `--json` | Emit the result as JSON. |
 
 ### `lifecycle log [env]`
 

--- a/packages/core/src/cli/handlers/lifecycle.ts
+++ b/packages/core/src/cli/handlers/lifecycle.ts
@@ -5,6 +5,7 @@ import { readSnapshot, readEnvironmentSnapshots, listSnapshots, fetchLifecycle, 
 import { computeBuildDigest, diffDigests } from "../../lifecycle/digest";
 import { diffLive, diffLiveArtifacts, type LiveDiffResult, type LiveArtifactDiffResult } from "../../lifecycle/live-diff";
 import { buildChangeSet, renderChangeSet, type ChangeSet } from "../../lifecycle/change-set";
+import { affectedStacks } from "../../lifecycle/affected";
 import { loadChantConfig } from "../../config";
 import { formatError, formatWarning, formatSuccess, formatBold } from "../format";
 import type { CommandContext } from "../registry";
@@ -575,4 +576,60 @@ function printSnapshotTable(snapshot: LifecycleSnapshot): void {
       meta.status
     );
   }
+}
+
+/**
+ * chant lifecycle affected --base <ref> [--head <ref>] [--include-dependents] [--json]
+ *
+ * Read-only: report which stacks a change affects (directly-changed via artifact
+ * diff, dependents via the cross-stack graph, external-input as indeterminate).
+ * Returns the set; fanning plan/apply over it is an Op the user composes.
+ */
+export async function runLifecycleAffected(ctx: CommandContext): Promise<number> {
+  const { args, plugins } = ctx;
+  if (!args.base) {
+    console.error(formatError({
+      message: "Base ref is required: chant lifecycle affected --base <ref> [--head <ref>] [--include-dependents]",
+    }));
+    return 1;
+  }
+
+  const { config } = await loadChantConfig(resolve("."));
+  const projectPath = resolveBuildRoot(args, config);
+
+  let result;
+  try {
+    result = await affectedStacks({
+      projectPath,
+      serializers: plugins.map((p) => p.serializer),
+      baseRef: args.base,
+      headRef: args.head,
+      includeDependents: args.includeDependents,
+    });
+  } catch (err) {
+    console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+    return 1;
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return 0;
+  }
+
+  if (result.changed.length === 0 && result.dependents.length === 0) {
+    console.error(formatSuccess("No stacks affected"));
+  } else {
+    console.log(formatBold("Directly changed:"));
+    console.log(result.changed.length ? result.changed.map((s) => `  ${s}`).join("\n") : "  (none)");
+    if (args.includeDependents) {
+      console.log(formatBold("\nDependents (consume a changed stack):"));
+      console.log(result.dependents.length ? result.dependents.map((s) => `  ${s}`).join("\n") : "  (none)");
+    }
+  }
+  if (result.indeterminate.length > 0) {
+    console.error(formatWarning({
+      message: `External-input stacks — cannot confirm from source: ${result.indeterminate.join(", ")}`,
+    }));
+  }
+  return 0;
 }

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -14,7 +14,7 @@ import { runInit, runInitLexicon } from "./handlers/init";
 import { runList, runDescribe, runImport, runUpdate, runDoctor } from "./handlers/misc";
 import { runVendor } from "./handlers/vendor";
 import { runMigrate } from "./handlers/migrate";
-import { runLifecycleSnapshot, runLifecycleShow, runLifecycleDiff, runLifecyclePlan, runLifecycleLog, runLifecycleUnknown } from "./handlers/lifecycle";
+import { runLifecycleSnapshot, runLifecycleShow, runLifecycleDiff, runLifecyclePlan, runLifecycleAffected, runLifecycleLog, runLifecycleUnknown } from "./handlers/lifecycle";
 import { runGraph } from "./handlers/graph";
 import { runOp, runOpList, runOpStatus, runOpSignal, runOpCancel, runOpLog } from "./handlers/run";
 
@@ -120,6 +120,12 @@ export function parseArgs(args: string[]): ParsedArgs {
       result.env = args[++i];
     } else if (arg === "--stacks") {
       result.stacks = true;
+    } else if (arg === "--base") {
+      result.base = args[++i];
+    } else if (arg === "--head") {
+      result.head = args[++i];
+    } else if (arg === "--include-dependents") {
+      result.includeDependents = true;
     } else if (arg === "--local") {
       result.local = true;
     } else if (arg === "--temporal") {
@@ -182,6 +188,7 @@ Lifecycle (alias: lc):
   lifecycle diff <env>      Compare current build against last snapshot
                             --live: query cloud now and detect drift
   lifecycle plan <env>      Typed change set (create/update/delete/adopt) vs live
+  lifecycle affected        Stacks a change affects (--base <ref> [--include-dependents])
                             --json: emit the ChangeSet as JSON
   lifecycle log [env]       History of lifecycle snapshots
 
@@ -306,6 +313,7 @@ const registry: CommandDef[] = [
   { name: "lifecycle show", handler: runLifecycleShow },
   { name: "lifecycle diff", requiresPlugins: true, handler: runLifecycleDiff },
   { name: "lifecycle plan", requiresPlugins: true, handler: runLifecyclePlan },
+  { name: "lifecycle affected", requiresPlugins: true, handler: runLifecycleAffected },
   { name: "lifecycle log", handler: runLifecycleLog },
 
   // Serve subcommands

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -57,6 +57,12 @@ export interface ParsedArgs {
   env?: string;
   /** `chant graph --stacks` — render the cross-stack apply-ordering graph */
   stacks?: boolean;
+  /** `chant lifecycle affected --base <ref>` — base git ref to diff against */
+  base?: string;
+  /** `chant lifecycle affected --head <ref>` — head git ref (default: working tree) */
+  head?: string;
+  /** `chant lifecycle affected --include-dependents` — add downstream consumers */
+  includeDependents?: boolean;
 }
 
 /**

--- a/packages/core/src/lifecycle/affected.test.ts
+++ b/packages/core/src/lifecycle/affected.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  changedStacks,
+  dependentStacks,
+  computeAffected,
+  externalInputStacks,
+  affectedStacks,
+} from "./affected";
+import type { StackGraph } from "../build";
+import type { Serializer } from "../serializer";
+import type { Declarable } from "../declarable";
+
+const execFileAsync = promisify(execFile);
+
+// Serializer whose output reflects entity names + types, so a value change moves
+// the bytes but an unrelated edit (comment) does not.
+const fakeSerializer: Serializer = {
+  name: "fake",
+  rulePrefix: "FAKE",
+  serialize: (entities) =>
+    JSON.stringify([...entities.keys()].sort().map((k) => ({ k, t: entities.get(k)!.entityType }))),
+};
+
+function widget(type: string): string {
+  return `export const foo = { lexicon: "fake", entityType: "${type}", [Symbol.for("chant.declarable")]: true };\n`;
+}
+
+// ── Pure model ────────────────────────────────────────────────────────────────
+
+describe("changedStacks", () => {
+  test("flags stacks whose output differs, and added/removed stacks", () => {
+    const base = new Map([["a", "1"], ["b", "2"], ["gone", "x"]]);
+    const head = new Map([["a", "1"], ["b", "CHANGED"], ["new", "y"]]);
+    expect(changedStacks(base, head)).toEqual(["b", "gone", "new"]);
+  });
+  test("identical builds → nothing changed", () => {
+    const m = new Map([["a", "1"], ["b", "2"]]);
+    expect(changedStacks(m, new Map(m))).toEqual([]);
+  });
+});
+
+describe("dependentStacks", () => {
+  // Diamond: top→left, top→right, left→base, right→base (consumer→producer).
+  const graph: StackGraph = {
+    nodes: ["base", "left", "right", "top"],
+    edges: [
+      { from: "left", to: "base" },
+      { from: "right", to: "base" },
+      { from: "top", to: "left" },
+      { from: "top", to: "right" },
+    ],
+    order: ["base", "left", "right", "top"],
+    waves: [["base"], ["left", "right"], ["top"]],
+    cycles: [],
+  };
+  test("a changed producer surfaces all transitive consumers", () => {
+    expect(dependentStacks(["base"], graph)).toEqual(["left", "right", "top"]);
+  });
+  test("a changed mid-stack surfaces only what's above it", () => {
+    expect(dependentStacks(["left"], graph)).toEqual(["top"]);
+  });
+  test("nothing depends on the top", () => {
+    expect(dependentStacks(["top"], graph)).toEqual([]);
+  });
+});
+
+describe("computeAffected", () => {
+  const graph: StackGraph = {
+    nodes: ["aws", "k8s"],
+    edges: [{ from: "k8s", to: "aws" }],
+    order: ["aws", "k8s"],
+    waves: [["aws"], ["k8s"]],
+    cycles: [],
+  };
+  const base = new Map([["aws", "v1"], ["k8s", "same"]]);
+  const head = new Map([["aws", "v2"], ["k8s", "same"]]);
+
+  test("dependents excluded by default", () => {
+    const r = computeAffected(base, head, graph);
+    expect(r.changed).toEqual(["aws"]);
+    expect(r.dependents).toEqual([]);
+  });
+  test("--include-dependents adds the unchanged consumer of a changed producer", () => {
+    const r = computeAffected(base, head, graph, { includeDependents: true });
+    expect(r.changed).toEqual(["aws"]);
+    expect(r.dependents).toEqual(["k8s"]); // k8s bytes unchanged, but consumes aws
+  });
+  test("external-input stacks are reported as indeterminate", () => {
+    const r = computeAffected(base, head, graph, { externalInput: ["k8s"] });
+    expect(r.indeterminate).toEqual(["k8s"]);
+  });
+});
+
+describe("externalInputStacks", () => {
+  test("detects stacks declaring a deploy-time parameter", () => {
+    const entities = new Map<string, Declarable>([
+      ["p", { lexicon: "aws", entityType: "Param", parameterType: "String" } as unknown as Declarable],
+      ["r", { lexicon: "k8s", entityType: "Deployment" } as unknown as Declarable],
+    ]);
+    expect(externalInputStacks(entities)).toEqual(["aws"]);
+  });
+});
+
+// ── Integration: artifact diff over real builds ──────────────────────────────
+
+describe("affectedStacks — baseDir (caller-supplied)", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "chant-affected-it-"));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  const srcDir = (name: string, content: string): string => {
+    const dir = join(root, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "infra.ts"), content);
+    return dir;
+  };
+
+  test("a value change makes the stack affected", async () => {
+    const base = srcDir("base", widget("Widget"));
+    const head = srcDir("head", widget("Gadget"));
+    const r = await affectedStacks({ projectPath: head, baseDir: base, serializers: [fakeSerializer] });
+    expect(r.changed).toEqual(["fake"]);
+  });
+
+  test("a no-output-change refactor is NOT affected (deterministic build)", async () => {
+    const base = srcDir("base", widget("Widget"));
+    // Same declarable, only a comment added — serialized output is identical.
+    const head = srcDir("head", "// a harmless refactor\n" + widget("Widget"));
+    const r = await affectedStacks({ projectPath: head, baseDir: base, serializers: [fakeSerializer] });
+    expect(r.changed).toEqual([]);
+  });
+});
+
+describe("affectedStacks — baseRef (git worktree)", () => {
+  let repo: string;
+  beforeEach(async () => {
+    repo = mkdtempSync(join(tmpdir(), "chant-affected-git-"));
+    const git = (...a: string[]) => execFileAsync("git", a, { cwd: repo });
+    await git("init", "-q");
+    await git("config", "user.email", "t@t.dev");
+    await git("config", "user.name", "t");
+    writeFileSync(join(repo, "infra.ts"), widget("Widget"));
+    await git("add", "-A");
+    await git("commit", "-q", "-m", "base");
+  });
+  afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+  test("diffs the working tree against a base ref via one worktree", async () => {
+    // Mutate the working tree (uncommitted) — the head build sees this.
+    writeFileSync(join(repo, "infra.ts"), widget("Gadget"));
+    const r = await affectedStacks({ projectPath: repo, baseRef: "HEAD", serializers: [fakeSerializer] });
+    expect(r.changed).toEqual(["fake"]);
+  }, 30_000);
+});

--- a/packages/core/src/lifecycle/affected.ts
+++ b/packages/core/src/lifecycle/affected.ts
@@ -1,0 +1,202 @@
+/**
+ * Selective change-set scoping — which stacks does a change affect?
+ *
+ * "Affected" is two distinct things, because chant serializes cross-stack
+ * references symbolically:
+ *   1. **Directly changed** — the stack's built artifact differs between base
+ *      and head. Caught by artifact diff over deterministic builds, so it
+ *      ignores comment-only / refactor-with-no-output-change edits.
+ *   2. **Operationally affected (dependents)** — a stack whose own artifact is
+ *      unchanged but which consumes an upstream export whose value changed. Its
+ *      bytes don't move, yet it may need re-apply. Caught by walking the
+ *      cross-stack graph (#200) from the directly-changed set; opt-in.
+ *
+ * A stack whose inputs come from outside synthesis (deploy-time params) cannot
+ * be judged from a source diff — reported as **indeterminate**, not silently
+ * included or excluded.
+ *
+ * This returns the set; it does not act. Fanning `lifecycle plan` / `ApplyOp`
+ * over it is an Op the user composes.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtempSync, rmSync, existsSync, symlinkSync, realpathSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { build, type StackGraph } from "../build";
+import { getPrimaryOutput } from "../lint/post-synth";
+import type { Serializer } from "../serializer";
+import type { Declarable } from "../declarable";
+
+const execFileAsync = promisify(execFile);
+
+export interface AffectedResult {
+  /** Stacks whose built artifact differs between base and head. */
+  changed: string[];
+  /** Downstream consumers of changed stacks (only when `includeDependents`). */
+  dependents: string[];
+  /** Stacks with deploy-time inputs — cannot be confirmed from a source diff. */
+  indeterminate: string[];
+}
+
+// ── Pure model ──────────────────────────────────────────────────────────────
+
+/** Stacks whose serialized output differs between the two builds (added/removed count). */
+export function changedStacks(
+  base: Map<string, string>,
+  head: Map<string, string>,
+): string[] {
+  const names = new Set([...base.keys(), ...head.keys()]);
+  const changed: string[] = [];
+  for (const name of names) {
+    if (base.get(name) !== head.get(name)) changed.push(name);
+  }
+  return changed.sort();
+}
+
+/**
+ * Walk the cross-stack graph backwards from `changed` to find every stack that
+ * (transitively) consumes a changed stack. Edge `from → to` means `from`
+ * depends on `to`, so a changed `to` makes `from` a dependent.
+ */
+export function dependentStacks(changed: string[], graph: StackGraph): string[] {
+  const consumersOf = new Map<string, string[]>();
+  for (const { from, to } of graph.edges) {
+    (consumersOf.get(to) ?? consumersOf.set(to, []).get(to)!).push(from);
+  }
+  const seen = new Set(changed);
+  const queue = [...changed];
+  const dependents = new Set<string>();
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    for (const consumer of consumersOf.get(node) ?? []) {
+      if (seen.has(consumer)) continue;
+      seen.add(consumer);
+      dependents.add(consumer);
+      queue.push(consumer);
+    }
+  }
+  return [...dependents].sort();
+}
+
+/**
+ * Compute the affected set from two per-stack artifact maps and the cross-stack
+ * graph. Pure — no builds, no git — so the model is independently testable.
+ */
+export function computeAffected(
+  base: Map<string, string>,
+  head: Map<string, string>,
+  graph: StackGraph,
+  opts: { includeDependents?: boolean; externalInput?: string[] } = {},
+): AffectedResult {
+  const changed = changedStacks(base, head);
+  const dependents = opts.includeDependents ? dependentStacks(changed, graph) : [];
+  const indeterminate = [...(opts.externalInput ?? [])].sort();
+  return { changed, dependents, indeterminate };
+}
+
+// ── Build + git plumbing ──────────────────────────────────────────────────────
+
+/** A built BuildResult's per-stack (lexicon) primary output, keyed by stack. */
+export function artifactMap(outputs: Map<string, string | { primary: string }>): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const [stack, output] of outputs) map.set(stack, getPrimaryOutput(output as string));
+  return map;
+}
+
+/** Stacks (lexicons) that declare a deploy-time parameter — external input. */
+export function externalInputStacks(entities: Map<string, Declarable>): string[] {
+  const stacks = new Set<string>();
+  for (const [, entity] of entities) {
+    if ("parameterType" in entity && typeof (entity as { parameterType?: unknown }).parameterType === "string") {
+      stacks.add(entity.lexicon);
+    }
+  }
+  return [...stacks].sort();
+}
+
+async function gitTopLevel(cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], { cwd });
+  return stdout.trim();
+}
+
+/**
+ * Check out `ref` into a throwaway worktree, symlink the repo's node_modules so
+ * lexicon imports resolve, run `fn`, then remove the worktree. At most one
+ * worktree exists at a time.
+ */
+async function withWorktree<T>(repoRoot: string, ref: string, fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), "chant-affected-"));
+  await execFileAsync("git", ["worktree", "add", "--detach", dir, ref], { cwd: repoRoot });
+  try {
+    const nm = join(repoRoot, "node_modules");
+    const linked = join(dir, "node_modules");
+    if (existsSync(nm) && !existsSync(linked)) symlinkSync(nm, linked, "dir");
+    return await fn(dir);
+  } finally {
+    await execFileAsync("git", ["worktree", "remove", "--force", dir], { cwd: repoRoot }).catch(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+  }
+}
+
+export interface AffectedStacksOptions {
+  /** Project source directory to scope (the head/working-tree build root). */
+  projectPath: string;
+  serializers: Serializer[];
+  /** Base git ref to diff against (built in a throwaway worktree). */
+  baseRef?: string;
+  /** Head git ref. Defaults to the working tree (built in place — no worktree). */
+  headRef?: string;
+  /**
+   * Caller-supplied base source directory (already on disk). Takes precedence
+   * over `baseRef` — no worktree is created. Use for a build cache or two dist
+   * trees you already have.
+   */
+  baseDir?: string;
+  includeDependents?: boolean;
+}
+
+/**
+ * Compute the affected stacks for a change. Head is built in place (the working
+ * tree); base is built from `baseDir` if supplied, else from `baseRef` via a
+ * single throwaway worktree. Builds are deterministic, so a cached/supplied base
+ * is as trustworthy as a rebuild.
+ */
+export async function affectedStacks(opts: AffectedStacksOptions): Promise<AffectedResult> {
+  const projectPath = resolve(opts.projectPath);
+  const needsWorktree = Boolean(opts.headRef) || Boolean(opts.baseRef && !opts.baseDir);
+  const repoRoot = needsWorktree ? await gitTopLevel(projectPath) : projectPath;
+  // Canonicalize via realpath so the worktree-relative path is correct even when
+  // the temp dir is a symlink (macOS /var → /private/var) and `git
+  // rev-parse --show-toplevel` reports the real path.
+  const relProject = needsWorktree ? relative(repoRoot, realpathSync(projectPath)) : "";
+
+  // Head: the in-place build of the working tree, unless an explicit headRef is
+  // given (then a throwaway worktree — removed before the base worktree, so at
+  // most one exists at a time).
+  const head = opts.headRef
+    ? await withWorktree(repoRoot, opts.headRef, (dir) => build(join(dir, relProject), opts.serializers))
+    : await build(projectPath, opts.serializers);
+  const headMap = artifactMap(head.outputs);
+  const externalInput = externalInputStacks(head.entities);
+
+  // Base: caller-supplied dir (cheapest), else a single worktree at baseRef.
+  let baseMap: Map<string, string>;
+  if (opts.baseDir) {
+    const baseBuild = await build(resolve(opts.baseDir), opts.serializers);
+    baseMap = artifactMap(baseBuild.outputs);
+  } else if (opts.baseRef) {
+    baseMap = await withWorktree(repoRoot, opts.baseRef, async (dir) => {
+      const baseBuild = await build(join(dir, relProject), opts.serializers);
+      return artifactMap(baseBuild.outputs);
+    });
+  } else {
+    throw new Error("affectedStacks requires either baseDir or baseRef");
+  }
+
+  return computeAffected(baseMap, headMap, head.manifest.stackGraph, {
+    includeDependents: opts.includeDependents,
+    externalInput,
+  });
+}

--- a/packages/core/src/lifecycle/index.ts
+++ b/packages/core/src/lifecycle/index.ts
@@ -4,3 +4,4 @@ export * from "./digest";
 export * from "./snapshot";
 export * from "./live-diff";
 export * from "./change-set";
+export * from "./affected";


### PR DESCRIPTION
"Which stacks does this change affect?" — the **primitive**, not a CI tool. Read-only: returns the set; fanning `lifecycle plan` / an `ApplyOp` over it is an Op the user composes. chant never blindly applies the set.

## The model
"Affected" is two distinct things, because chant serializes cross-stack references symbolically:
- **Directly changed** — the stack's built artifact differs between base and head. **Artifact diff** over deterministic builds, so a comment-only / refactor-with-no-output-change edit is correctly excluded.
- **Operationally affected (dependents)** — a stack whose own artifact is *unchanged* but which consumes an upstream export whose value changed. Caught by walking **#200's cross-stack graph** from the changed set; opt-in via `--include-dependents`.
- **Indeterminate** — a stack with deploy-time inputs (parameters) can't be judged from a source diff; reported separately, not silently in/excluded.

## What's added
- `lifecycle/affected.ts`: pure model (`changedStacks`, `dependentStacks` over #200's edge set, `computeAffected`) + the `affectedStacks()` runner, **exported from core**.
- Builds are lazy: **head** = in-place working-tree build; **base** = caller-supplied dir, else `--base <ref>` in a **single throwaway worktree** (≤1, auto-removed, node_modules symlinked). Deterministic build ⇒ a supplied/cached base is as trustworthy as a rebuild.
- `chant lifecycle affected --base <ref> [--head <ref>] [--include-dependents] [--json]`. **Consumes #200's graph — no second extractor** (the #199↔#200 contract).

## Scope notes
- **SHA-keyed artifact cache** and **explicit `dependsOn`** stay fast-follow — the worktree path + inferred edges suffice for v1.
- The **fan-out is documented, not shipped** (a `jq | while` snippet / an Op you write).

## Validation
- `npx vitest run packages/core/src` → 1621 passed (new: pure model — changed/added/removed, dependents over a diamond, external passthrough; `affectedStacks` over **real builds** — caller-supplied base value-change vs no-output refactor, and a **git-worktree** base ref).
- `tsc` clean; `eslint` clean; `npm --prefix docs run build` → 115 pages.

Closes #199
Refs #198, #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)