### PR TITLE
test: stabilize flaky alert-triage workflow test (#278)

### DIFF
--- a/examples/alert-triage/activities/workflow.test.ts
+++ b/examples/alert-triage/activities/workflow.test.ts
@@ -82,7 +82,10 @@ describe("alert-triage workflow", () => {
     expect(record.approved).toBe(true);
     expect(record.applied).toBe(true);
     expect(durationMs).toBeLessThan(60 * 60 * 1000); // no 12h wait
-  }, 120_000);
+    // retry: the Temporal time-skipping harness can transiently flake under CI
+    // load (worker/timer timing); the assertions are deterministic, so a retry
+    // absorbs the flake without masking a real failure.
+  }, { timeout: 120_000, retry: 2 });
 
   test("risky remediation applies once the approval signal arrives", async () => {
     const { record, durationMs } = await runTriage({ risky: true, signal: true });
@@ -90,7 +93,7 @@ describe("alert-triage workflow", () => {
     expect(record.applied).toBe(true);
     expect(record.calls).toEqual(["classify", "context", "propose", "apply", "notify"]);
     expect(durationMs).toBeLessThan(60 * 60 * 1000); // signal short-circuits the gate
-  }, 120_000);
+  }, { timeout: 120_000, retry: 2 });
 
   test("risky remediation without approval waits out the gate and is never applied", async () => {
     const { record, durationMs } = await runTriage({ risky: true });
@@ -99,5 +102,6 @@ describe("alert-triage workflow", () => {
     expect(record.calls).not.toContain("apply");
     expect(record.calls).toContain("notify");
     expect(durationMs).toBeGreaterThan(11 * 60 * 60 * 1000); // ~12h gate timeout
-  }, 120_000);
+    // retry: see note above — absorbs transient Temporal-harness timing flakes.
+  }, { timeout: 120_000, retry: 2 });
 });


### PR DESCRIPTION
Closes #278. Adds per-test `retry: 2` to the three Temporal time-skipping tests in `examples/alert-triage/activities/workflow.test.ts` — they transiently flake under CI load (worker/timer timing) while the assertions are deterministic. `beforeAll` (env setup) untouched. Verified: the file still passes (3/3), eslint clean.