### PR TITLE
feat(github): reject unsound and obfuscated expressions (#290)

### DIFF
--- a/lexicons/github/docs/src/content/docs/index.mdx
+++ b/lexicons/github/docs/src/content/docs/index.mdx
@@ -52,7 +52,7 @@ The lexicon provides **2 resources** (Workflow, Job), **13 composites** (Checkou
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 45 |
+| Lint rules | 48 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitHub`

--- a/lexicons/github/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/github/docs/src/content/docs/lint-rules.mdx
@@ -261,6 +261,24 @@ Flags a `password:` / `token:` / `registry-password:` set to a literal rather th
 
 Flags `${{ secrets.* }}` expanded directly into a `run:` script, where a transform can defeat log masking and the raw value is exposed to argument injection. Pass it through an `env:` variable and reference `"$VAR"` quoted.
 
+### GHA046 — Logically unsound guard condition
+
+**Severity:** warning
+
+Flags an `if:` condition that reads like a gate but evaluates to a constant — `true`/`false` literals, an `X == X` tautology, or a collapse via `|| true` / `&& false`. A gate that constrains nothing is misleading.
+
+### GHA047 — Ineffective contains() guard
+
+**Severity:** warning
+
+Flags `contains('literal', <dynamic>)` — a constant haystack with a dynamic needle. `contains(search, item)` tests whether `item` is in `search`, so reversed arguments make the result depend on a fixed string. Swap them.
+
+### GHA048 — Obfuscated guard condition
+
+**Severity:** warning
+
+Flags an `if:` gate whose compared operand is built through `format()` / `join()` / `fromJSON()` indirection. Constructing the operand at evaluation time hides what the gate checks — compare against the value directly.
+
 ## Running lint
 
 ```bash

--- a/lexicons/github/src/codegen/docs.ts
+++ b/lexicons/github/src/codegen/docs.ts
@@ -1078,6 +1078,24 @@ Flags a \`password:\` / \`token:\` / \`registry-password:\` set to a literal rat
 
 Flags \`\${{ secrets.* }}\` expanded directly into a \`run:\` script, where a transform can defeat log masking and the raw value is exposed to argument injection. Pass it through an \`env:\` variable and reference \`"$VAR"\` quoted.
 
+### GHA046 — Logically unsound guard condition
+
+**Severity:** warning
+
+Flags an \`if:\` condition that reads like a gate but evaluates to a constant — \`true\`/\`false\` literals, an \`X == X\` tautology, or a collapse via \`|| true\` / \`&& false\`. A gate that constrains nothing is misleading.
+
+### GHA047 — Ineffective contains() guard
+
+**Severity:** warning
+
+Flags \`contains('literal', <dynamic>)\` — a constant haystack with a dynamic needle. \`contains(search, item)\` tests whether \`item\` is in \`search\`, so reversed arguments make the result depend on a fixed string. Swap them.
+
+### GHA048 — Obfuscated guard condition
+
+**Severity:** warning
+
+Flags an \`if:\` gate whose compared operand is built through \`format()\` / \`join()\` / \`fromJSON()\` indirection. Constructing the operand at evaluation time hides what the gate checks — compare against the value directly.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/github/src/lint/post-synth/gha046.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha046.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha046, unsoundReason } from "./gha046";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA046: unsound guard condition", () => {
+  test("unsoundReason classifies constants", () => {
+    expect(unsoundReason("true")).toContain("always true");
+    expect(unsoundReason("${{ false }}")).toContain("always false");
+    expect(unsoundReason("${{ success() || true }}")).toContain("always true");
+    expect(unsoundReason("${{ github.ref == github.ref }}")).toContain("always true");
+    expect(unsoundReason("${{ github.ref == 'refs/heads/main' }}")).toBeUndefined();
+  });
+
+  test("flags an always-true literal gate", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: true
+    steps:
+      - run: echo build
+`;
+    const diags = gha046.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA046");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag a real condition", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: \${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - run: echo build
+`;
+    const diags = gha046.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha046.ts
+++ b/lexicons/github/src/lint/post-synth/gha046.ts
@@ -1,0 +1,56 @@
+/**
+ * GHA046: Logically Unsound Guard Condition
+ *
+ * Flags an `if:` condition that reads like a security/flow gate but evaluates to
+ * a constant — `true`/`false` literals, an `X == X` tautology, or an expression
+ * that collapses via `|| true` / `&& false`. These pass review by looking like a
+ * control while gating nothing (or everything).
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractIfConditions } from "./yaml-helpers";
+
+/** Strip a leading `${{` / trailing `}}` wrapper from an expression. */
+function inner(expr: string): string {
+  return expr.replace(/^\$\{\{/, "").replace(/\}\}$/, "").trim();
+}
+
+/** Classify a condition as a constant guard, returning a reason or undefined. */
+export function unsoundReason(expr: string): string | undefined {
+  const e = inner(expr);
+  if (e === "true") return "always true (true literal)";
+  if (e === "false") return "always false (false literal)";
+  if (/\|\|\s*true\b/.test(e)) return "always true (|| true collapses the condition)";
+  if (/&&\s*false\b/.test(e)) return "always false (&& false collapses the condition)";
+  const eq = e.match(/^([\w.$'"[\]-]+)\s*==\s*([\w.$'"[\]-]+)$/);
+  if (eq && eq[1] === eq[2]) return "always true (both sides of == are identical)";
+  const ne = e.match(/^([\w.$'"[\]-]+)\s*!=\s*([\w.$'"[\]-]+)$/);
+  if (ne && ne[1] === ne[2]) return "always false (both sides of != are identical)";
+  return undefined;
+}
+
+export const gha046: PostSynthCheck = {
+  id: "GHA046",
+  description: "Logically unsound (constant) guard condition",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, expr } of extractIfConditions(yaml)) {
+        const reason = unsoundReason(expr);
+        if (!reason) continue;
+        diagnostics.push({
+          checkId: "GHA046",
+          severity: "warning",
+          message: `Job "${job}" has an if: condition that is ${reason}: "${expr}". A gate that does not constrain anything is misleading — remove it or write the real condition.`,
+          entity: job,
+          lexicon: "github",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha047.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha047.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha047 } from "./gha047";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA047: reversed contains() guard", () => {
+  test("flags contains('literal', dynamic)", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: \${{ contains('refs/heads/main', github.ref) }}
+    steps:
+      - run: echo build
+`;
+    const diags = gha047.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA047");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag normal contains(dynamic, 'literal')", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: \${{ contains(github.event.pull_request.labels.*.name, 'bug') }}
+    steps:
+      - run: echo build
+`;
+    const diags = gha047.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag contains() of two literals", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: \${{ contains('abc', 'b') }}
+    steps:
+      - run: echo build
+`;
+    const diags = gha047.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha047.ts
+++ b/lexicons/github/src/lint/post-synth/gha047.ts
@@ -1,0 +1,51 @@
+/**
+ * GHA047: Ineffective `contains()` Guard (Reversed Arguments)
+ *
+ * Flags `contains('literal', <dynamic>)` — a string literal as the haystack and
+ * a dynamic value as the needle. `contains(search, item)` checks whether `item`
+ * is in `search`, so a constant first argument makes the result depend on a
+ * fixed string rather than the runtime value the author intended to test. The
+ * usual fix is to swap the arguments.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractIfConditions } from "./yaml-helpers";
+
+// contains( 'literal' | "literal" , <something that is not a literal> )
+const REVERSED_CONTAINS = /contains\(\s*(['"][^'"]*['"])\s*,\s*([^)]+)\)/g;
+
+function isLiteral(arg: string): boolean {
+  const t = arg.trim();
+  return (t.startsWith("'") && t.endsWith("'")) || (t.startsWith('"') && t.endsWith('"'));
+}
+
+export const gha047: PostSynthCheck = {
+  id: "GHA047",
+  description: "Ineffective contains() guard with reversed arguments",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, expr } of extractIfConditions(yaml)) {
+        let m: RegExpExecArray | null;
+        REVERSED_CONTAINS.lastIndex = 0;
+        while ((m = REVERSED_CONTAINS.exec(expr)) !== null) {
+          // First arg is a literal; flag only when the second arg is dynamic.
+          if (isLiteral(m[2])) continue;
+          diagnostics.push({
+            checkId: "GHA047",
+            severity: "warning",
+            message: `Job "${job}" calls contains() with a string-literal haystack and a dynamic needle: "${m[0]}". contains(search, item) tests whether item is in search — swap the arguments so the dynamic value is searched.`,
+            entity: job,
+            lexicon: "github",
+          });
+          break;
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha048.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha048.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha048 } from "./gha048";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA048: obfuscated guard condition", () => {
+  test("flags an operand built with format() in a comparison", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: \${{ format('{0}', github.actor) == 'octocat' }}
+    steps:
+      - run: echo build
+`;
+    const diags = gha048.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA048");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag a direct comparison", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: \${{ github.actor == 'octocat' }}
+    steps:
+      - run: echo build
+`;
+    const diags = gha048.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha048.ts
+++ b/lexicons/github/src/lint/post-synth/gha048.ts
@@ -1,0 +1,41 @@
+/**
+ * GHA048: Obfuscated Guard Condition
+ *
+ * Flags an `if:` condition that builds its compared value through string
+ * indirection — `format()`, `join()`, or `fromJSON()` feeding a comparison.
+ * Constructing the operand at evaluation time hides what the gate actually
+ * checks, which is how an unsound condition (GHA046/GHA047) is disguised to pass
+ * review. Write the comparison against the value directly.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractIfConditions } from "./yaml-helpers";
+
+const INDIRECTION = /\b(format|join|fromJSON)\s*\(/i;
+const COMPARISON = /==|!=|&&|\|\||contains\(|startsWith\(|endsWith\(/;
+
+export const gha048: PostSynthCheck = {
+  id: "GHA048",
+  description: "Obfuscated guard condition (operand built by indirection)",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, expr } of extractIfConditions(yaml)) {
+        if (INDIRECTION.test(expr) && COMPARISON.test(expr)) {
+          diagnostics.push({
+            checkId: "GHA048",
+            severity: "warning",
+            message: `Job "${job}" builds its if: gate through string indirection (format/join/fromJSON) feeding a comparison: "${expr}". Compare against the value directly so the condition is auditable.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/plugin.test.ts
+++ b/lexicons/github/src/plugin.test.ts
@@ -24,7 +24,7 @@ describe("githubPlugin", () => {
 
   test("provides post-synth checks", () => {
     const checks = githubPlugin.postSynthChecks!();
-    expect(checks.length).toBe(32);
+    expect(checks.length).toBe(35);
 
     const checkIds = checks.map((c) => c.id);
     expect(checkIds).toContain("GHA006");
@@ -51,6 +51,9 @@ describe("githubPlugin", () => {
     expect(checkIds).toContain("GHA043");
     expect(checkIds).toContain("GHA044");
     expect(checkIds).toContain("GHA045");
+    expect(checkIds).toContain("GHA046");
+    expect(checkIds).toContain("GHA047");
+    expect(checkIds).toContain("GHA048");
   });
 
   test("lint IDs are unique across rules and post-synth checks", () => {


### PR DESCRIPTION
Closes #290.

A condition can read like a security control while doing nothing. Three post-synth checks on `if:` conditions in emitted workflow YAML:

| ID | Check | Severity |
|----|-------|----------|
| GHA046 | logically unsound (constant) guard — `true`/`false`, `X == X`, `\|\| true`, `&& false` | warning |
| GHA047 | ineffective `contains('literal', <dynamic>)` (reversed arguments) | warning |
| GHA048 | obfuscated guard whose operand is built via `format`/`join`/`fromJSON` indirection | warning |

### Auto-fix item
The acceptance item "auto-fix where the corrected intent is unambiguous" is **N/A at the post-synth layer**: `PostSynthDiagnostic` has no fix channel — post-synth reads emitted YAML and reports diagnostics. Auto-fix belongs to the declarative source-lint rules and is noted as such in the commit.

Positive + negative fixture test per check (`unsoundReason` unit-tested directly). `npx vitest run` green for the github lexicon; eslint clean; docs regenerated. Stacked on #289; rebased onto main after merge.