### PR TITLE
fix(github): resolve duplicate GHA020 lint ID (#293)

### DIFF
--- a/lexicons/github/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/github/docs/src/content/docs/lint-rules.mdx
@@ -135,6 +135,12 @@ Flags matrix strategy dimensions with an empty values array. An empty dimension 
 
 Flags jobs whose `needs:` entries reference a job not defined in the workflow. This causes a workflow validation error on GitHub.
 
+### GHA013 — Missing job-level permissions for sensitive triggers
+
+**Severity:** warning
+
+Flags jobs without an explicit `permissions:` block when the workflow uses a sensitive trigger (`pull_request_target` or `workflow_dispatch`). Declaring job-level permissions keeps least-privilege scope on workflows that run with elevated context.
+
 ### GHA017 — Missing permissions block
 
 **Severity:** info

--- a/lexicons/github/src/codegen/docs.ts
+++ b/lexicons/github/src/codegen/docs.ts
@@ -952,6 +952,12 @@ Flags matrix strategy dimensions with an empty values array. An empty dimension 
 
 Flags jobs whose \`needs:\` entries reference a job not defined in the workflow. This causes a workflow validation error on GitHub.
 
+### GHA013 — Missing job-level permissions for sensitive triggers
+
+**Severity:** warning
+
+Flags jobs without an explicit \`permissions:\` block when the workflow uses a sensitive trigger (\`pull_request_target\` or \`workflow_dispatch\`). Declaring job-level permissions keeps least-privilege scope on workflows that run with elevated context.
+
 ### GHA017 — Missing permissions block
 
 **Severity:** info

--- a/lexicons/github/src/lint/post-synth/gha013.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha013.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest";
 import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
-import { gha020 } from "./gha020";
+import { gha013 } from "./gha013";
 
 function makeCtx(yaml: string): PostSynthContext {
   return {
@@ -16,7 +16,7 @@ function makeCtx(yaml: string): PostSynthContext {
   };
 }
 
-describe("GHA020: missing job-level permissions for sensitive triggers", () => {
+describe("GHA013: missing job-level permissions for sensitive triggers", () => {
   test("flags job without permissions when using pull_request_target", () => {
     const yaml = `name: Review
 on:
@@ -27,9 +27,9 @@ jobs:
     steps:
       - run: echo review
 `;
-    const diags = gha020.check(makeCtx(yaml));
+    const diags = gha013.check(makeCtx(yaml));
     expect(diags).toHaveLength(1);
-    expect(diags[0].checkId).toBe("GHA020");
+    expect(diags[0].checkId).toBe("GHA013");
     expect(diags[0].severity).toBe("warning");
     expect(diags[0].message).toContain("review");
   });
@@ -44,9 +44,9 @@ jobs:
     steps:
       - run: echo deploy
 `;
-    const diags = gha020.check(makeCtx(yaml));
+    const diags = gha013.check(makeCtx(yaml));
     expect(diags).toHaveLength(1);
-    expect(diags[0].checkId).toBe("GHA020");
+    expect(diags[0].checkId).toBe("GHA013");
     expect(diags[0].message).toContain("deploy");
   });
 
@@ -60,7 +60,7 @@ jobs:
     steps:
       - run: echo build
 `;
-    const diags = gha020.check(makeCtx(yaml));
+    const diags = gha013.check(makeCtx(yaml));
     expect(diags).toHaveLength(0);
   });
 });

--- a/lexicons/github/src/lint/post-synth/gha013.ts
+++ b/lexicons/github/src/lint/post-synth/gha013.ts
@@ -1,5 +1,5 @@
 /**
- * GHA020: Missing Job-Level Permissions for Sensitive Triggers
+ * GHA013: Missing Job-Level Permissions for Sensitive Triggers
  *
  * Flags jobs without explicit `permissions:` when the workflow uses
  * `pull_request_target` or `workflow_dispatch` triggers.
@@ -8,8 +8,8 @@
 import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
 import { getPrimaryOutput, extractJobs, extractTriggers } from "./yaml-helpers";
 
-export const gha020: PostSynthCheck = {
-  id: "GHA020",
+export const gha013: PostSynthCheck = {
+  id: "GHA013",
   description: "Missing job-level permissions for sensitive triggers",
 
   check(ctx: PostSynthContext): PostSynthDiagnostic[] {
@@ -25,7 +25,7 @@ export const gha020: PostSynthCheck = {
       for (const [jobName, job] of jobs) {
         if (!job.permissions) {
           diagnostics.push({
-            checkId: "GHA020",
+            checkId: "GHA013",
             severity: "warning",
             message: `Job "${jobName}" lacks explicit permissions but workflow uses a sensitive trigger. Add job-level permissions for least-privilege security.`,
             entity: jobName,

--- a/lexicons/github/src/plugin.test.ts
+++ b/lexicons/github/src/plugin.test.ts
@@ -30,9 +30,25 @@ describe("githubPlugin", () => {
     expect(checkIds).toContain("GHA006");
     expect(checkIds).toContain("GHA009");
     expect(checkIds).toContain("GHA011");
+    expect(checkIds).toContain("GHA013");
     expect(checkIds).toContain("GHA017");
     expect(checkIds).toContain("GHA018");
     expect(checkIds).toContain("GHA019");
+  });
+
+  test("lint IDs are unique across rules and post-synth checks", () => {
+    const ruleIds = githubPlugin.lintRules!().map((r) => r.id);
+    const checkIds = githubPlugin.postSynthChecks!().map((c) => c.id);
+    const allIds = [...ruleIds, ...checkIds];
+
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const id of allIds) {
+      if (seen.has(id)) duplicates.add(id);
+      seen.add(id);
+    }
+
+    expect(Array.from(duplicates)).toEqual([]);
   });
 
   test("provides intrinsics", () => {


### PR DESCRIPTION
Closes #293.

## Problem
Two checks both claimed `GHA020`: the `detect-secrets` declarative rule and the `missing job-level permissions` post-synth check. Colliding IDs make suppressions and diagnostics ambiguous.

## Fix
- Renumber the post-synth *missing job-level permissions* check `GHA020` → `GHA013` (a free ID). `GHA020` stays on the `detect-secrets` rule.
- Add a `plugin.test.ts` guard that fails if any lint ID collides across rules + post-synth checks, preventing recurrence.
- Document `GHA013` in `codegen/docs.ts` and regenerate `lint-rules.mdx`.

## Tests
- `gha013.test.ts` (renamed from `gha020.test.ts`) — positive + negative.
- New uniqueness guard in `plugin.test.ts`.
- `npx vitest run` green for github lint + plugin; core `tsc --noEmit` clean.