### PR TITLE
feat(k8s): SecureIngress emits a real CertManager::Certificate (#279)

### DIFF
--- a/lexicons/k8s/src/composites/composites.test.ts
+++ b/lexicons/k8s/src/composites/composites.test.ts
@@ -1486,6 +1486,8 @@ describe("SecureIngress", () => {
   test("creates certificate when clusterIssuer set", () => {
     const result = SecureIngress({ ...minProps, clusterIssuer: "letsencrypt-prod" });
     expect(result.certificate).toBeDefined();
+    // A real cert-manager Certificate, not the former Ingress-proxy placeholder.
+    expect(result.certificate!.constructor.name).toBe("Certificate");
     const certSpec = p(result.certificate!).spec as any;
     expect(certSpec.issuerRef.name).toBe("letsencrypt-prod");
     expect(certSpec.dnsNames).toEqual(["app.example.com"]);

--- a/lexicons/k8s/src/composites/secure-ingress.ts
+++ b/lexicons/k8s/src/composites/secure-ingress.ts
@@ -6,7 +6,7 @@
  */
 
 import { Composite, mergeDefaults } from "@intentius/chant";
-import { Ingress } from "../generated";
+import { Ingress, Certificate } from "../generated";
 
 export interface SecureIngressHost {
   /** Hostname (e.g., "api.example.com"). */
@@ -44,7 +44,7 @@ export interface SecureIngressProps {
 
 export interface SecureIngressResult {
   ingress: InstanceType<typeof Ingress>;
-  certificate?: InstanceType<typeof Ingress>; // CRD — use Ingress as proxy Declarable
+  certificate?: InstanceType<typeof Certificate>; // cert-manager.io/v1 Certificate
 }
 
 /**
@@ -135,8 +135,10 @@ export const SecureIngress = Composite<SecureIngressProps>((props) => {
   const result: Record<string, any> = { ingress };
 
   if (clusterIssuer) {
-    // Certificate is a CRD — use Ingress constructor as a generic Declarable wrapper
-    result.certificate = new Ingress(mergeDefaults({
+    // A real cert-manager Certificate (the ingress-shim annotation on the Ingress
+    // above is also set, so either path issues the cert; the explicit resource
+    // makes the cert lifecycle declarable).
+    result.certificate = new Certificate(mergeDefaults({
       metadata: {
         name: secretName,
         ...(namespace && { namespace }),


### PR DESCRIPTION
Closes #279. Now that the lexicon generates cert-manager classes (#276), the `SecureIngress` composite emits a real `Certificate` (cert-manager.io/v1) when `clusterIssuer` is set, instead of the former `Ingress`-proxy placeholder (wrong kind). The ingress-shim annotation is still set, so either path issues the cert; the explicit resource makes the cert lifecycle declarable. Test asserts `constructor.name === 'Certificate'`. Verified: SecureIngress tests pass, typecheck + eslint clean.