### PR TITLE
feat(github): guard trust boundaries against untrusted input (#288)

### DIFF
--- a/lexicons/github/docs/src/content/docs/index.mdx
+++ b/lexicons/github/docs/src/content/docs/index.mdx
@@ -52,7 +52,7 @@ The lexicon provides **2 resources** (Workflow, Job), **13 composites** (Checkou
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 35 |
+| Lint rules | 40 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitHub`

--- a/lexicons/github/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/github/docs/src/content/docs/lint-rules.mdx
@@ -201,6 +201,36 @@ Flags individual write scopes declared at the workflow level, which apply to eve
 
 Flags a workflow that grants the token write access while using a trigger that can run untrusted code (`pull_request_target`, `workflow_run`). An injected step would run with standing write credentials — drop the write scope or isolate the privileged work in a separate trusted workflow.
 
+### GHA036 — Untrusted input in a run: command
+
+**Severity:** error
+
+Flags an attacker-controllable expression context (PR title, branch name, issue/comment body, commit message) interpolated directly into a `run:` script — a script-injection sink. Pass the value through an `env:` variable and reference it quoted instead.
+
+### GHA037 — Untrusted input written to GITHUB_ENV / GITHUB_PATH
+
+**Severity:** error
+
+Flags a `run:` step that writes untrusted input into `$GITHUB_ENV` or `$GITHUB_PATH`, which set environment/PATH state for later steps and can escalate into takeover of a subsequent privileged step.
+
+### GHA038 — workflow_run trigger checking out untrusted code
+
+**Severity:** warning
+
+Generalizes GHA018 to the `workflow_run` trigger, which runs with repo write scope and secrets. Checking out the head/artifact of the triggering run pulls untrusted code into that privileged context.
+
+### GHA039 — Authorization gate on a spoofable identity
+
+**Severity:** warning
+
+Flags an `if:` condition that gates on a commit-author identity field (`author.name` / `author.email`). Those come from git metadata the committer sets freely and can be spoofed — gate on a verified signal (environment protection, CODEOWNERS, verified actor).
+
+### GHA040 — Self-hosted runner on an untrusted-code trigger
+
+**Severity:** warning
+
+Flags a job on a self-hosted runner under a trigger a fork can reach (`pull_request`, `pull_request_target`, `workflow_run`). Self-hosted runners are non-ephemeral and shared, so untrusted code can persist and compromise later jobs.
+
 ## Running lint
 
 ```bash

--- a/lexicons/github/src/codegen/docs.ts
+++ b/lexicons/github/src/codegen/docs.ts
@@ -1018,6 +1018,36 @@ Flags individual write scopes declared at the workflow level, which apply to eve
 
 Flags a workflow that grants the token write access while using a trigger that can run untrusted code (\`pull_request_target\`, \`workflow_run\`). An injected step would run with standing write credentials — drop the write scope or isolate the privileged work in a separate trusted workflow.
 
+### GHA036 — Untrusted input in a run: command
+
+**Severity:** error
+
+Flags an attacker-controllable expression context (PR title, branch name, issue/comment body, commit message) interpolated directly into a \`run:\` script — a script-injection sink. Pass the value through an \`env:\` variable and reference it quoted instead.
+
+### GHA037 — Untrusted input written to GITHUB_ENV / GITHUB_PATH
+
+**Severity:** error
+
+Flags a \`run:\` step that writes untrusted input into \`$GITHUB_ENV\` or \`$GITHUB_PATH\`, which set environment/PATH state for later steps and can escalate into takeover of a subsequent privileged step.
+
+### GHA038 — workflow_run trigger checking out untrusted code
+
+**Severity:** warning
+
+Generalizes GHA018 to the \`workflow_run\` trigger, which runs with repo write scope and secrets. Checking out the head/artifact of the triggering run pulls untrusted code into that privileged context.
+
+### GHA039 — Authorization gate on a spoofable identity
+
+**Severity:** warning
+
+Flags an \`if:\` condition that gates on a commit-author identity field (\`author.name\` / \`author.email\`). Those come from git metadata the committer sets freely and can be spoofed — gate on a verified signal (environment protection, CODEOWNERS, verified actor).
+
+### GHA040 — Self-hosted runner on an untrusted-code trigger
+
+**Severity:** warning
+
+Flags a job on a self-hosted runner under a trigger a fork can reach (\`pull_request\`, \`pull_request_target\`, \`workflow_run\`). Self-hosted runners are non-ephemeral and shared, so untrusted code can persist and compromise later jobs.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/github/src/lint/post-synth/gha036.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha036.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha036 } from "./gha036";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA036: untrusted input in run:", () => {
+  test("flags PR title interpolated into a block-scalar run", () => {
+    const yaml = `name: CI
+on:
+  pull_request_target:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: greet
+        run: |
+          echo "Title: \${{ github.event.pull_request.title }}"
+`;
+    const diags = gha036.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA036");
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].entity).toBe("build");
+    expect(diags[0].message).toContain("github.event.pull_request.title");
+  });
+
+  test("flags head_ref interpolated into an inline run", () => {
+    const yaml = `name: CI
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ github.head_ref }}
+`;
+    const diags = gha036.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain("github.head_ref");
+  });
+
+  test("does not flag a trusted context in run:", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ github.sha }}
+`;
+    const diags = gha036.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha036.ts
+++ b/lexicons/github/src/lint/post-synth/gha036.ts
@@ -1,0 +1,42 @@
+/**
+ * GHA036: Untrusted Input Interpolated into a Shell Command
+ *
+ * Flags attacker-controllable expression contexts (PR titles, branch names,
+ * issue/comment bodies, commit messages) interpolated directly into a `run:`
+ * script. The value is expanded into the shell before the script runs, so a
+ * crafted payload becomes command execution. Pass untrusted input through an
+ * `env:` variable and reference it quoted instead.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractRunBlocks, extractExpressions } from "./yaml-helpers";
+import { matchUntrustedContext } from "../rules/data/untrusted-contexts";
+
+export const gha036: PostSynthCheck = {
+  id: "GHA036",
+  description: "Untrusted input interpolated into a run: shell command",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, run } of extractRunBlocks(yaml)) {
+        for (const expr of extractExpressions(run)) {
+          const ctxName = matchUntrustedContext(expr);
+          if (!ctxName) continue;
+          diagnostics.push({
+            checkId: "GHA036",
+            severity: "error",
+            message: `Job "${job}" interpolates untrusted input \${{ ${ctxName} ... }} into a run: script — this is a script-injection sink. Pass it through an env: variable and reference "$VAR" quoted instead.`,
+            entity: job,
+            lexicon: "github",
+          });
+          break; // one diagnostic per run block is enough
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha037.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha037.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha037 } from "./gha037";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA037: untrusted input to GITHUB_ENV / GITHUB_PATH", () => {
+  test("flags untrusted input written to GITHUB_ENV", () => {
+    const yaml = `name: CI
+on:
+  pull_request_target:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "BRANCH=\${{ github.event.pull_request.head.ref }}" >> "$GITHUB_ENV"
+`;
+    const diags = gha037.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA037");
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].message).toContain("GITHUB_ENV");
+  });
+
+  test("does not flag a trusted value written to GITHUB_ENV", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "SHA=\${{ github.sha }}" >> "$GITHUB_ENV"
+`;
+    const diags = gha037.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag untrusted input that does not touch env files", () => {
+    const yaml = `name: CI
+on:
+  pull_request_target:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo done
+`;
+    const diags = gha037.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha037.ts
+++ b/lexicons/github/src/lint/post-synth/gha037.ts
@@ -1,0 +1,46 @@
+/**
+ * GHA037: Untrusted Input Written to GITHUB_ENV / GITHUB_PATH
+ *
+ * Flags a `run:` step that writes attacker-controllable input into the
+ * `$GITHUB_ENV` or `$GITHUB_PATH` files. Those files set environment variables
+ * and PATH entries for *later* steps, so injecting into them escalates a data
+ * value into influence over subsequent privileged steps (a known path to
+ * `LD_PRELOAD`/`NODE_OPTIONS`-style takeover).
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractRunBlocks, extractExpressions } from "./yaml-helpers";
+import { matchUntrustedContext } from "../rules/data/untrusted-contexts";
+
+const ENV_FILE_RE = /GITHUB_ENV|GITHUB_PATH/;
+
+export const gha037: PostSynthCheck = {
+  id: "GHA037",
+  description: "Untrusted input written to GITHUB_ENV / GITHUB_PATH",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, run } of extractRunBlocks(yaml)) {
+        if (!ENV_FILE_RE.test(run)) continue;
+        for (const expr of extractExpressions(run)) {
+          const ctxName = matchUntrustedContext(expr);
+          if (!ctxName) continue;
+          const file = run.includes("GITHUB_PATH") ? "GITHUB_PATH" : "GITHUB_ENV";
+          diagnostics.push({
+            checkId: "GHA037",
+            severity: "error",
+            message: `Job "${job}" writes untrusted input \${{ ${ctxName} ... }} into $${file}, which sets state for later steps. Sanitize/validate the value or avoid persisting untrusted input across steps.`,
+            entity: job,
+            lexicon: "github",
+          });
+          break;
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha038.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha038.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha038 } from "./gha038";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA038: workflow_run with checkout", () => {
+  test("flags checkout under workflow_run", () => {
+    const yaml = `name: Followup
+on:
+  workflow_run:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo build
+`;
+    const diags = gha038.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA038");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag workflow_run without checkout", () => {
+    const yaml = `name: Followup
+on:
+  workflow_run:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha038.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag checkout on a safe trigger", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`;
+    const diags = gha038.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha038.ts
+++ b/lexicons/github/src/lint/post-synth/gha038.ts
@@ -1,0 +1,41 @@
+/**
+ * GHA038: Privileged `workflow_run` Trigger Checking Out Untrusted Code
+ *
+ * Generalizes GHA018 (pull_request_target + checkout) to the other privileged
+ * trigger that runs in the base-repo context: `workflow_run`. A `workflow_run`
+ * workflow has repo write scope and secrets, and checking out the artifact/head
+ * of the triggering run pulls untrusted code into that privileged context.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractTriggers, extractJobs, hasCheckoutAction } from "./yaml-helpers";
+
+export const gha038: PostSynthCheck = {
+  id: "GHA038",
+  description: "workflow_run trigger with checkout runs untrusted code in a privileged context",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const triggers = extractTriggers(yaml);
+      if (!triggers["workflow_run"]) continue;
+
+      const jobs = extractJobs(yaml);
+      for (const [jobName, job] of jobs) {
+        if (job.steps && hasCheckoutAction(job.steps)) {
+          diagnostics.push({
+            checkId: "GHA038",
+            severity: "warning",
+            message: `Job "${jobName}" checks out code under a workflow_run trigger, which runs with repo write scope and secrets. Treat the checked-out code as untrusted — avoid executing it, or move execution to an unprivileged workflow.`,
+            entity: jobName,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha039.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha039.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha039 } from "./gha039";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA039: spoofable identity gate", () => {
+  test("flags an if: gating on commit author email", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: \${{ github.event.head_commit.author.email == 'maintainer@example.com' }}
+    steps:
+      - run: echo build
+`;
+    const diags = gha039.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA039");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag an if: on a trustworthy signal", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: \${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - run: echo build
+`;
+    const diags = gha039.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag a non-author field referenced without comparison", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: \${{ always() }}
+    steps:
+      - run: echo build
+`;
+    const diags = gha039.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha039.ts
+++ b/lexicons/github/src/lint/post-synth/gha039.ts
@@ -1,0 +1,41 @@
+/**
+ * GHA039: Spoofable Identity Used as an Authorization Gate
+ *
+ * Flags an `if:` condition that gates execution on a commit-author identity
+ * field (`...author.name` / `...author.email`). Those values come straight from
+ * git metadata the committer sets freely, so an attacker can forge them to pass
+ * the gate. Use a trustworthy signal — environment protection rules, CODEOWNERS,
+ * or membership checks against a verified actor.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractIfConditions } from "./yaml-helpers";
+
+const SPOOFABLE_FIELD_RE = /\.author\.(name|email)\b/;
+const COMPARISON_RE = /==|!=|contains\s*\(/;
+
+export const gha039: PostSynthCheck = {
+  id: "GHA039",
+  description: "Authorization gate on a spoofable commit-author identity field",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, expr } of extractIfConditions(yaml)) {
+        if (SPOOFABLE_FIELD_RE.test(expr) && COMPARISON_RE.test(expr)) {
+          diagnostics.push({
+            checkId: "GHA039",
+            severity: "warning",
+            message: `Job "${job}" gates on a commit-author identity field in an if: condition (${expr}). Author name/email are attacker-controlled and can be spoofed — gate on a verified signal (environment protection, CODEOWNERS, verified actor) instead.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha040.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha040.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha040 } from "./gha040";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA040: self-hosted runner on untrusted trigger", () => {
+  test("flags self-hosted runner under pull_request", () => {
+    const yaml = `name: CI
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - run: echo build
+`;
+    const diags = gha040.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA040");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("flags self-hosted in an array runs-on under workflow_run", () => {
+    const yaml = `name: CI
+on:
+  workflow_run:
+jobs:
+  build:
+    runs-on: [self-hosted, linux]
+    steps:
+      - run: echo build
+`;
+    const diags = gha040.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+  });
+
+  test("does not flag GitHub-hosted runner under untrusted trigger", () => {
+    const yaml = `name: CI
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha040.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag self-hosted on a safe trigger", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - run: echo build
+`;
+    const diags = gha040.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha040.ts
+++ b/lexicons/github/src/lint/post-synth/gha040.ts
@@ -1,0 +1,43 @@
+/**
+ * GHA040: Self-Hosted Runner on a Trigger That Can Run Untrusted Code
+ *
+ * Flags a job that runs on a self-hosted runner under a trigger reachable by a
+ * fork or outside contributor (`pull_request`, `pull_request_target`,
+ * `workflow_run`). Self-hosted runners are non-ephemeral by default and share a
+ * host, so untrusted code can persist on the runner and compromise later jobs.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractTriggers, extractRunsOnByJob } from "./yaml-helpers";
+
+const UNTRUSTED_TRIGGERS = ["pull_request", "pull_request_target", "workflow_run"];
+
+export const gha040: PostSynthCheck = {
+  id: "GHA040",
+  description: "Self-hosted runner on a trigger that can run untrusted code",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const triggers = extractTriggers(yaml);
+      const untrusted = UNTRUSTED_TRIGGERS.filter((t) => triggers[t]);
+      if (untrusted.length === 0) continue;
+
+      for (const [job, labels] of extractRunsOnByJob(yaml)) {
+        if (labels.some((l) => l === "self-hosted")) {
+          diagnostics.push({
+            checkId: "GHA040",
+            severity: "warning",
+            message: `Job "${job}" runs on a self-hosted runner under the ${untrusted.join("/")} trigger, which a fork can reach. Use ephemeral GitHub-hosted runners for untrusted code, or require approval before the job runs.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/yaml-helpers.ts
+++ b/lexicons/github/src/lint/post-synth/yaml-helpers.ts
@@ -231,6 +231,120 @@ export function extractImageRefs(yaml: string): ImageRef[] {
   return refs;
 }
 
+/**
+ * Walk the `jobs:` block line-by-line, tracking the current job. Robust to `|`
+ * block scalars (which the structural parser does not handle), so it is the
+ * right tool for scanning `run:`/`if:`/`runs-on:` content.
+ */
+function scanJobLines(yaml: string, onLine: (job: string, line: string, indent: number, lineNo: number, lines: string[]) => void): void {
+  const lines = yaml.split("\n");
+  let inJobs = false;
+  let currentJob = "";
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^jobs:\s*$/.test(line)) { inJobs = true; continue; }
+    if (!inJobs) continue;
+    if (/^\S/.test(line)) { inJobs = false; continue; } // dedented to a new top-level key
+    const jobHeader = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+    if (jobHeader) { currentJob = jobHeader[1]; continue; }
+    if (!currentJob) continue;
+    const indent = line.search(/\S/);
+    if (indent < 0) continue;
+    onLine(currentJob, line, indent, i, lines);
+  }
+}
+
+/** A `run:` script block with its owning job. */
+export interface RunBlock {
+  job: string;
+  run: string;
+}
+
+/**
+ * Extract every `run:` script (inline and `|`/`>` block scalars) with its
+ * owning job.
+ */
+export function extractRunBlocks(yaml: string): RunBlock[] {
+  const out: RunBlock[] = [];
+  const consumed = new Set<number>();
+  scanJobLines(yaml, (job, line, _indent, lineNo, lines) => {
+    if (consumed.has(lineNo)) return;
+    const m = line.match(/^(\s*)(- )?run:\s*(.*)$/);
+    if (!m) return;
+    const keyIndent = m[1].length + (m[2] ? 2 : 0); // column where `run:` begins
+    const value = m[3].trim();
+    if (value === "|" || value === "|-" || value === ">" || value === ">-" || value === "|+" || value === ">+") {
+      const blockLines: string[] = [];
+      for (let j = lineNo + 1; j < lines.length; j++) {
+        const bl = lines[j];
+        if (bl.trim() === "") { blockLines.push(""); consumed.add(j); continue; }
+        const bi = bl.search(/\S/);
+        if (bi <= keyIndent) break;
+        blockLines.push(bl.trimStart());
+        consumed.add(j);
+      }
+      out.push({ job, run: blockLines.join("\n") });
+    } else {
+      out.push({ job, run: value.replace(/^['"]|['"]$/g, "") });
+    }
+  });
+  return out;
+}
+
+/** An `if:` condition with its owning job. */
+export interface IfCondition {
+  job: string;
+  expr: string;
+}
+
+/** Extract every `if:` condition (job-level and step-level) with its job. */
+export function extractIfConditions(yaml: string): IfCondition[] {
+  const out: IfCondition[] = [];
+  scanJobLines(yaml, (job, line) => {
+    const m = line.match(/^\s+(?:- )?if:\s*(.+)$/);
+    if (m) out.push({ job, expr: m[1].trim().replace(/^['"]|['"]$/g, "") });
+  });
+  return out;
+}
+
+/** Extract each job's `runs-on:` value(s) as a flat list of labels. */
+export function extractRunsOnByJob(yaml: string): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  scanJobLines(yaml, (job, line, indent, lineNo, lines) => {
+    const m = line.match(/^\s+runs-on:\s*(.*)$/);
+    if (!m) return;
+    const value = m[1].trim();
+    const labels: string[] = [];
+    if (value === "") {
+      for (let j = lineNo + 1; j < lines.length; j++) {
+        const item = lines[j].match(/^\s+- (.+)$/);
+        if (!item) break;
+        labels.push(item[1].trim().replace(/^['"]|['"]$/g, ""));
+      }
+    } else if (value.startsWith("[")) {
+      for (const part of value.replace(/^\[|\]$/g, "").split(",")) {
+        const t = part.trim().replace(/^['"]|['"]$/g, "");
+        if (t) labels.push(t);
+      }
+    } else {
+      labels.push(value.replace(/^['"]|['"]$/g, ""));
+    }
+    out.set(job, labels);
+  });
+  return out;
+}
+
+/** Pull every `${{ ... }}` expression body out of a string. */
+export function extractExpressions(text: string): string[] {
+  const out: string[] = [];
+  const re = /\$\{\{(.+?)\}\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    out.push(m[1].trim());
+  }
+  return out;
+}
+
 /** A permissions value as it appears in YAML: a string preset or a scope map. */
 export type PermissionsValue = string | Record<string, string>;
 

--- a/lexicons/github/src/lint/rules/data/untrusted-contexts.ts
+++ b/lexicons/github/src/lint/rules/data/untrusted-contexts.ts
@@ -1,0 +1,44 @@
+/**
+ * Vendored snapshot of GitHub Actions expression contexts that are
+ * attacker-controllable — their values come from event payloads a fork or an
+ * outside contributor can set. Interpolating them into a shell (`run:`), into
+ * `GITHUB_ENV`/`GITHUB_PATH`, or into another execution sink turns data into
+ * code (script injection).
+ *
+ * Source: GitHub's "Security hardening for GitHub Actions — understanding the
+ * risk of script injections" plus the commonly-cited untrusted-context list.
+ * Advisory and necessarily incomplete; refresh by editing this list.
+ */
+export const UNTRUSTED_CONTEXTS: readonly string[] = [
+  "github.event.issue.title",
+  "github.event.issue.body",
+  "github.event.pull_request.title",
+  "github.event.pull_request.body",
+  "github.event.pull_request.head.ref",
+  "github.event.pull_request.head.label",
+  "github.event.pull_request.head.repo.default_branch",
+  "github.event.comment.body",
+  "github.event.review.body",
+  "github.event.review_comment.body",
+  "github.event.discussion.title",
+  "github.event.discussion.body",
+  "github.event.head_commit.message",
+  "github.event.head_commit.author.email",
+  "github.event.head_commit.author.name",
+  "github.event.commits", // .*.message / .*.author.* (array — matched by prefix)
+  "github.event.pages", // .*.page_name
+  "github.head_ref",
+];
+
+/**
+ * Return the first untrusted context referenced inside an expression body, or
+ * undefined. Matches by substring so array element accesses
+ * (`github.event.commits[0].message`) are caught via their prefix.
+ */
+export function matchUntrustedContext(exprBody: string): string | undefined {
+  const normalized = exprBody.replace(/\s+/g, "");
+  for (const ctx of UNTRUSTED_CONTEXTS) {
+    if (normalized.includes(ctx.replace(/\s+/g, ""))) return ctx;
+  }
+  return undefined;
+}

--- a/lexicons/github/src/plugin.test.ts
+++ b/lexicons/github/src/plugin.test.ts
@@ -24,7 +24,7 @@ describe("githubPlugin", () => {
 
   test("provides post-synth checks", () => {
     const checks = githubPlugin.postSynthChecks!();
-    expect(checks.length).toBe(22);
+    expect(checks.length).toBe(27);
 
     const checkIds = checks.map((c) => c.id);
     expect(checkIds).toContain("GHA006");
@@ -41,6 +41,11 @@ describe("githubPlugin", () => {
     expect(checkIds).toContain("GHA033");
     expect(checkIds).toContain("GHA034");
     expect(checkIds).toContain("GHA035");
+    expect(checkIds).toContain("GHA036");
+    expect(checkIds).toContain("GHA037");
+    expect(checkIds).toContain("GHA038");
+    expect(checkIds).toContain("GHA039");
+    expect(checkIds).toContain("GHA040");
   });
 
   test("lint IDs are unique across rules and post-synth checks", () => {


### PR DESCRIPTION
Closes #288.

The general script-injection / untrusted-execution surface, beyond the `pull_request_target` + checkout case (GHA018/GHA025). Five post-synth checks on emitted workflow YAML:

| ID | Check | Severity |
|----|-------|----------|
| GHA036 | attacker-controllable context interpolated into a `run:` script | error |
| GHA037 | untrusted input written to `$GITHUB_ENV` / `$GITHUB_PATH` | error |
| GHA038 | `workflow_run` trigger with checkout (generalizes GHA018) | warning |
| GHA039 | `if:` gate on a spoofable commit-author identity field | warning |
| GHA040 | self-hosted runner under a fork-reachable trigger | warning |

### Mechanism
- Vendored `data/untrusted-contexts.ts` lists the attacker-controllable expression contexts (PR title/body, `head_ref`, issue/comment/discussion bodies, commit messages) with a substring matcher; checks classify expressions found in `run:`/`if:` sinks against it.
- New **line-based** scanners in `yaml-helpers.ts` (`extractRunBlocks`, `extractIfConditions`, `extractRunsOnByJob`, `extractExpressions`) correctly handle `|`/`>` block scalars and the dash form of `run:` — cases the structural `parseYAML` does not. This is why a regex/line approach is used here rather than `parseYAML`.

### Scope
GHA039 is deliberately conservative (commit-author `name`/`email`, the clearly-forgeable git-metadata fields) to keep false positives low; `github.actor`-style gates are common and legitimate and are not flagged.

### Tests / checks
Positive + negative fixture test per check (16 tests), including block-scalar and dash-form `run:` fixtures. `npx vitest run` green for the github lexicon (200 tests); eslint clean; docs regenerated. Stacked on #287; rebased onto main after merge.