### PR TITLE
feat(op): policyGate — gate an apply on organizational policy (#201 T4)

### DIFF
--- a/docs/src/content/docs/guide/organizational-policy.mdx
+++ b/docs/src/content/docs/guide/organizational-policy.mdx
@@ -66,10 +66,35 @@ language." Org policy is post-synth checks the org authors — nothing more.
 
 ## Gating an apply
 
-Build-time policy fails fast, before anything is applied. Gating an *apply*
-through a policy pass — run the policy, then block or pause for a signed,
-audited override before `ApplyOp` — slots into the existing
-[gate / `onFailure`](/chant/guide/ops/) model and is tracked as a follow-on.
+`chant build` already fails on a policy violation, so any pipeline that builds
+before applying is gated. To gate an apply *inside* an [Op](/chant/guide/ops/),
+add a **`policyGate()`** step before the apply phase:
+
+```ts
+import { Op, phase, build, policyGate, kubectlApply } from "@intentius/chant-lexicon-temporal";
+
+export default Op({
+  name: "deploy",
+  phases: [
+    phase("Build", [build(".")]),
+    // Re-runs lint.policies over the resolved resources; a violation fails the
+    // workflow here, so nothing is applied.
+    phase("Policy", [policyGate({ env: "prod" })]),
+    phase("Apply", [kubectlApply("k8s.yaml")]),
+  ],
+});
+```
+
+`policyGate` builds the project, runs `lint.policies` with the given `env` (or
+`ownership.env`), and **blocks** on any violation — non-retryable and
+single-attempt (a deterministic violation is not worth retrying). It is a plain
+activity, so it gates under both the local executor and Temporal. A clean
+evaluation passes through to the apply.
+
+> **Signed override (deferred).** Pausing for a human, signed, audited override
+> to proceed *despite* a violation requires conditional gating in the generated
+> workflow — it is tracked as a follow-on, not in this version. Today `policyGate`
+> blocks; loosen the policy or fix the violation to proceed.
 
 ## Try it
 

--- a/lexicons/temporal/src/config.ts
+++ b/lexicons/temporal/src/config.ts
@@ -143,6 +143,16 @@ export const TEMPORAL_ACTIVITY_PROFILES = {
       nonRetryableErrorTypes: ["ArgoSyncFailedError"],
     },
   },
+
+  /**
+   * Organizational policy gate (`policyGate`): build the project and evaluate
+   * `lint.policies`. Deterministic — a violation is the same on every attempt —
+   * so a single attempt, short timeout, no retry. Fails fast in both executors.
+   */
+  policyCheck: {
+    startToCloseTimeout: "5m",
+    retry: { maximumAttempts: 1 },
+  },
 } as const satisfies Record<string, TemporalActivityProfile>;
 
 export interface TemporalWorkerProfile {

--- a/lexicons/temporal/src/index.ts
+++ b/lexicons/temporal/src/index.ts
@@ -48,5 +48,6 @@ export {
   lifecycleSnapshot,
   shell,
   teardown,
+  policyGate,
 } from "@intentius/chant/op";
 export type { OpConfig, PhaseDefinition, StepDefinition, ActivityStep, GateStep } from "@intentius/chant/op";

--- a/lexicons/temporal/src/op/activities/index.ts
+++ b/lexicons/temporal/src/op/activities/index.ts
@@ -30,3 +30,6 @@ export type { NativeApplyArgs, CompensateApplyArgs, ApplyTarget, DeleteMode } fr
 
 export { waitForArgoSync, defaultArgoStatusFetcher, ArgoSyncFailedError } from "./argo";
 export type { WaitForArgoSyncArgs, ArgoAppStatus, ArgoStatusFetcher } from "./argo";
+
+export { policyGate } from "./policy";
+export type { PolicyGateArgs } from "./policy";

--- a/lexicons/temporal/src/op/activities/policy.test.ts
+++ b/lexicons/temporal/src/op/activities/policy.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "vitest";
+import { resolve } from "node:path";
+import { policyGate } from "./policy";
+
+// The #201 org-policy example: a compliant workload + a policy pack
+// (ORG-COST-CENTER all-envs, ORG-PROD-TLS prod-only). policyGate builds it and
+// runs the policies — passing in dev, blocking in prod.
+const orgPolicySrc = resolve(import.meta.dirname, "../../../../k8s/examples/org-policy/src");
+
+describe("policyGate activity (#201 T4 — gate an apply on policy)", () => {
+  test("passes when policy is satisfied (no env, and dev)", async () => {
+    await expect(policyGate({ path: orgPolicySrc })).resolves.toBeUndefined();
+    await expect(policyGate({ path: orgPolicySrc, env: "dev" })).resolves.toBeUndefined();
+  }, 30_000);
+
+  test("blocks the apply on a prod policy violation", async () => {
+    await expect(policyGate({ path: orgPolicySrc, env: "prod" })).rejects.toThrow(/ORG-PROD-TLS/);
+  }, 30_000);
+});

--- a/lexicons/temporal/src/op/activities/policy.ts
+++ b/lexicons/temporal/src/op/activities/policy.ts
@@ -1,0 +1,32 @@
+import { ApplicationFailure } from "@temporalio/common";
+import { evaluateProjectPolicies } from "@intentius/chant/lint/policy";
+
+export interface PolicyGateArgs {
+  /** Project/source directory to build and evaluate. Default ".". */
+  path?: string;
+  /** Environment for policy evaluation (falls back to `ownership.env`). */
+  env?: string;
+}
+
+/**
+ * Gate an apply on organizational policy: build the project, run its
+ * `lint.policies` over the resolved resources, and **block** on any violation.
+ * Place it as a step before the apply phase — a violation fails the workflow
+ * (non-retryable; the `policyCheck` profile is single-attempt) so nothing is
+ * applied. A clean evaluation passes through.
+ *
+ * Runs in both executors — it is a plain activity, not a Temporal gate.
+ */
+export async function policyGate(args: PolicyGateArgs, _signal?: AbortSignal): Promise<void> {
+  const { violations, env } = await evaluateProjectPolicies({ path: args.path ?? ".", env: args.env });
+  if (violations.length > 0) {
+    const summary = violations
+      .map((v) => `[${v.checkId}]${v.entity ? ` ${v.entity}:` : ""} ${v.message}`)
+      .join("; ");
+    throw ApplicationFailure.nonRetryable(
+      `Organizational policy blocked the apply — ${violations.length} violation(s): ${summary}`,
+      "PolicyViolation",
+    );
+  }
+  console.log(`[policy] ${env ? `env=${env}: ` : ""}no violations — apply may proceed`);
+}

--- a/packages/core/src/cli/commands/build.ts
+++ b/packages/core/src/cli/commands/build.ts
@@ -2,8 +2,8 @@ import { build } from "../../build";
 import { loadChantConfig, resolveOwnershipMarker } from "../../config";
 import type { Serializer, SerializerResult } from "../../serializer";
 import type { LexiconPlugin } from "../../lexicon";
-import { runPostSynthChecks, isPostSynthCheck } from "../../lint/post-synth";
-import type { PostSynthCheck } from "../../lint/post-synth";
+import { runPostSynthChecks } from "../../lint/post-synth";
+import { loadPolicyChecks } from "../../lint/policy";
 import { sortedJsonReplacer } from "../../utils";
 import { formatError, formatWarning, formatSuccess, formatBold, formatInfo } from "../format";
 import { writeFileSync, mkdirSync } from "fs";
@@ -34,25 +34,6 @@ export interface BuildOptions {
   env?: string;
 }
 
-/** Load project-authored policy checks from `lint.policies` file paths. */
-async function loadPolicyChecks(paths: string[], configDir: string): Promise<PostSynthCheck[]> {
-  const checks: PostSynthCheck[] = [];
-  for (const p of paths) {
-    const resolved = resolve(configDir, p);
-    let mod: Record<string, unknown>;
-    try {
-      mod = (await import(resolved)) as Record<string, unknown>;
-    } catch (err) {
-      throw new Error(
-        `Failed to load policy "${p}": ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-    for (const value of Object.values(mod)) {
-      if (isPostSynthCheck(value)) checks.push(value);
-    }
-  }
-  return checks;
-}
 
 /**
  * Build command result

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export * from "./lint/declarative";
 export * from "./lint/selectors";
 export * from "./lint/named-checks";
 export * from "./lint/post-synth";
+export * from "./lint/policy";
 export * from "./lint/rule-loader";
 export * from "./lint/discover";
 export * from "./import/parser";

--- a/packages/core/src/lint/policy.ts
+++ b/packages/core/src/lint/policy.ts
@@ -1,0 +1,81 @@
+/**
+ * Project-authored organizational policy: loading the policy pack and evaluating
+ * it against a freshly built project. `chant build` runs policies inline; the
+ * `policyGate` Op step runs this to gate an apply on the same checks.
+ */
+import { resolve, dirname } from "node:path";
+import { loadChantConfig } from "../config";
+import { resolveProjectLexicons, loadPlugins } from "../cli/plugins";
+import { build } from "../build";
+import { runPostSynthChecks, isPostSynthCheck } from "./post-synth";
+import type { PostSynthCheck, PostSynthDiagnostic } from "./post-synth";
+
+/** Load project policy checks (one or more `PostSynthCheck` exports) from files. */
+export async function loadPolicyChecks(paths: string[], configDir: string): Promise<PostSynthCheck[]> {
+  const checks: PostSynthCheck[] = [];
+  for (const p of paths) {
+    const resolved = resolve(configDir, p);
+    let mod: Record<string, unknown>;
+    try {
+      mod = (await import(resolved)) as Record<string, unknown>;
+    } catch (err) {
+      throw new Error(
+        `Failed to load policy "${p}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    for (const value of Object.values(mod)) {
+      if (isPostSynthCheck(value)) checks.push(value);
+    }
+  }
+  return checks;
+}
+
+export interface PolicyEvaluation {
+  /** All policy diagnostics (errors + warnings). */
+  diagnostics: PostSynthDiagnostic[];
+  /** The error-severity subset — these are policy *violations* that gate. */
+  violations: PostSynthDiagnostic[];
+  /** The environment policies were evaluated against (if any). */
+  env?: string;
+}
+
+/**
+ * Build a project and run its `lint.policies` over the resolved resources,
+ * standalone — used by the `policyGate` Op step to gate an apply on the same
+ * organizational policy `chant build` enforces. Loads the project's lexicons,
+ * builds, then runs the policy pack with `env` (explicit, else `ownership.env`).
+ */
+export async function evaluateProjectPolicies(opts: {
+  path: string;
+  env?: string;
+}): Promise<PolicyEvaluation> {
+  const buildPath = resolve(opts.path);
+
+  const lexiconNames = await resolveProjectLexicons(buildPath);
+  const plugins = await loadPlugins(lexiconNames);
+  const serializers = plugins.map((p) => p.serializer);
+
+  // Config can live in the build dir or its parent (the project root).
+  const loaded = await loadChantConfig(buildPath).then((r) =>
+    r.configPath ? r : loadChantConfig(dirname(buildPath)),
+  );
+  const config = loaded.config;
+  const configDir = loaded.configPath ? dirname(loaded.configPath) : buildPath;
+  const env = opts.env ?? config.ownership?.env;
+
+  const result = await build(buildPath, serializers);
+  if (result.errors.length > 0) {
+    throw new Error("Build failed — cannot evaluate policy on a broken build");
+  }
+
+  const checks = config.lint?.policies?.length
+    ? await loadPolicyChecks(config.lint.policies, configDir)
+    : [];
+  if (checks.length === 0) {
+    return { diagnostics: [], violations: [], env };
+  }
+
+  const diagnostics = runPostSynthChecks(checks, result, env);
+  const violations = diagnostics.filter((d) => d.severity === "error");
+  return { diagnostics, violations, env };
+}

--- a/packages/core/src/op/builders.ts
+++ b/packages/core/src/op/builders.ts
@@ -130,3 +130,17 @@ export const shell = (
 /** Run `chant teardown` in the given project directory. Uses `longInfra` profile. */
 export const teardown = (path: string): ActivityStep =>
   activity("chantTeardown", { path }, "longInfra");
+
+/**
+ * Gate an apply on organizational policy: build the project and run its
+ * `lint.policies` over the resolved resources, blocking the workflow on any
+ * violation. Place it before the apply phase. `env` (or `ownership.env`) lets a
+ * policy branch on environment. Single-attempt (`policyCheck` profile) — a
+ * deterministic violation is not retried.
+ */
+export const policyGate = (opts?: { env?: string; path?: string }): ActivityStep =>
+  activity(
+    "policyGate",
+    { path: opts?.path ?? ".", ...(opts?.env ? { env: opts.env } : {}) },
+    "policyCheck",
+  );

--- a/packages/core/src/op/index.ts
+++ b/packages/core/src/op/index.ts
@@ -1,5 +1,5 @@
 export { Op, phase, activity, gate, build, kubectlApply, helmInstall, waitForStack,
-         gitlabPipeline, lifecycleSnapshot, shell, teardown } from "./builders";
+         gitlabPipeline, lifecycleSnapshot, shell, teardown, policyGate } from "./builders";
 export { OpResource } from "./resource";
 export type { OpConfig, PhaseDefinition, StepDefinition, ActivityStep, GateStep } from "./types";
 export { discoverOps } from "./discover";

--- a/packages/core/src/op/op.test.ts
+++ b/packages/core/src/op/op.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from "vitest";
 import { Op, phase, activity, gate, build, kubectlApply, helmInstall,
-         waitForStack, gitlabPipeline, lifecycleSnapshot, shell, teardown } from "./builders";
+         waitForStack, gitlabPipeline, lifecycleSnapshot, shell, teardown, policyGate } from "./builders";
 import { DECLARABLE_MARKER, type Declarable } from "../declarable";
 
 // ── Op() ──────────────────────────────────────────────────────────────────────
@@ -195,6 +195,20 @@ describe("pre-built shortcuts", () => {
     expect(a.fn).toBe("chantTeardown");
     expect(a.args?.path).toBe("./project");
     expect(a.profile).toBe("longInfra");
+  });
+
+  it("policyGate() produces a policyGate activity with the single-attempt policyCheck profile", () => {
+    const a = policyGate({ env: "prod" });
+    expect(a.fn).toBe("policyGate");
+    expect(a.args?.path).toBe("."); // defaults to the project dir
+    expect(a.args?.env).toBe("prod");
+    expect(a.profile).toBe("policyCheck");
+  });
+
+  it("policyGate() with no opts defaults path to '.' and omits env", () => {
+    const a = policyGate();
+    expect(a.args?.path).toBe(".");
+    expect("env" in (a.args ?? {})).toBe(false);
   });
 });
 

--- a/packages/core/src/op/types.ts
+++ b/packages/core/src/op/types.ts
@@ -45,7 +45,7 @@ export interface ActivityStep {
    * Key from TEMPORAL_ACTIVITY_PROFILES controlling timeout + retry.
    * Default: "fastIdempotent"
    */
-  profile?: "fastIdempotent" | "longInfra" | "k8sWait" | "humanGate" | "argoSync";
+  profile?: "fastIdempotent" | "longInfra" | "k8sWait" | "humanGate" | "argoSync" | "policyCheck";
   /**
    * Surface this activity's return value as a workflow search attribute.
    *


### PR DESCRIPTION
The apply-side half of #201 — a **`policyGate()`** Op step that runs the project's `lint.policies` over the resolved resources and **blocks the workflow before the apply phase** on any violation. With the build-time enforcement from deliverable A, organizational policy now gates both `chant build` and an Op-driven apply.

## What's added
- **`evaluateProjectPolicies({ path, env })`** (`lint/policy.ts`, exported) — loads the project's lexicons, builds, runs `lint.policies`, returns error-severity violations. `loadPolicyChecks` moved here and **shared with `buildCommand`** (was a private copy).
- **`policyGate` activity** (temporal lexicon) — calls `evaluateProjectPolicies` and throws a non-retryable `ApplicationFailure` listing the violations. A plain activity, so it gates under **both the local executor and Temporal**.
- **`policyGate()` step builder** + a new single-attempt **`policyCheck` profile** (5m, `maxAttempts: 1`) so a deterministic violation fails fast in both executors.

```ts
phase("Build",  [build(".")]),
phase("Policy", [policyGate({ env: "prod" })]),  // violation fails the workflow here
phase("Apply",  [kubectlApply("k8s.yaml")]),
```

## Deferred (on demand)
The **signed/audited override** — proceed *despite* a violation via a human-approved gate — needs conditional gating in the generated workflow (it strains the declarative Op model). Per the umbrella's portfolio-watch caution, it's deferred until demand. Today `policyGate` blocks; loosen the policy or fix the violation. (Same deferral pattern as #203 rung-2 / #204 provenance.)

## Validation
- `npx vitest run packages/core/src lexicons/temporal/src/op` → 1696 passed (new: builder asserts the `policyCheck` profile + args; the activity end-to-end over the `org-policy` example — passes no-env/dev, blocks prod with `ORG-PROD-TLS`).
- `npx vitest run lexicons/temporal` → 204 passed; `prepack` + validation pass.
- `tsc` (core) clean; `eslint` clean; `npm --prefix docs run build` → 115 pages.

Closes #201
Refs #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)