### PR TITLE
feat(github): enforce least-privilege token permissions (#287)

### DIFF
--- a/lexicons/github/docs/src/content/docs/index.mdx
+++ b/lexicons/github/docs/src/content/docs/index.mdx
@@ -52,7 +52,7 @@ The lexicon provides **2 resources** (Workflow, Job), **13 composites** (Checkou
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 32 |
+| Lint rules | 35 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitHub`

--- a/lexicons/github/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/github/docs/src/content/docs/lint-rules.mdx
@@ -183,6 +183,24 @@ Flags a `uses:` slug that is a near-miss (edit distance 1–2) of a popular acti
 
 Flags a `uses:` slug that a vendored snapshot marks as archived/abandoned or carrying a disclosed security issue, with remediation. Advisory and necessarily incomplete.
 
+### GHA033 — Blanket write-all permissions
+
+**Severity:** warning
+
+Flags `permissions: write-all` at the workflow or job level. It grants the `GITHUB_TOKEN` every write scope regardless of need — replace it with the specific scopes the job uses.
+
+### GHA034 — Write permissions granted workflow-wide
+
+**Severity:** warning
+
+Flags individual write scopes declared at the workflow level, which apply to every job even when only one needs them. Move each write scope onto the specific job that uses it. (The `write-all` preset is covered by GHA033.)
+
+### GHA035 — Elevated scope on an untrusted-code trigger
+
+**Severity:** error
+
+Flags a workflow that grants the token write access while using a trigger that can run untrusted code (`pull_request_target`, `workflow_run`). An injected step would run with standing write credentials — drop the write scope or isolate the privileged work in a separate trusted workflow.
+
 ## Running lint
 
 ```bash

--- a/lexicons/github/src/codegen/docs.ts
+++ b/lexicons/github/src/codegen/docs.ts
@@ -1000,6 +1000,24 @@ Flags a \`uses:\` slug that is a near-miss (edit distance 1–2) of a popular ac
 
 Flags a \`uses:\` slug that a vendored snapshot marks as archived/abandoned or carrying a disclosed security issue, with remediation. Advisory and necessarily incomplete.
 
+### GHA033 — Blanket write-all permissions
+
+**Severity:** warning
+
+Flags \`permissions: write-all\` at the workflow or job level. It grants the \`GITHUB_TOKEN\` every write scope regardless of need — replace it with the specific scopes the job uses.
+
+### GHA034 — Write permissions granted workflow-wide
+
+**Severity:** warning
+
+Flags individual write scopes declared at the workflow level, which apply to every job even when only one needs them. Move each write scope onto the specific job that uses it. (The \`write-all\` preset is covered by GHA033.)
+
+### GHA035 — Elevated scope on an untrusted-code trigger
+
+**Severity:** error
+
+Flags a workflow that grants the token write access while using a trigger that can run untrusted code (\`pull_request_target\`, \`workflow_run\`). An injected step would run with standing write credentials — drop the write scope or isolate the privileged work in a separate trusted workflow.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/github/src/lint/post-synth/gha033.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha033.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha033 } from "./gha033";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA033: blanket write-all permissions", () => {
+  test("flags workflow-level write-all", () => {
+    const yaml = `name: CI
+on:
+  push:
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha033.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA033");
+    expect(diags[0].message).toContain("write-all");
+  });
+
+  test("flags job-level write-all", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - run: echo build
+`;
+    const diags = gha033.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag scoped permissions", () => {
+    const yaml = `name: CI
+on:
+  push:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha033.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha033.ts
+++ b/lexicons/github/src/lint/post-synth/gha033.ts
@@ -1,0 +1,47 @@
+/**
+ * GHA033: Blanket `write-all` Token Permissions
+ *
+ * Flags a `permissions: write-all` grant at the workflow or job level. It hands
+ * the `GITHUB_TOKEN` every write scope regardless of what the job uses, so any
+ * compromised or injected step becomes a write-capable actor across the repo.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractWorkflowPermissions, extractJobPermissions, writeSurface } from "./yaml-helpers";
+
+export const gha033: PostSynthCheck = {
+  id: "GHA033",
+  description: "Blanket write-all token permissions",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+
+      const wf = extractWorkflowPermissions(yaml);
+      if (wf && writeSurface(wf).writeAll) {
+        diagnostics.push({
+          checkId: "GHA033",
+          severity: "warning",
+          message: `Workflow declares permissions: write-all — replace it with the specific scopes the jobs actually need (least privilege).`,
+          lexicon: "github",
+        });
+      }
+
+      for (const [job, perms] of extractJobPermissions(yaml)) {
+        if (writeSurface(perms).writeAll) {
+          diagnostics.push({
+            checkId: "GHA033",
+            severity: "warning",
+            message: `Job "${job}" declares permissions: write-all — replace it with the specific scopes this job needs (least privilege).`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha034.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha034.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha034 } from "./gha034";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA034: workflow-wide write scope", () => {
+  test("flags a workflow-level write scope", () => {
+    const yaml = `name: CI
+on:
+  push:
+permissions:
+  contents: write
+  packages: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha034.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA034");
+    expect(diags[0].message).toContain("contents");
+    expect(diags[0].message).toContain("packages");
+  });
+
+  test("does not flag workflow-level read-only scopes", () => {
+    const yaml = `name: CI
+on:
+  push:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha034.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag write-all (owned by GHA033)", () => {
+    const yaml = `name: CI
+on:
+  push:
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha034.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag job-scoped write (the recommended form)", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - run: echo build
+`;
+    const diags = gha034.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha034.ts
+++ b/lexicons/github/src/lint/post-synth/gha034.ts
@@ -1,0 +1,41 @@
+/**
+ * GHA034: Workflow-Wide Write Scope (Prefer Job-Scoped Permissions)
+ *
+ * Flags individual write scopes granted at the workflow level. A workflow-wide
+ * grant gives every job that scope even when only one needs it. Least privilege
+ * prefers declaring the write scope on the single job that uses it.
+ *
+ * The `write-all` blanket preset is handled by GHA033 and skipped here.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractWorkflowPermissions, writeSurface } from "./yaml-helpers";
+
+export const gha034: PostSynthCheck = {
+  id: "GHA034",
+  description: "Write permissions granted workflow-wide instead of per-job",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+
+      const wf = extractWorkflowPermissions(yaml);
+      if (!wf) continue;
+
+      const { writeAll, scopes } = writeSurface(wf);
+      if (writeAll) continue; // GHA033 owns write-all
+      if (scopes.length === 0) continue;
+
+      diagnostics.push({
+        checkId: "GHA034",
+        severity: "warning",
+        message: `Workflow grants write scope (${scopes.join(", ")}) for all jobs — move each write scope onto the specific job that needs it for least privilege.`,
+        lexicon: "github",
+      });
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha035.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha035.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha035 } from "./gha035";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA035: elevated scope on untrusted-code trigger", () => {
+  test("errors on workflow-level write with pull_request_target", () => {
+    const yaml = `name: Review
+on:
+  pull_request_target:
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha035.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA035");
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].message).toContain("pull_request_target");
+  });
+
+  test("errors on job-level write-all with workflow_run", () => {
+    const yaml = `name: Followup
+on:
+  workflow_run:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - run: echo build
+`;
+    const diags = gha035.check(makeCtx(yaml));
+    expect(diags.some((d) => d.severity === "error" && d.entity === "build")).toBe(true);
+  });
+
+  test("does not flag write scope on a safe trigger", () => {
+    const yaml = `name: CI
+on:
+  push:
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha035.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag read-only scope on untrusted trigger", () => {
+    const yaml = `name: Review
+on:
+  pull_request_target:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha035.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha035.ts
+++ b/lexicons/github/src/lint/post-synth/gha035.ts
@@ -1,0 +1,66 @@
+/**
+ * GHA035: Elevated Token Scope on an Untrusted-Code Trigger
+ *
+ * Raises the stakes of GHA033/GHA034: when a workflow can run untrusted code
+ * (`pull_request_target`, `workflow_run`) and also grants the token write
+ * access, an injected step runs with standing write credentials. This is the
+ * combination behind most CI privilege-escalation incidents, so it is an error.
+ *
+ * Cross-references the trust-boundary checks (GHA018 / GHA025 / GHA038).
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import {
+  getPrimaryOutput,
+  extractTriggers,
+  extractWorkflowPermissions,
+  extractJobPermissions,
+  writeSurface,
+  grantsWrite,
+} from "./yaml-helpers";
+
+const UNTRUSTED_TRIGGERS = ["pull_request_target", "workflow_run"];
+
+function describeWrite(perms: ReturnType<typeof writeSurface>): string {
+  return perms.writeAll ? "write-all" : perms.scopes.map((s) => `${s}: write`).join(", ");
+}
+
+export const gha035: PostSynthCheck = {
+  id: "GHA035",
+  description: "Elevated token scope on a trigger that can run untrusted code",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const triggers = extractTriggers(yaml);
+      const untrusted = UNTRUSTED_TRIGGERS.filter((t) => triggers[t]);
+      if (untrusted.length === 0) continue;
+
+      const wf = extractWorkflowPermissions(yaml);
+      if (wf && grantsWrite(wf)) {
+        diagnostics.push({
+          checkId: "GHA035",
+          severity: "error",
+          message: `Workflow grants write token scope (${describeWrite(writeSurface(wf))}) while using the ${untrusted.join("/")} trigger, which can run untrusted code. Drop write scope or gate the privileged work behind a separate trusted workflow.`,
+          lexicon: "github",
+        });
+      }
+
+      for (const [job, perms] of extractJobPermissions(yaml)) {
+        if (grantsWrite(perms)) {
+          diagnostics.push({
+            checkId: "GHA035",
+            severity: "error",
+            message: `Job "${job}" grants write token scope (${describeWrite(writeSurface(perms))}) while the workflow uses the ${untrusted.join("/")} trigger, which can run untrusted code. Drop write scope or isolate the privileged work.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/yaml-helpers.ts
+++ b/lexicons/github/src/lint/post-synth/yaml-helpers.ts
@@ -231,6 +231,51 @@ export function extractImageRefs(yaml: string): ImageRef[] {
   return refs;
 }
 
+/** A permissions value as it appears in YAML: a string preset or a scope map. */
+export type PermissionsValue = string | Record<string, string>;
+
+/** The workflow-level `permissions:` value, if present. */
+export function extractWorkflowPermissions(yaml: string): PermissionsValue | undefined {
+  const doc = parseDoc(yaml);
+  const perms = doc?.permissions;
+  if (typeof perms === "string") return perms;
+  if (perms && typeof perms === "object" && !Array.isArray(perms)) return perms as Record<string, string>;
+  return undefined;
+}
+
+/** Per-job `permissions:` values, keyed by job name. Only jobs that declare one. */
+export function extractJobPermissions(yaml: string): Map<string, PermissionsValue> {
+  const out = new Map<string, PermissionsValue>();
+  for (const [job, jobObj] of jobEntries(yaml)) {
+    const perms = jobObj.permissions;
+    if (typeof perms === "string") out.set(job, perms);
+    else if (perms && typeof perms === "object" && !Array.isArray(perms)) out.set(job, perms as Record<string, string>);
+  }
+  return out;
+}
+
+/**
+ * Classify a permissions value's write surface.
+ * `writeAll` is the `write-all` blanket preset; `scopes` lists the individual
+ * scopes granted `write` in map form.
+ */
+export function writeSurface(perms: PermissionsValue): { writeAll: boolean; scopes: string[] } {
+  if (typeof perms === "string") {
+    return { writeAll: perms === "write-all", scopes: [] };
+  }
+  const scopes: string[] = [];
+  for (const [scope, level] of Object.entries(perms)) {
+    if (level === "write") scopes.push(scope);
+  }
+  return { writeAll: false, scopes };
+}
+
+/** True if the permissions value grants any write access (blanket or scoped). */
+export function grantsWrite(perms: PermissionsValue): boolean {
+  const { writeAll, scopes } = writeSurface(perms);
+  return writeAll || scopes.length > 0;
+}
+
 /**
  * Split an action `uses:` value into its `owner/repo` slug and git ref.
  * Returns undefined for local (`./`, `../`) and `docker://` references, which

--- a/lexicons/github/src/plugin.test.ts
+++ b/lexicons/github/src/plugin.test.ts
@@ -24,7 +24,7 @@ describe("githubPlugin", () => {
 
   test("provides post-synth checks", () => {
     const checks = githubPlugin.postSynthChecks!();
-    expect(checks.length).toBe(19);
+    expect(checks.length).toBe(22);
 
     const checkIds = checks.map((c) => c.id);
     expect(checkIds).toContain("GHA006");
@@ -38,6 +38,9 @@ describe("githubPlugin", () => {
     expect(checkIds).toContain("GHA030");
     expect(checkIds).toContain("GHA031");
     expect(checkIds).toContain("GHA032");
+    expect(checkIds).toContain("GHA033");
+    expect(checkIds).toContain("GHA034");
+    expect(checkIds).toContain("GHA035");
   });
 
   test("lint IDs are unique across rules and post-synth checks", () => {


### PR DESCRIPTION
Closes #287.

Complements GHA017 (missing permissions): flags *over-broad* `GITHUB_TOKEN` scopes. Three post-synth checks on emitted workflow YAML:

| ID | Check | Severity |
|----|-------|----------|
| GHA033 | blanket `permissions: write-all` (workflow or job) | warning |
| GHA034 | write scopes granted workflow-wide instead of per-job (prefer job-scoped least privilege) | warning |
| GHA035 | write scope combined with an untrusted-code trigger (`pull_request_target` / `workflow_run`) | error |

### Mapping to acceptance criteria
- *Flag blanket write scopes* → GHA033.
- *Prefer job-scoped minimal permissions* → GHA034 (workflow-wide writes; `write-all` deferred to GHA033 to avoid double-flagging).
- *Raise severity on elevated scope + untrusted trigger* → GHA035 (error), cross-referencing the trust-boundary checks.
- *Optionally require a justifying comment on elevated scope* → **N/A at this layer**: chant's serializer emits no YAML comments, so a comment-justification check has nothing to read on emitted output. It belongs to source lint, not post-synth. Documented in the commit.

### Helpers / tests
- New permission helpers in `yaml-helpers.ts`: `extractWorkflowPermissions`, `extractJobPermissions`, `writeSurface`, `grantsWrite` (structural `parseYAML`).
- Positive + negative fixture test per check. `npx vitest run` green for the github lexicon; eslint clean; docs regenerated.

Stacked on #286 during development; rebased onto main after #286 merged, so the diff is #287-only.