### PR TITLE
docs(k8s): link CRD-Generated Classes page in the sidebar

### DIFF
--- a/lexicons/k8s/docs/src/content/docs/index.mdx
+++ b/lexicons/k8s/docs/src/content/docs/index.mdx
@@ -58,14 +58,14 @@ The lexicon provides **147 resource types** (Deployment, Service, ConfigMap, Sta
 
 | Metric | Count |
 |--------|-------|
-| Resources | 153 |
-| Property types | 109 |
-| Services | 23 |
+| Resources | 165 |
+| Property types | 166 |
+| Services | 27 |
 | Intrinsic functions | 0 |
 | Pseudo-parameters | 0 |
 | Lint rules | 34 |
 
-**Lexicon version:** 0.1.14  
+**Lexicon version:** 0.1.21  
 **Namespace:** `K8s`
 
 - [Getting Started](./getting-started)

--- a/lexicons/k8s/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/k8s/docs/src/content/docs/lint-rules.mdx
@@ -57,7 +57,7 @@ Post-synth checks run against the serialized YAML after build.
 | Rule | Description |
 |------|-------------|
 | WK8201 | Container missing resource limits |
-| WK8301 | Container missing health probes (skips Jobs/CronJobs) |
+| WK8301 | Port-serving container missing health probes (skips Jobs/CronJobs and port-less workers) |
 | WK8302 | Single replica Deployment |
 | WK8303 | HA Deployment without PodDisruptionBudget |
 

--- a/lexicons/k8s/src/codegen/docs.ts
+++ b/lexicons/k8s/src/codegen/docs.ts
@@ -1151,6 +1151,7 @@ The lexicon also provides MCP (Model Context Protocol) tools and resources:
     ],
     basePath: "/chant/lexicons/k8s/",
     sidebarExtra: [
+      { label: "CRD-Generated Classes", slug: "crd-classes" },
       { label: "Argo CD Composites", slug: "argo-composites" },
       {
         label: "Vendor Composites",


### PR DESCRIPTION
## Problem

#282 added the **CRD-Generated Classes** page and a manual sidebar entry in `lexicons/k8s/docs/astro.config.mjs`. But the k8s docs sidebar is **generated** from `src/codegen/docs.ts` — the deploy runs `npm run docs`, which regenerates `astro.config.mjs` at build time. So on publish the manual entry was overwritten: the page shipped live (HTTP 200) but **unlinked** from the left nav.

## Fix

Add the entry to `sidebarExtra` in `docs.ts` (the source of truth), so it survives regeneration.

Also commits regenerated `index.mdx` / `lint-rules.mdx` that had drifted from the generator (resource counts 153→165, lexicon version 0.1.14→0.1.21, WK8301 description from #244) — otherwise they reappear as drift on every `npm run docs`.

## Verify

`npm run docs` → `astro.config.mjs` sidebar includes `crd-classes`, the content page is preserved.