### PR TITLE
feat(k8s): generate Gateway API classes (add to CRD sources) (#272)

### DIFF
--- a/lexicons/k8s/src/crd/crd-sources.ts
+++ b/lexicons/k8s/src/crd/crd-sources.ts
@@ -37,6 +37,26 @@ const KUBERAY_CRD_BASE = `https://raw.githubusercontent.com/ray-project/kuberay/
 const ARGOCD_VERSION = "v2.13.3";
 const ARGOCD_CRD_BASE = `https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/crds`;
 
+/**
+ * Gateway API CRDs — gateway.networking.k8s.io (standard channel)
+ *
+ * The modern, portable replacement for Ingress. GRPCRoute in particular is the
+ * native way to express a gRPC route (vs. ingress-controller annotations).
+ *
+ * Produces (the `gateway.networking.k8s.io` group maps to the `Gateway`
+ * namespace via the first-segment rule in crd/parser.ts):
+ *   K8s::Gateway::GatewayClass    → apiVersion: gateway.networking.k8s.io/v1,      kind: GatewayClass
+ *   K8s::Gateway::Gateway         → apiVersion: gateway.networking.k8s.io/v1,      kind: Gateway
+ *   K8s::Gateway::HTTPRoute       → apiVersion: gateway.networking.k8s.io/v1,      kind: HTTPRoute
+ *   K8s::Gateway::GRPCRoute       → apiVersion: gateway.networking.k8s.io/v1,      kind: GRPCRoute
+ *   K8s::Gateway::ReferenceGrant  → apiVersion: gateway.networking.k8s.io/v1beta1, kind: ReferenceGrant
+ *
+ * CRD install: kubectl apply -f
+ *   https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+ */
+const GATEWAY_API_VERSION = "v1.2.1";
+const GATEWAY_API_CRD_BASE = `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${GATEWAY_API_VERSION}/config/crd/standard`;
+
 export const CRD_SOURCES: CRDSource[] = [
   { type: "url", url: `${KUBERAY_CRD_BASE}/ray.io_rayclusters.yaml` },
   { type: "url", url: `${KUBERAY_CRD_BASE}/ray.io_rayjobs.yaml` },
@@ -44,4 +64,9 @@ export const CRD_SOURCES: CRDSource[] = [
   { type: "url", url: `${ARGOCD_CRD_BASE}/application-crd.yaml` },
   { type: "url", url: `${ARGOCD_CRD_BASE}/applicationset-crd.yaml` },
   { type: "url", url: `${ARGOCD_CRD_BASE}/appproject-crd.yaml` },
+  { type: "url", url: `${GATEWAY_API_CRD_BASE}/gateway.networking.k8s.io_gatewayclasses.yaml` },
+  { type: "url", url: `${GATEWAY_API_CRD_BASE}/gateway.networking.k8s.io_gateways.yaml` },
+  { type: "url", url: `${GATEWAY_API_CRD_BASE}/gateway.networking.k8s.io_httproutes.yaml` },
+  { type: "url", url: `${GATEWAY_API_CRD_BASE}/gateway.networking.k8s.io_grpcroutes.yaml` },
+  { type: "url", url: `${GATEWAY_API_CRD_BASE}/gateway.networking.k8s.io_referencegrants.yaml` },
 ];


### PR DESCRIPTION
Closes #272.

## Why
The k8s lexicon generates from the core k8s OpenAPI + a curated CRD list (`crd-sources.ts` — KubeRay, Argo CD). **Gateway API** (`gateway.networking.k8s.io`) is CRD-based and not in that list, so it emitted no classes — pushing authors onto legacy `Ingress` + controller annotations, notably for gRPC where `GRPCRoute` is the native expression.

## Change
Add the Gateway API **standard-channel** CRDs (**v1.2.1**) to `CRD_SOURCES`. The generator now emits (under the `Gateway` namespace — the `gateway.networking.k8s.io` first-segment rule needs no `GROUP_NAMESPACE_OVERRIDES` entry):

| Class | apiVersion |
|---|---|
| `K8s::Gateway::GatewayClass` | `gateway.networking.k8s.io/v1` |
| `K8s::Gateway::Gateway` | `gateway.networking.k8s.io/v1` |
| `K8s::Gateway::HTTPRoute` | `gateway.networking.k8s.io/v1` |
| `K8s::Gateway::GRPCRoute` | `gateway.networking.k8s.io/v1` |
| `K8s::Gateway::ReferenceGrant` | `gateway.networking.k8s.io/v1beta1` |

Only `crd-sources.ts` changes; generated artifacts are gitignored and rebuilt by `prepack`, so CI exercises the CRD fetch.

## Verification
- `npm run --prefix lexicons/k8s prepack` → regenerates clean (194 resources), **validate passes** (`types-compile`, `required-names`, …).
- The five GVKs map exactly as above (checked `dist/meta.json`).
- Core typecheck (`tsc -p packages/core`) + CRD parser tests green; eslint clean.

## Notes
Out of scope (follow-ups noted in #272): cert-manager (`Certificate`/`Issuer`) — would also let the `SecureIngress` composite emit a real `Certificate` instead of its current `Ingress`-proxy placeholder; and a `Gateway`/`GRPCRoute` composite.