### PR TITLE
feat(github): scope and contain secrets (#289)

### DIFF
--- a/lexicons/github/docs/src/content/docs/index.mdx
+++ b/lexicons/github/docs/src/content/docs/index.mdx
@@ -52,7 +52,7 @@ The lexicon provides **2 resources** (Workflow, Job), **13 composites** (Checkou
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 40 |
+| Lint rules | 45 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitHub`

--- a/lexicons/github/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/github/docs/src/content/docs/lint-rules.mdx
@@ -231,6 +231,36 @@ Flags an `if:` condition that gates on a commit-author identity field (`author.n
 
 Flags a job on a self-hosted runner under a trigger a fork can reach (`pull_request`, `pull_request_target`, `workflow_run`). Self-hosted runners are non-ephemeral and shared, so untrusted code can persist and compromise later jobs.
 
+### GHA041 — Blanket secrets: inherit into a reusable workflow
+
+**Severity:** warning
+
+Flags a reusable-workflow call passing `secrets: inherit`, which hands the called workflow every caller secret. Pass through only the specific secrets it needs.
+
+### GHA042 — Entire secrets context passed
+
+**Severity:** warning
+
+Flags `toJSON(secrets)` passed into a step or reusable workflow, serializing every secret where one or two specific references would do.
+
+### GHA043 — Secret consumed without an environment gate
+
+**Severity:** warning
+
+Extends GHA026: when a workflow gates some jobs with an `environment:`, flags the specific secret-using jobs that have none — the inconsistent-gating case where a job skips the approval/scoping applied elsewhere.
+
+### GHA044 — Hardcoded registry/container credential
+
+**Severity:** error
+
+Flags a `password:` / `token:` / `registry-password:` set to a literal rather than a `${{ secrets.* }}` reference. Move the credential into a secret.
+
+### GHA045 — Secret interpolated into a run: command
+
+**Severity:** warning
+
+Flags `${{ secrets.* }}` expanded directly into a `run:` script, where a transform can defeat log masking and the raw value is exposed to argument injection. Pass it through an `env:` variable and reference `"$VAR"` quoted.
+
 ## Running lint
 
 ```bash

--- a/lexicons/github/src/codegen/docs.ts
+++ b/lexicons/github/src/codegen/docs.ts
@@ -1048,6 +1048,36 @@ Flags an \`if:\` condition that gates on a commit-author identity field (\`autho
 
 Flags a job on a self-hosted runner under a trigger a fork can reach (\`pull_request\`, \`pull_request_target\`, \`workflow_run\`). Self-hosted runners are non-ephemeral and shared, so untrusted code can persist and compromise later jobs.
 
+### GHA041 — Blanket secrets: inherit into a reusable workflow
+
+**Severity:** warning
+
+Flags a reusable-workflow call passing \`secrets: inherit\`, which hands the called workflow every caller secret. Pass through only the specific secrets it needs.
+
+### GHA042 — Entire secrets context passed
+
+**Severity:** warning
+
+Flags \`toJSON(secrets)\` passed into a step or reusable workflow, serializing every secret where one or two specific references would do.
+
+### GHA043 — Secret consumed without an environment gate
+
+**Severity:** warning
+
+Extends GHA026: when a workflow gates some jobs with an \`environment:\`, flags the specific secret-using jobs that have none — the inconsistent-gating case where a job skips the approval/scoping applied elsewhere.
+
+### GHA044 — Hardcoded registry/container credential
+
+**Severity:** error
+
+Flags a \`password:\` / \`token:\` / \`registry-password:\` set to a literal rather than a \`\${{ secrets.* }}\` reference. Move the credential into a secret.
+
+### GHA045 — Secret interpolated into a run: command
+
+**Severity:** warning
+
+Flags \`\${{ secrets.* }}\` expanded directly into a \`run:\` script, where a transform can defeat log masking and the raw value is exposed to argument injection. Pass it through an \`env:\` variable and reference \`"$VAR"\` quoted.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/github/src/lint/post-synth/gha041.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha041.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha041 } from "./gha041";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA041: secrets: inherit", () => {
+  test("flags a reusable call with secrets: inherit", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  call:
+    uses: org/repo/.github/workflows/deploy.yml@v1
+    secrets: inherit
+`;
+    const diags = gha041.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA041");
+    expect(diags[0].entity).toBe("call");
+  });
+
+  test("does not flag explicit secret pass-through", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  call:
+    uses: org/repo/.github/workflows/deploy.yml@v1
+    secrets:
+      token: \${{ secrets.DEPLOY_TOKEN }}
+`;
+    const diags = gha041.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha041.ts
+++ b/lexicons/github/src/lint/post-synth/gha041.ts
@@ -1,0 +1,38 @@
+/**
+ * GHA041: Blanket `secrets: inherit` into a Reusable Workflow
+ *
+ * Flags a reusable-workflow call that passes `secrets: inherit`. Inheritance
+ * hands the called workflow every secret the caller can see, regardless of what
+ * it needs. Pass through only the specific secrets the reusable workflow uses.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, jobLines } from "./yaml-helpers";
+
+export const gha041: PostSynthCheck = {
+  id: "GHA041",
+  description: "Blanket secrets: inherit into a reusable workflow",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const seen = new Set<string>();
+      for (const { job, line } of jobLines(yaml)) {
+        if (/^\s+secrets:\s*inherit\s*$/.test(line) && !seen.has(job)) {
+          seen.add(job);
+          diagnostics.push({
+            checkId: "GHA041",
+            severity: "warning",
+            message: `Job "${job}" calls a reusable workflow with secrets: inherit, passing every caller secret. Pass through only the specific secrets it needs.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha042.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha042.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha042 } from "./gha042";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA042: whole secrets context passed", () => {
+  test("flags toJSON(secrets)", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: some/action@v1
+        with:
+          blob: \${{ toJSON(secrets) }}
+`;
+    const diags = gha042.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA042");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag a specific secret reference", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: some/action@v1
+        with:
+          token: \${{ secrets.API_TOKEN }}
+`;
+    const diags = gha042.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha042.ts
+++ b/lexicons/github/src/lint/post-synth/gha042.ts
@@ -1,0 +1,40 @@
+/**
+ * GHA042: Whole Secrets Context Passed Where Specific Secrets Would Do
+ *
+ * Flags `toJSON(secrets)` (serializing the entire secrets context) passed into
+ * a step's `with:`/`env:` or to a reusable workflow. It hands the consumer every
+ * secret instead of the one or two it needs. Reference specific secrets.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, jobLines } from "./yaml-helpers";
+
+const TO_JSON_SECRETS = /to_?json\s*\(\s*secrets\s*\)/i;
+
+export const gha042: PostSynthCheck = {
+  id: "GHA042",
+  description: "Entire secrets context passed where specific secrets would do",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const seen = new Set<string>();
+      for (const { job, line } of jobLines(yaml)) {
+        if (TO_JSON_SECRETS.test(line) && !seen.has(job)) {
+          seen.add(job);
+          diagnostics.push({
+            checkId: "GHA042",
+            severity: "warning",
+            message: `Job "${job}" passes the entire secrets context via toJSON(secrets). Reference only the specific secrets the consumer needs.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha043.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha043.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha043 } from "./gha043";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA043: secret without environment gate (inconsistent gating)", () => {
+  test("flags a secret-using job with no environment when others are gated", () => {
+    const yaml = `name: CD
+on:
+  push:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo deploy
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ secrets.SLACK_TOKEN }}
+`;
+    const diags = gha043.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA043");
+    expect(diags[0].entity).toBe("notify");
+  });
+
+  test("does not flag when the secret-using job is itself gated", () => {
+    const yaml = `name: CD
+on:
+  push:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo \${{ secrets.DEPLOY_TOKEN }}
+`;
+    const diags = gha043.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not fire when no job uses an environment (GHA026 territory)", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ secrets.TOKEN }}
+`;
+    const diags = gha043.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha043.ts
+++ b/lexicons/github/src/lint/post-synth/gha043.ts
@@ -1,0 +1,41 @@
+/**
+ * GHA043: Secret Consumed in a Job Without an Environment Gate
+ *
+ * Extends GHA026 (which fires only when a workflow uses secrets and defines no
+ * environment at all). When a workflow *does* gate some jobs with an
+ * `environment:`, this flags the specific jobs that consume secrets without one
+ * — the inconsistent-gating case, where a secret-using job skips the approval
+ * and scoping the author applied elsewhere.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, jobsReferencingSecrets, extractJobEnvironments } from "./yaml-helpers";
+
+export const gha043: PostSynthCheck = {
+  id: "GHA043",
+  description: "Secret consumed in a job without an environment gate",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const gated = extractJobEnvironments(yaml);
+      if (gated.size === 0) continue; // no environments used anywhere — GHA026 territory
+
+      for (const job of jobsReferencingSecrets(yaml)) {
+        if (!gated.has(job)) {
+          diagnostics.push({
+            checkId: "GHA043",
+            severity: "warning",
+            message: `Job "${job}" consumes a secret but declares no environment:, while other jobs in this workflow are environment-gated. Gate this job too, or confirm it should bypass the approval/scoping the others use.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha044.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha044.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha044 } from "./gha044";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA044: hardcoded registry/container credential", () => {
+  test("flags a hardcoded password literal", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          username: myuser
+          password: hunter2
+`;
+    const diags = gha044.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA044");
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag a password sourced from a secret", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          username: myuser
+          password: \${{ secrets.DOCKER_PASSWORD }}
+`;
+    const diags = gha044.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha044.ts
+++ b/lexicons/github/src/lint/post-synth/gha044.ts
@@ -1,0 +1,41 @@
+/**
+ * GHA044: Hardcoded Registry / Container Credential
+ *
+ * Flags a `password:` / `token:` / `registry-password:` value that is a literal
+ * rather than a `${{ secrets.* }}` reference — e.g. a registry login or service
+ * credential inlined in plain text. Move it into a secret.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, jobLines } from "./yaml-helpers";
+
+const CRED_KEY_RE = /^\s+(?:- )?(password|token|registry-password):\s*(.+)$/;
+
+export const gha044: PostSynthCheck = {
+  id: "GHA044",
+  description: "Hardcoded registry/container credential",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, line } of jobLines(yaml)) {
+        const m = line.match(CRED_KEY_RE);
+        if (!m) continue;
+        const key = m[1];
+        const value = m[2].trim().replace(/^['"]|['"]$/g, "");
+        if (value === "" || value.includes("${{")) continue; // empty or a proper expression
+        diagnostics.push({
+          checkId: "GHA044",
+          severity: "error",
+          message: `Job "${job}" sets ${key}: to a hardcoded literal. Reference a secret (\${{ secrets.NAME }}) instead of inlining the credential.`,
+          entity: job,
+          lexicon: "github",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha045.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha045.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha045 } from "./gha045";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA045: secret interpolated into run:", () => {
+  test("flags a secret interpolated into a run command", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -H "Authorization: \${{ secrets.API_TOKEN }}" https://example.com
+`;
+    const diags = gha045.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA045");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag a secret passed via env (the recommended form)", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          TOKEN: \${{ secrets.API_TOKEN }}
+        run: curl -H "Authorization: $TOKEN" https://example.com
+`;
+    const diags = gha045.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha045.ts
+++ b/lexicons/github/src/lint/post-synth/gha045.ts
@@ -1,0 +1,38 @@
+/**
+ * GHA045: Secret Interpolated Directly into a Shell Command
+ *
+ * Flags `${{ secrets.* }}` expanded straight into a `run:` script. The value is
+ * substituted into the command line before the shell runs, where a transform
+ * (base64, reversing, splitting) can defeat GitHub's log masking and leak it,
+ * and the raw value is exposed to argument-injection. Pass secrets through an
+ * `env:` variable and reference "$VAR" quoted instead.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractRunBlocks, extractExpressions } from "./yaml-helpers";
+
+export const gha045: PostSynthCheck = {
+  id: "GHA045",
+  description: "Secret interpolated directly into a run: shell command",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, run } of extractRunBlocks(yaml)) {
+        const leaked = extractExpressions(run).some((e) => /\bsecrets\./.test(e));
+        if (!leaked) continue;
+        diagnostics.push({
+          checkId: "GHA045",
+          severity: "warning",
+          message: `Job "${job}" interpolates a secret directly into a run: script, where a transform can defeat log masking. Pass it through an env: variable and reference "$VAR" quoted instead.`,
+          entity: job,
+          lexicon: "github",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/yaml-helpers.ts
+++ b/lexicons/github/src/lint/post-synth/yaml-helpers.ts
@@ -345,6 +345,31 @@ export function extractExpressions(text: string): string[] {
   return out;
 }
 
+/** Every line inside the `jobs:` block paired with its owning job name. */
+export function jobLines(yaml: string): Array<{ job: string; line: string }> {
+  const out: Array<{ job: string; line: string }> = [];
+  scanJobLines(yaml, (job, line) => out.push({ job, line }));
+  return out;
+}
+
+/** Set of jobs that declare an `environment:`. */
+export function extractJobEnvironments(yaml: string): Set<string> {
+  const set = new Set<string>();
+  scanJobLines(yaml, (job, line) => {
+    if (/^\s+environment:/.test(line)) set.add(job);
+  });
+  return set;
+}
+
+/** Set of jobs whose body references a `secrets.` context. */
+export function jobsReferencingSecrets(yaml: string): Set<string> {
+  const set = new Set<string>();
+  scanJobLines(yaml, (job, line) => {
+    if (/secrets\./.test(line)) set.add(job);
+  });
+  return set;
+}
+
 /** A permissions value as it appears in YAML: a string preset or a scope map. */
 export type PermissionsValue = string | Record<string, string>;
 

--- a/lexicons/github/src/plugin.test.ts
+++ b/lexicons/github/src/plugin.test.ts
@@ -24,7 +24,7 @@ describe("githubPlugin", () => {
 
   test("provides post-synth checks", () => {
     const checks = githubPlugin.postSynthChecks!();
-    expect(checks.length).toBe(27);
+    expect(checks.length).toBe(32);
 
     const checkIds = checks.map((c) => c.id);
     expect(checkIds).toContain("GHA006");
@@ -46,6 +46,11 @@ describe("githubPlugin", () => {
     expect(checkIds).toContain("GHA038");
     expect(checkIds).toContain("GHA039");
     expect(checkIds).toContain("GHA040");
+    expect(checkIds).toContain("GHA041");
+    expect(checkIds).toContain("GHA042");
+    expect(checkIds).toContain("GHA043");
+    expect(checkIds).toContain("GHA044");
+    expect(checkIds).toContain("GHA045");
   });
 
   test("lint IDs are unique across rules and post-synth checks", () => {


### PR DESCRIPTION
Closes #289.

The secret *exposure* surface beyond hardcoding (GHA003/GHA020). Five post-synth checks:

| ID | Check | Severity |
|----|-------|----------|
| GHA041 | reusable workflow called with `secrets: inherit` | warning |
| GHA042 | entire secrets context passed via `toJSON(secrets)` | warning |
| GHA043 | secret consumed in a job with no `environment:` while other jobs are gated | warning |
| GHA044 | hardcoded `password:` / `token:` / `registry-password:` literal | error |
| GHA045 | `${{ secrets.* }}` interpolated directly into a `run:` command | warning |

### Notes
- **GHA043 extends GHA026** rather than duplicating it: GHA026 fires once when a workflow uses secrets and defines *no* environment anywhere; GHA043 catches the *inconsistent-gating* case — some jobs are environment-gated, but a specific secret-using job is not.
- New helpers `jobLines`, `extractJobEnvironments`, `jobsReferencingSecrets` in `yaml-helpers.ts`.

Positive + negative fixture test per check. `npx vitest run` green for the github lexicon (211 tests); eslint clean; docs regenerated. Stacked on #288; rebased onto main after merge.