### PR TITLE
docs: declaration/ownership diagram + chant-forward lifecycle model

### DIFF
--- a/docs/diagrams/declaration-ownership.svg
+++ b/docs/diagrams/declaration-ownership.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 200" font-family="Helvetica,Arial,sans-serif">
+  <!-- field = everything outside both sets -->
+  <rect x="8" y="8" width="744" height="184" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5"/>
+  <text x="28" y="32" font-size="12.5" font-weight="bold" fill="#334155">Foreign</text>
+  <text x="86" y="32" font-size="11.5" fill="#64748B">— outside both, never touched</text>
+
+  <!-- the two overlapping sets, as horizontal capsules -->
+  <rect x="48" y="66" width="424" height="104" rx="52" fill="#93C5FD" fill-opacity="0.4" stroke="#2563EB" stroke-width="2"/>
+  <rect x="288" y="66" width="424" height="104" rx="52" fill="#FCD34D" fill-opacity="0.4" stroke="#D97706" stroke-width="2"/>
+
+  <!-- set titles -->
+  <text x="150" y="58" font-size="14" font-weight="bold" fill="#1E3A8A" text-anchor="middle">Declared</text>
+  <text x="610" y="58" font-size="14" font-weight="bold" fill="#92400E" text-anchor="middle">Owned</text>
+
+  <!-- Declared only -->
+  <text x="158" y="114" font-size="13" font-weight="bold" fill="#1E3A8A" text-anchor="middle">To create</text>
+  <text x="158" y="132" font-size="10.5" fill="#1E3A8A" text-anchor="middle">stamps the marker</text>
+
+  <!-- Declared ∩ Owned -->
+  <text x="380" y="114" font-size="13" font-weight="bold" fill="#14532D" text-anchor="middle">Managed</text>
+  <text x="380" y="132" font-size="10.5" fill="#14532D" text-anchor="middle">create / update</text>
+
+  <!-- Owned only -->
+  <text x="602" y="106" font-size="13" font-weight="bold" fill="#78350F" text-anchor="middle">Owned orphan</text>
+  <text x="602" y="124" font-size="10.5" fill="#78350F" text-anchor="middle">the delete decision</text>
+  <text x="602" y="142" font-size="10.5" font-weight="bold" fill="#B45309" text-anchor="middle">→ delete or retain</text>
+</svg>

--- a/docs/src/components/Diagram.astro
+++ b/docs/src/components/Diagram.astro
@@ -9,6 +9,6 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const src = `${base}/diagrams/${name}.svg`;
 ---
 <figure class="diagram not-content" style="overflow-x:auto;margin:1.5rem 0;">
-  <img src={src} alt={alt} loading="lazy" decoding="async" style="display:block;height:auto;min-width:min-content;" />
+  <img src={src} alt={alt} loading="lazy" decoding="async" style="display:block;max-width:100%;height:auto;margin:0 auto;" />
   {caption && <figcaption style="text-align:center;font-size:0.875rem;color:var(--sl-color-gray-3);margin-top:0.5rem;">{caption}</figcaption>}
 </figure>

--- a/docs/src/content/docs/concepts/lifecycle-models.mdx
+++ b/docs/src/content/docs/concepts/lifecycle-models.mdx
@@ -4,6 +4,7 @@ description: The three axes that describe any lifecycle model, and where chant s
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Diagram from '../../../components/Diagram.astro';
 
 Every infrastructure tool takes a position on the lifecycle — how infrastructure is created, changed, reconciled, and retired — usually implicitly, and usually welded to the compiler so you can't take one without the other. chant declines that bet: **pluggable lexicons in, pluggable lifecycles out, pure synthesis in the middle.** Bring your own lifecycle, and chant makes it durable.
 
@@ -54,6 +55,18 @@ This third axis is the one most tools collapse into the first: they answer "is t
 - **Truth is the live system.** chant reads the cloud directly. The snapshot it stores is evidence for diffing, never a source of truth.
 - **Reconciliation direction is a per-environment choice.** A dev environment might only observe; staging might reconcile `cloud → code`; production might apply `code → cloud` behind a gate. Same project, different dial positions.
 - **Ownership is answered by live markers.** A chant-managed resource carries a [marker](/chant/configuration/config-file/#ownership) — a standard tag or label — that records the stack identity on the resource itself. "Is this mine?" is answered by reading that marker, never by a record chant has to lock.
+
+## Declaration and ownership are independent
+
+<Diagram name="declaration-ownership" alt="Two overlapping bands, Declared and Owned, on a Foreign field. Declared-only is to-create, the overlap is managed, Owned-only is the owned orphan where the delete-or-retain decision lives, and everything outside both bands is foreign and never touched." caption="Declaration and ownership are two overlapping sets. A delete is only possible where a resource is owned but no longer declared — everything outside both is foreign." />
+
+Declaration is your source — what your TypeScript exports. Ownership is a fact recorded on the live resource — a marker chant reads, never a record it locks. Because the two are separate, dropping a resource from your source does not by itself delete it. [`chant lifecycle plan`](/chant/cli/lifecycle/) proposes a delete only for a resource that is owned **and** no longer declared. Three levers decide what happens to it.
+
+- **`ApplyOp delete: "never"`** — stack-wide. Apply never prunes, so an undeclared resource is left alone.
+- **Strip the marker** — per-resource. The prune is marker-scoped, so an unmarked resource is foreign and never touched.
+- **Spec-true retain** — the target spec's own knob. CloudFormation `DeletionPolicy: Retain`, the K8s prune selector. chant passes it through rather than inventing one.
+
+No hosted state file decides this. A resource lives or dies based on what you declare and what its live marker says, which is why the snapshot can be deleted between runs with no change in behavior.
 
 ## The dial
 

--- a/scripts/build-diagrams.sh
+++ b/scripts/build-diagrams.sh
@@ -16,6 +16,14 @@ build_diagrams() {
     echo "  $f → $out_dir/$name.svg"
     count=$((count + 1))
   done
+  # Hand-authored SVGs (e.g. Venn diagrams graphviz can't draw) are copied through as-is.
+  for f in "$src_dir"/*.svg; do
+    [ -f "$f" ] || continue
+    name=$(basename "$f")
+    cp "$f" "$out_dir/$name"
+    echo "  $f → $out_dir/$name (copied)"
+    count=$((count + 1))
+  done
   [ "$count" -gt 0 ] && echo "  $count diagram(s) built in $out_dir"
 }
 


### PR DESCRIPTION
## What

Adds a **Declaration and ownership are independent** section to `concepts/lifecycle-models.mdx`, with a diagram showing the two as overlapping sets (declared vs owned). The delete decision lives only where a resource is owned but no longer declared, and three levers move it out of that region — `ApplyOp delete: "never"`, stripping the ownership marker, and spec-true retain (e.g. CloudFormation `DeletionPolicy: Retain`). Written entirely in chant's own terms.

## Changes

- **`concepts/lifecycle-models.mdx`** — new section + embedded `declaration-ownership` diagram.
- **`docs/diagrams/declaration-ownership.svg`** — hand-authored two-set diagram (graphviz can't draw it).
- **`Diagram.astro`** — diagrams now scale to column width (`max-width:100%`) instead of forcing natural width and side-scrolling. Applies to all diagrams.
- **`scripts/build-diagrams.sh`** — copy hand-authored `.svg` sources through to `public/diagrams/` alongside the generated `.dot` outputs.

## Notes

- `DeletionPolicy: Retain` round-trip through `chant build` was verified manually (typed field → serializer → emitted template).
- Unrelated: a separate YAML-output bug surfaced during that verification, filed as #284.