### PR TITLE
feat(github): pin & vet external action & image references (#286)

### DIFF
--- a/lexicons/github/docs/src/content/docs/index.mdx
+++ b/lexicons/github/docs/src/content/docs/index.mdx
@@ -52,9 +52,9 @@ The lexicon provides **2 resources** (Workflow, Job), **13 composites** (Checkou
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 28 |
+| Lint rules | 32 |
 
-**Lexicon version:** 0.1.14  
+**Lexicon version:** 0.1.23  
 **Namespace:** `GitHub`
 
 - [Getting Started](./getting-started)

--- a/lexicons/github/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/github/docs/src/content/docs/lint-rules.mdx
@@ -159,6 +159,30 @@ Flags workflows triggered by `pull_request_target` that include `actions/checkou
 
 Detects cycles in the `needs:` dependency graph. If job A needs B and B needs A (directly or transitively), GitHub rejects the workflow. Reports the full cycle chain in the diagnostic message.
 
+### GHA029 — Action or reusable workflow not pinned to a commit SHA
+
+**Severity:** warning
+
+Flags any `uses:` — step action or job-level reusable workflow — pinned to a mutable tag or branch instead of a full commit SHA. Tags can be repointed to malicious code after review, so every external reference should be pinned. `actions/checkout` is covered by the more specific GHA021; local (`./`) and `docker://` references are out of scope. Owners in the vendored trusted allowlist are exempt.
+
+### GHA030 — Container image not pinned to a digest
+
+**Severity:** warning
+
+Flags job `container:` images, `services:` images, and `docker://` step references that are not pinned to an immutable `@sha256:` digest. A mutable tag can be repointed to a different image after review.
+
+### GHA031 — Action resembles a well-known action
+
+**Severity:** warning
+
+Flags a `uses:` slug that is a near-miss (edit distance 1–2) of a popular action but not an exact match — a likely typo or impersonation under different ownership. Advisory; backed by a vendored reference list.
+
+### GHA032 — Archived or compromised action
+
+**Severity:** warning
+
+Flags a `uses:` slug that a vendored snapshot marks as archived/abandoned or carrying a disclosed security issue, with remediation. Advisory and necessarily incomplete.
+
 ## Running lint
 
 ```bash

--- a/lexicons/github/src/codegen/docs.ts
+++ b/lexicons/github/src/codegen/docs.ts
@@ -976,6 +976,30 @@ Flags workflows triggered by \`pull_request_target\` that include \`actions/chec
 
 Detects cycles in the \`needs:\` dependency graph. If job A needs B and B needs A (directly or transitively), GitHub rejects the workflow. Reports the full cycle chain in the diagnostic message.
 
+### GHA029 — Action or reusable workflow not pinned to a commit SHA
+
+**Severity:** warning
+
+Flags any \`uses:\` — step action or job-level reusable workflow — pinned to a mutable tag or branch instead of a full commit SHA. Tags can be repointed to malicious code after review, so every external reference should be pinned. \`actions/checkout\` is covered by the more specific GHA021; local (\`./\`) and \`docker://\` references are out of scope. Owners in the vendored trusted allowlist are exempt.
+
+### GHA030 — Container image not pinned to a digest
+
+**Severity:** warning
+
+Flags job \`container:\` images, \`services:\` images, and \`docker://\` step references that are not pinned to an immutable \`@sha256:\` digest. A mutable tag can be repointed to a different image after review.
+
+### GHA031 — Action resembles a well-known action
+
+**Severity:** warning
+
+Flags a \`uses:\` slug that is a near-miss (edit distance 1–2) of a popular action but not an exact match — a likely typo or impersonation under different ownership. Advisory; backed by a vendored reference list.
+
+### GHA032 — Archived or compromised action
+
+**Severity:** warning
+
+Flags a \`uses:\` slug that a vendored snapshot marks as archived/abandoned or carrying a disclosed security issue, with remediation. Advisory and necessarily incomplete.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/github/src/lint/post-synth/gha029.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha029.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha029, findUnpinnedActions } from "./gha029";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA029: unpinned action / reusable workflow", () => {
+  test("flags a step action pinned to a tag", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+      - run: echo build
+`;
+    const diags = gha029.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA029");
+    expect(diags[0].severity).toBe("warning");
+    expect(diags[0].entity).toBe("build");
+    expect(diags[0].message).toContain("actions/setup-node@v4");
+  });
+
+  test("flags a job-level reusable workflow pinned to a tag", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  call:
+    uses: org/repo/.github/workflows/reusable.yml@v1
+`;
+    const diags = gha029.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain("reusable.yml@v1");
+  });
+
+  test("does not flag an action pinned to a full SHA", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
+      - run: echo build
+`;
+    const diags = gha029.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag actions/checkout (owned by GHA021)", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`;
+    const diags = gha029.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag local actions", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/local
+`;
+    const diags = gha029.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("allowlist exempts a trusted owner", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: trustedco/action@v1
+`;
+    expect(findUnpinnedActions(yaml)).toHaveLength(1);
+    expect(findUnpinnedActions(yaml, new Set(["trustedco"]))).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha029.ts
+++ b/lexicons/github/src/lint/post-synth/gha029.ts
@@ -1,0 +1,68 @@
+/**
+ * GHA029: Unpinned Action or Reusable-Workflow Reference
+ *
+ * Flags any `uses:` (step action or job-level reusable workflow) that is pinned
+ * to a mutable tag or branch instead of a full 40-character commit SHA. A tag
+ * can be repointed to malicious code after review, so every external reference
+ * is a supply-chain trust decision.
+ *
+ * `actions/checkout` is intentionally left to the more specific GHA021. Local
+ * references (`./`, `../`) and `docker://` images (GHA030) are out of scope.
+ * Owners in the trusted allowlist are exempt.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractActionRefs, parseActionUses } from "./yaml-helpers";
+import { TRUSTED_ACTION_OWNERS } from "../rules/data/trusted-action-owners";
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+export interface UnpinnedRef {
+  job: string;
+  ref: string;
+  slug: string;
+}
+
+/**
+ * Find every action/reusable-workflow `uses:` that is not pinned to a commit
+ * SHA. Exposed as a pure function so the allowlist behaviour is testable.
+ */
+export function findUnpinnedActions(
+  yaml: string,
+  trustedOwners: ReadonlySet<string> = TRUSTED_ACTION_OWNERS,
+): UnpinnedRef[] {
+  const result: UnpinnedRef[] = [];
+  for (const { job, ref } of extractActionRefs(yaml)) {
+    const parsed = parseActionUses(ref);
+    if (!parsed) continue; // local or docker:// reference
+    if (parsed.slug === "actions/checkout") continue; // owned by GHA021
+    if (trustedOwners.has(parsed.owner)) continue;
+    if (SHA_RE.test(parsed.gitRef)) continue; // already pinned
+    result.push({ job, ref, slug: parsed.slug });
+  }
+  return result;
+}
+
+export const gha029: PostSynthCheck = {
+  id: "GHA029",
+  description: "Action or reusable workflow not pinned to a commit SHA",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, ref } of findUnpinnedActions(yaml)) {
+        diagnostics.push({
+          checkId: "GHA029",
+          severity: "warning",
+          message: `Job "${job}" uses ${ref} pinned to a tag or branch — pin to a full commit SHA for supply-chain security.`,
+          entity: job,
+          lexicon: "github",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha030.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha030.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha030 } from "./gha030";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA030: container image without digest", () => {
+  test("flags a container image pinned to a tag", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:20
+    steps:
+      - run: echo build
+`;
+    const diags = gha030.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA030");
+    expect(diags[0].entity).toBe("build");
+    expect(diags[0].message).toContain("node:20");
+  });
+
+  test("flags a service image pinned to a tag", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7
+    steps:
+      - run: echo build
+`;
+    const diags = gha030.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain("redis:7");
+  });
+
+  test("flags a docker:// step reference without digest", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://alpine:3.19
+`;
+    const diags = gha030.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain("alpine:3.19");
+  });
+
+  test("does not flag a container image pinned to a digest", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    steps:
+      - run: echo build
+`;
+    const diags = gha030.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha030.ts
+++ b/lexicons/github/src/lint/post-synth/gha030.ts
@@ -1,0 +1,41 @@
+/**
+ * GHA030: Container Image Without an Immutable Digest
+ *
+ * Flags job `container:` images, `services:` images, and `docker://` step
+ * references that are not pinned to an immutable `@sha256:` digest. A mutable
+ * tag (`:latest`, `:20`) can be repointed to a different image after review.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractImageRefs } from "./yaml-helpers";
+
+const SOURCE_LABEL: Record<string, string> = {
+  container: "container image",
+  service: "service image",
+  step: "docker:// image",
+};
+
+export const gha030: PostSynthCheck = {
+  id: "GHA030",
+  description: "Container image not pinned to an immutable digest",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, image, source } of extractImageRefs(yaml)) {
+        if (image.includes("@sha256:")) continue;
+        diagnostics.push({
+          checkId: "GHA030",
+          severity: "warning",
+          message: `Job "${job}" ${SOURCE_LABEL[source]} "${image}" is not pinned to a digest — reference it by @sha256:... so the image cannot change after review.`,
+          entity: job,
+          lexicon: "github",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha031.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha031.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha031, editDistance, nearestLookAlike } from "./gha031";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA031: look-alike action reference", () => {
+  test("editDistance basics", () => {
+    expect(editDistance("abc", "abc", 2)).toBe(0);
+    expect(editDistance("actions/chekout", "actions/checkout", 2)).toBe(1);
+    expect(editDistance("totally/different-name-xyz", "actions/checkout", 2)).toBe(3);
+  });
+
+  test("nearestLookAlike returns the close known slug", () => {
+    expect(nearestLookAlike("actions/checkout")).toBeUndefined(); // exact match
+    expect(nearestLookAlike("actions/chekout")).toBe("actions/checkout");
+    expect(nearestLookAlike("totally/unrelated")).toBeUndefined();
+  });
+
+  test("flags a typo-squatted action", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkoutt@v4
+`;
+    const diags = gha031.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA031");
+    expect(diags[0].message).toContain("actions/checkout");
+  });
+
+  test("does not flag a legitimate exact known action", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`;
+    const diags = gha031.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag an unrelated third-party action", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: my-org/my-custom-thing@v1
+`;
+    const diags = gha031.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha031.ts
+++ b/lexicons/github/src/lint/post-synth/gha031.ts
@@ -1,0 +1,77 @@
+/**
+ * GHA031: Action Reference Resembling a Well-Known Action
+ *
+ * Flags a `uses:` slug that is a near-miss (edit distance 1–2) of a popular
+ * action but not an exact match — a likely typo or a deliberate impersonation
+ * of the well-known action under different ownership. Advisory only; backed by
+ * a vendored reference list.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractActionRefs, parseActionUses } from "./yaml-helpers";
+import { KNOWN_ACTION_SLUGS } from "../rules/data/known-action-slugs";
+
+const KNOWN = new Set(KNOWN_ACTION_SLUGS);
+
+/** Levenshtein edit distance, capped: returns early once it exceeds `max`. */
+export function editDistance(a: string, b: string, max: number): number {
+  if (a === b) return 0;
+  if (Math.abs(a.length - b.length) > max) return max + 1;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    let rowMin = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      const val = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+      curr.push(val);
+      if (val < rowMin) rowMin = val;
+    }
+    if (rowMin > max) return max + 1;
+    prev = curr;
+  }
+  return prev[b.length];
+}
+
+/** Find the nearest known slug within edit distance 1–2 of `slug`, if any. */
+export function nearestLookAlike(slug: string): string | undefined {
+  if (KNOWN.has(slug)) return undefined; // exact match is legitimate
+  let best: string | undefined;
+  let bestDist = 3;
+  for (const known of KNOWN) {
+    const d = editDistance(slug, known, 2);
+    if (d >= 1 && d <= 2 && d < bestDist) {
+      best = known;
+      bestDist = d;
+    }
+  }
+  return best;
+}
+
+export const gha031: PostSynthCheck = {
+  id: "GHA031",
+  description: "Action reference resembles a well-known action (possible impersonation)",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, ref } of extractActionRefs(yaml)) {
+        const parsed = parseActionUses(ref);
+        if (!parsed) continue;
+        const lookAlike = nearestLookAlike(parsed.slug);
+        if (!lookAlike) continue;
+        diagnostics.push({
+          checkId: "GHA031",
+          severity: "warning",
+          message: `Job "${job}" uses "${parsed.slug}", which closely resembles the well-known action "${lookAlike}". Confirm the owner is who you intend — this may be a typo or impersonation.`,
+          entity: job,
+          lexicon: "github",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha032.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha032.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha032 } from "./gha032";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA032: archived or compromised action", () => {
+  test("flags a known compromised action", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tj-actions/changed-files@v44
+`;
+    const diags = gha032.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA032");
+    expect(diags[0].entity).toBe("build");
+    expect(diags[0].message).toContain("tj-actions/changed-files");
+  });
+
+  test("flags a known archived action", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-ruby@v1
+`;
+    const diags = gha032.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain("ruby/setup-ruby");
+  });
+
+  test("does not flag a maintained action", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+`;
+    const diags = gha032.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha032.ts
+++ b/lexicons/github/src/lint/post-synth/gha032.ts
@@ -1,0 +1,39 @@
+/**
+ * GHA032: Reference to an Archived or Compromised Action
+ *
+ * Flags a `uses:` slug that a vendored snapshot marks as archived/abandoned or
+ * carrying a disclosed security issue. Advisory only — the dataset is
+ * necessarily incomplete and may lag upstream changes.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractActionRefs, parseActionUses } from "./yaml-helpers";
+import { FLAGGED_ACTIONS } from "../rules/data/flagged-actions";
+
+export const gha032: PostSynthCheck = {
+  id: "GHA032",
+  description: "Action is archived/abandoned or has a disclosed security issue",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, ref } of extractActionRefs(yaml)) {
+        const parsed = parseActionUses(ref);
+        if (!parsed) continue;
+        const flagged = FLAGGED_ACTIONS[parsed.slug];
+        if (!flagged) continue;
+        diagnostics.push({
+          checkId: "GHA032",
+          severity: "warning",
+          message: `Job "${job}" uses "${parsed.slug}" — ${flagged.reason}. ${flagged.remediation}.`,
+          entity: job,
+          lexicon: "github",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/yaml-helpers.ts
+++ b/lexicons/github/src/lint/post-synth/yaml-helpers.ts
@@ -2,6 +2,8 @@
  * Helpers for parsing serialized GitHub Actions YAML in post-synth checks.
  */
 
+import { parseYAML } from "@intentius/chant/yaml";
+
 export { getPrimaryOutput } from "@intentius/chant/lint/post-synth";
 
 export interface ParsedJob {
@@ -126,4 +128,120 @@ export function extractWorkflowName(yaml: string): string | undefined {
  */
 export function hasPermissions(yaml: string): boolean {
   return /^permissions:/m.test(yaml);
+}
+
+/** A single `uses:` reference found in a workflow. */
+export interface ActionRef {
+  /** Owning job name. */
+  job: string;
+  /** The raw `uses:` value (e.g. `actions/setup-node@v4`). */
+  ref: string;
+  /** Whether it is a step-level action or a job-level reusable workflow. */
+  level: "step" | "job";
+}
+
+/** A container/service/docker image reference found in a workflow. */
+export interface ImageRef {
+  /** Owning job name. */
+  job: string;
+  /** The raw image reference (e.g. `node:20`). */
+  image: string;
+  /** Where the image was declared. */
+  source: "container" | "service" | "step";
+}
+
+function parseDoc(yaml: string): Record<string, unknown> | undefined {
+  try {
+    return parseYAML(yaml);
+  } catch {
+    return undefined;
+  }
+}
+
+function jobEntries(yaml: string): Array<[string, Record<string, unknown>]> {
+  const doc = parseDoc(yaml);
+  const jobs = doc?.jobs;
+  if (!jobs || typeof jobs !== "object") return [];
+  const out: Array<[string, Record<string, unknown>]> = [];
+  for (const [name, val] of Object.entries(jobs as Record<string, unknown>)) {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      out.push([name, val as Record<string, unknown>]);
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract every `uses:` reference from the workflow — both step-level actions
+ * and job-level reusable-workflow calls. Uses the structural YAML parser so
+ * nested jobs/steps are handled reliably.
+ */
+export function extractActionRefs(yaml: string): ActionRef[] {
+  const refs: ActionRef[] = [];
+  for (const [job, jobObj] of jobEntries(yaml)) {
+    if (typeof jobObj.uses === "string") {
+      refs.push({ job, ref: jobObj.uses, level: "job" });
+    }
+    const steps = jobObj.steps;
+    if (Array.isArray(steps)) {
+      for (const step of steps) {
+        if (step && typeof step === "object" && typeof (step as Record<string, unknown>).uses === "string") {
+          refs.push({ job, ref: (step as Record<string, unknown>).uses as string, level: "step" });
+        }
+      }
+    }
+  }
+  return refs;
+}
+
+/**
+ * Extract every container/service/`docker://` image reference from the workflow.
+ */
+export function extractImageRefs(yaml: string): ImageRef[] {
+  const refs: ImageRef[] = [];
+  for (const [job, jobObj] of jobEntries(yaml)) {
+    const container = jobObj.container;
+    if (typeof container === "string") {
+      refs.push({ job, image: container, source: "container" });
+    } else if (container && typeof container === "object" && typeof (container as Record<string, unknown>).image === "string") {
+      refs.push({ job, image: (container as Record<string, unknown>).image as string, source: "container" });
+    }
+
+    const services = jobObj.services;
+    if (services && typeof services === "object" && !Array.isArray(services)) {
+      for (const svc of Object.values(services as Record<string, unknown>)) {
+        if (typeof svc === "string") {
+          refs.push({ job, image: svc, source: "service" });
+        } else if (svc && typeof svc === "object" && typeof (svc as Record<string, unknown>).image === "string") {
+          refs.push({ job, image: (svc as Record<string, unknown>).image as string, source: "service" });
+        }
+      }
+    }
+
+    const steps = jobObj.steps;
+    if (Array.isArray(steps)) {
+      for (const step of steps) {
+        const uses = step && typeof step === "object" ? (step as Record<string, unknown>).uses : undefined;
+        if (typeof uses === "string" && uses.startsWith("docker://")) {
+          refs.push({ job, image: uses.slice("docker://".length), source: "step" });
+        }
+      }
+    }
+  }
+  return refs;
+}
+
+/**
+ * Split an action `uses:` value into its `owner/repo` slug and git ref.
+ * Returns undefined for local (`./`, `../`) and `docker://` references, which
+ * are not GitHub action repository references.
+ */
+export function parseActionUses(uses: string): { owner: string; repo: string; slug: string; gitRef: string } | undefined {
+  if (uses.startsWith("./") || uses.startsWith("../") || uses.startsWith("docker://")) return undefined;
+  const at = uses.lastIndexOf("@");
+  const path = at === -1 ? uses : uses.slice(0, at);
+  const gitRef = at === -1 ? "" : uses.slice(at + 1);
+  const segments = path.split("/");
+  if (segments.length < 2 || !segments[0] || !segments[1]) return undefined;
+  return { owner: segments[0], repo: segments[1], slug: `${segments[0]}/${segments[1]}`, gitRef };
 }

--- a/lexicons/github/src/lint/rules/data/flagged-actions.ts
+++ b/lexicons/github/src/lint/rules/data/flagged-actions.ts
@@ -1,0 +1,36 @@
+/**
+ * Vendored snapshot of action `owner/repo` slugs that are archived/abandoned or
+ * carry a disclosed security issue. Used by GHA032.
+ *
+ * Advisory only, and necessarily incomplete. Refresh source: GitHub Security
+ * Advisories (GHSA), CVE feeds, and upstream "archived" repo status. Accept
+ * staleness — regenerate periodically by editing this map. A missing entry only
+ * means a known-bad upstream goes unflagged; it never blocks a build.
+ *
+ * Keep entries factual and dated so the advice stays actionable.
+ */
+export interface FlaggedAction {
+  /** Why the upstream is flagged. */
+  reason: string;
+  /** What to do instead. */
+  remediation: string;
+}
+
+export const FLAGGED_ACTIONS: Readonly<Record<string, FlaggedAction>> = {
+  "tj-actions/changed-files": {
+    reason: "supply-chain compromise disclosed March 2025 (CVE-2025-30066) — tags were repointed to leak CI secrets",
+    remediation: "pin to a vetted commit SHA from before the compromise, or migrate to an audited alternative",
+  },
+  "actions/setup-ruby": {
+    reason: "archived and unmaintained",
+    remediation: "use ruby/setup-ruby",
+  },
+  "actions/create-release": {
+    reason: "archived and unmaintained",
+    remediation: "use softprops/action-gh-release or the gh CLI",
+  },
+  "actions/upload-release-asset": {
+    reason: "archived and unmaintained",
+    remediation: "use softprops/action-gh-release or the gh CLI",
+  },
+};

--- a/lexicons/github/src/lint/rules/data/known-action-slugs.ts
+++ b/lexicons/github/src/lint/rules/data/known-action-slugs.ts
@@ -1,0 +1,38 @@
+/**
+ * Vendored snapshot of widely-used GitHub Action `owner/repo` slugs.
+ *
+ * Used by the look-alike check (GHA031) as the reference set: a `uses:` slug
+ * that is a near-miss (edit distance 1–2) of one of these — but not an exact
+ * match — is likely a typo or an impersonation of the popular action.
+ *
+ * Advisory only. Refresh source: the GitHub Marketplace "most-used" actions and
+ * the actions/* org. Accept staleness — regenerate periodically by editing this
+ * list; a stale entry only weakens look-alike detection, it never blocks a build.
+ */
+export const KNOWN_ACTION_SLUGS: readonly string[] = [
+  "actions/checkout",
+  "actions/setup-node",
+  "actions/setup-python",
+  "actions/setup-go",
+  "actions/setup-java",
+  "actions/setup-dotnet",
+  "actions/cache",
+  "actions/upload-artifact",
+  "actions/download-artifact",
+  "actions/github-script",
+  "actions/stale",
+  "actions/labeler",
+  "actions/dependency-review-action",
+  "docker/build-push-action",
+  "docker/login-action",
+  "docker/setup-buildx-action",
+  "docker/setup-qemu-action",
+  "docker/metadata-action",
+  "aws-actions/configure-aws-credentials",
+  "azure/login",
+  "google-github-actions/auth",
+  "hashicorp/setup-terraform",
+  "codecov/codecov-action",
+  "softprops/action-gh-release",
+  "peter-evans/create-pull-request",
+];

--- a/lexicons/github/src/lint/rules/data/trusted-action-owners.ts
+++ b/lexicons/github/src/lint/rules/data/trusted-action-owners.ts
@@ -1,0 +1,12 @@
+/**
+ * Allowlist of trusted action owners (GitHub orgs) whose `uses:` references are
+ * exempt from the SHA-pinning check (GHA029).
+ *
+ * Ships EMPTY by default: chant recommends pinning every external reference to a
+ * full commit SHA, including first-party ones. Populate this set to silence the
+ * pinning check for orgs you have decided to trust by tag (e.g. your own org).
+ *
+ * This is a vendored, code-level allowlist — `PostSynthContext` carries no
+ * per-check runtime config channel today. Refresh it by editing this file.
+ */
+export const TRUSTED_ACTION_OWNERS: ReadonlySet<string> = new Set<string>([]);

--- a/lexicons/github/src/plugin.test.ts
+++ b/lexicons/github/src/plugin.test.ts
@@ -24,7 +24,7 @@ describe("githubPlugin", () => {
 
   test("provides post-synth checks", () => {
     const checks = githubPlugin.postSynthChecks!();
-    expect(checks.length).toBe(15);
+    expect(checks.length).toBe(19);
 
     const checkIds = checks.map((c) => c.id);
     expect(checkIds).toContain("GHA006");
@@ -34,6 +34,10 @@ describe("githubPlugin", () => {
     expect(checkIds).toContain("GHA017");
     expect(checkIds).toContain("GHA018");
     expect(checkIds).toContain("GHA019");
+    expect(checkIds).toContain("GHA029");
+    expect(checkIds).toContain("GHA030");
+    expect(checkIds).toContain("GHA031");
+    expect(checkIds).toContain("GHA032");
   });
 
   test("lint IDs are unique across rules and post-synth checks", () => {


### PR DESCRIPTION
Closes #286.

Generalizes supply-chain vetting beyond `actions/checkout` (GHA021) to every external reference chant emits. Four new post-synth checks on the serialized workflow YAML:

| ID | Check | Severity |
|----|-------|----------|
| GHA029 | action / reusable-workflow `uses:` not pinned to a full commit SHA | warning |
| GHA030 | `container:` / `services:` / `docker://` image without an `@sha256:` digest | warning |
| GHA031 | `uses:` slug resembling a well-known action (typo / impersonation) | warning |
| GHA032 | archived/abandoned or disclosed-issue upstream | warning |

### Design notes
- **GHA029** deliberately skips `actions/checkout` (owned by the more specific GHA021) and `docker://` refs (GHA030), and exempts owners in a vendored `TRUSTED_ACTION_OWNERS` allowlist. The allowlist is a **code-level constant** because `PostSynthContext` has no per-check runtime-config channel; the core matcher is exposed as a pure `findUnpinnedActions(yaml, owners)` so the exemption path is unit-tested.
- **GHA031/GHA032** are backed by vendored snapshots under `lint/rules/data/` (`known-action-slugs.ts`, `flagged-actions.ts`) with header comments documenting refresh source/cadence. Advisory only — staleness weakens detection, never blocks a build (matches the issue's out-of-scope note on live resolution).
- New structural helpers (`extractActionRefs`, `extractImageRefs`, `parseActionUses`) parse via core `parseYAML` rather than regex, so nested `container`/`services`/`steps` are handled reliably.

### Tests / checks
- Positive + negative fixture test per check (`gha029–032.test.ts`), plus `editDistance`/`nearestLookAlike`/allowlist unit tests.
- `npx vitest run` green for the github lexicon (173 tests); core `tsc --noEmit` clean; eslint clean; docs regenerated.

Note: GHA013's renumber (#293) landed first, so 029+ is the next free range.