### PR TITLE
feat(github): artifact and cache hygiene (#291)

### DIFF
--- a/lexicons/github/docs/src/content/docs/index.mdx
+++ b/lexicons/github/docs/src/content/docs/index.mdx
@@ -52,7 +52,7 @@ The lexicon provides **2 resources** (Workflow, Job), **13 composites** (Checkou
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 48 |
+| Lint rules | 51 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitHub`

--- a/lexicons/github/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/github/docs/src/content/docs/lint-rules.mdx
@@ -279,6 +279,24 @@ Flags `contains('literal', <dynamic>)` — a constant haystack with a dynamic ne
 
 Flags an `if:` gate whose compared operand is built through `format()` / `join()` / `fromJSON()` indirection. Constructing the operand at evaluation time hides what the gate checks — compare against the value directly.
 
+### GHA049 — Persisted checkout credentials reachable by an artifact
+
+**Severity:** warning
+
+Flags a job that checks out with persisted credentials (the default) and uploads an artifact — the token in `.git/config` can be swept into the artifact. Set `persist-credentials: false` on the checkout.
+
+### GHA050 — Cache populated in a privileged context
+
+**Severity:** warning
+
+Flags `actions/cache` under a privileged trigger (`pull_request_target`, `workflow_run`). A cache entry influenced by a fork can be restored and executed by a later trusted run (cache poisoning) — restrict caching to trusted triggers.
+
+### GHA051 — Publish step using a long-lived token instead of OIDC
+
+**Severity:** info
+
+Flags a publish/release job that uses a long-lived token secret while requesting no `id-token: write`. If the registry supports OIDC, mint a short-lived federated credential per run instead of holding a standing token.
+
 ## Running lint
 
 ```bash

--- a/lexicons/github/src/codegen/docs.ts
+++ b/lexicons/github/src/codegen/docs.ts
@@ -1096,6 +1096,24 @@ Flags \`contains('literal', <dynamic>)\` — a constant haystack with a dynamic 
 
 Flags an \`if:\` gate whose compared operand is built through \`format()\` / \`join()\` / \`fromJSON()\` indirection. Constructing the operand at evaluation time hides what the gate checks — compare against the value directly.
 
+### GHA049 — Persisted checkout credentials reachable by an artifact
+
+**Severity:** warning
+
+Flags a job that checks out with persisted credentials (the default) and uploads an artifact — the token in \`.git/config\` can be swept into the artifact. Set \`persist-credentials: false\` on the checkout.
+
+### GHA050 — Cache populated in a privileged context
+
+**Severity:** warning
+
+Flags \`actions/cache\` under a privileged trigger (\`pull_request_target\`, \`workflow_run\`). A cache entry influenced by a fork can be restored and executed by a later trusted run (cache poisoning) — restrict caching to trusted triggers.
+
+### GHA051 — Publish step using a long-lived token instead of OIDC
+
+**Severity:** info
+
+Flags a publish/release job that uses a long-lived token secret while requesting no \`id-token: write\`. If the registry supports OIDC, mint a short-lived federated credential per run instead of holding a standing token.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/github/src/lint/post-synth/gha049.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha049.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha049 } from "./gha049";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA049: persisted checkout credentials in artifact", () => {
+  test("flags checkout + upload-artifact without persist-credentials: false", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/upload-artifact@v4
+        with:
+          path: .
+`;
+    const diags = gha049.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA049");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag when persist-credentials is disabled", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/upload-artifact@v4
+        with:
+          path: .
+`;
+    const diags = gha049.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag checkout without artifact upload", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo build
+`;
+    const diags = gha049.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha049.ts
+++ b/lexicons/github/src/lint/post-synth/gha049.ts
@@ -1,0 +1,42 @@
+/**
+ * GHA049: Persisted Checkout Credentials Reachable by an Uploaded Artifact
+ *
+ * `actions/checkout` writes the job token into `.git/config` by default
+ * (`persist-credentials: true`). A job that also uploads an artifact can sweep
+ * that `.git` directory into the artifact, leaking the token to anyone who can
+ * download it. Set `persist-credentials: false` on the checkout when the job
+ * uploads artifacts.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, linesByJob } from "./yaml-helpers";
+
+export const gha049: PostSynthCheck = {
+  id: "GHA049",
+  description: "Persisted checkout credentials reachable by an uploaded artifact",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job, lines] of linesByJob(yaml)) {
+        const text = lines.join("\n");
+        const hasCheckout = /uses:\s*actions\/checkout/.test(text);
+        const persistDisabled = /persist-credentials:\s*false/.test(text);
+        const uploadsArtifact = /uses:\s*actions\/upload-artifact/.test(text);
+        if (hasCheckout && uploadsArtifact && !persistDisabled) {
+          diagnostics.push({
+            checkId: "GHA049",
+            severity: "warning",
+            message: `Job "${job}" checks out with persisted credentials (default) and uploads an artifact — the token in .git/config can leak into the artifact. Set persist-credentials: false on the checkout.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha050.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha050.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha050 } from "./gha050";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA050: cache populated in privileged context", () => {
+  test("flags actions/cache under pull_request_target", () => {
+    const yaml = `name: CI
+on:
+  pull_request_target:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-cache
+`;
+    const diags = gha050.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA050");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag cache on a safe trigger", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-cache
+`;
+    const diags = gha050.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha050.ts
+++ b/lexicons/github/src/lint/post-synth/gha050.ts
@@ -1,0 +1,44 @@
+/**
+ * GHA050: Cache Populated in a Privileged Context (Poisoning Risk)
+ *
+ * Flags `actions/cache` use under a privileged trigger (`pull_request_target`,
+ * `workflow_run`) that runs in the base-repo context. Cache entries written from
+ * code influenced by a fork can later be restored by a trusted run and executed,
+ * a cache-poisoning path. Restrict caching to trusted triggers or scope keys so
+ * untrusted runs cannot write entries a privileged run will restore.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractTriggers, linesByJob } from "./yaml-helpers";
+
+const PRIVILEGED_TRIGGERS = ["pull_request_target", "workflow_run"];
+
+export const gha050: PostSynthCheck = {
+  id: "GHA050",
+  description: "Cache populated in a privileged context (poisoning risk)",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const triggers = extractTriggers(yaml);
+      const privileged = PRIVILEGED_TRIGGERS.filter((t) => triggers[t]);
+      if (privileged.length === 0) continue;
+
+      for (const [job, lines] of linesByJob(yaml)) {
+        if (lines.some((l) => /uses:\s*actions\/cache/.test(l))) {
+          diagnostics.push({
+            checkId: "GHA050",
+            severity: "warning",
+            message: `Job "${job}" populates a cache under the ${privileged.join("/")} trigger, which runs in the privileged base context. A poisoned cache entry could be restored and executed by a trusted run — restrict caching to trusted triggers.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha051.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha051.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha051 } from "./gha051";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA051: publish with long-lived token instead of OIDC", () => {
+  test("flags npm publish with a token secret and no id-token", () => {
+    const yaml = `name: Release
+on:
+  push:
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
+        run: npm publish
+`;
+    const diags = gha051.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA051");
+    expect(diags[0].severity).toBe("info");
+    expect(diags[0].entity).toBe("publish");
+  });
+
+  test("does not flag when id-token: write is requested", () => {
+    const yaml = `name: Release
+on:
+  push:
+permissions:
+  id-token: write
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
+        run: npm publish
+`;
+    const diags = gha051.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag a non-publish job", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          API: \${{ secrets.API_TOKEN }}
+        run: npm run build
+`;
+    const diags = gha051.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha051.ts
+++ b/lexicons/github/src/lint/post-synth/gha051.ts
@@ -1,0 +1,45 @@
+/**
+ * GHA051: Publish/Release Step Using a Long-Lived Token Instead of OIDC
+ *
+ * Flags a job that publishes a release/package using a long-lived token secret
+ * (`*_TOKEN`, `*_PASSWORD`, `*_API_KEY`) while the workflow requests no
+ * `id-token: write` permission. Registries that support OIDC let a workflow mint
+ * a short-lived, audience-scoped credential per run instead of holding a
+ * standing secret. Advisory — not every registry supports OIDC.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, linesByJob } from "./yaml-helpers";
+
+const PUBLISH_RE = /npm publish|yarn publish|pnpm publish|twine upload|poetry publish|cargo publish|gh release create|docker push|gh-action-pypi-publish|npm-publish/;
+const LONG_LIVED_SECRET_RE = /secrets\.(?!GITHUB_TOKEN\b)\w*(TOKEN|PASSWORD|API_KEY|APIKEY)/i;
+
+export const gha051: PostSynthCheck = {
+  id: "GHA051",
+  description: "Publish/release step using a long-lived token instead of OIDC",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const requestsOidc = /id-token:\s*write/.test(yaml);
+      if (requestsOidc) continue;
+
+      for (const [job, lines] of linesByJob(yaml)) {
+        const text = lines.join("\n");
+        if (PUBLISH_RE.test(text) && LONG_LIVED_SECRET_RE.test(text)) {
+          diagnostics.push({
+            checkId: "GHA051",
+            severity: "info",
+            message: `Job "${job}" publishes using a long-lived token secret and requests no id-token: write. If the registry supports OIDC, mint a short-lived federated credential (permissions: id-token: write) instead of holding a standing token.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/yaml-helpers.ts
+++ b/lexicons/github/src/lint/post-synth/yaml-helpers.ts
@@ -352,6 +352,17 @@ export function jobLines(yaml: string): Array<{ job: string; line: string }> {
   return out;
 }
 
+/** All lines inside the `jobs:` block grouped by owning job. */
+export function linesByJob(yaml: string): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  scanJobLines(yaml, (job, line) => {
+    const arr = out.get(job) ?? [];
+    arr.push(line);
+    out.set(job, arr);
+  });
+  return out;
+}
+
 /** Set of jobs that declare an `environment:`. */
 export function extractJobEnvironments(yaml: string): Set<string> {
   const set = new Set<string>();

--- a/lexicons/github/src/plugin.test.ts
+++ b/lexicons/github/src/plugin.test.ts
@@ -24,7 +24,7 @@ describe("githubPlugin", () => {
 
   test("provides post-synth checks", () => {
     const checks = githubPlugin.postSynthChecks!();
-    expect(checks.length).toBe(35);
+    expect(checks.length).toBe(38);
 
     const checkIds = checks.map((c) => c.id);
     expect(checkIds).toContain("GHA006");
@@ -54,6 +54,9 @@ describe("githubPlugin", () => {
     expect(checkIds).toContain("GHA046");
     expect(checkIds).toContain("GHA047");
     expect(checkIds).toContain("GHA048");
+    expect(checkIds).toContain("GHA049");
+    expect(checkIds).toContain("GHA050");
+    expect(checkIds).toContain("GHA051");
   });
 
   test("lint IDs are unique across rules and post-synth checks", () => {


### PR DESCRIPTION
Closes #291.

Persistent state that crosses a trust boundary carries privilege it shouldn't. Three post-synth checks on emitted workflow YAML:

| ID | Check | Severity |
|----|-------|----------|
| GHA049 | checkout with persisted credentials + `upload-artifact` (token in `.git` can leak into the artifact) | warning |
| GHA050 | `actions/cache` populated under a privileged trigger (`pull_request_target` / `workflow_run`) — cache poisoning | warning |
| GHA051 | publish/release job using a long-lived token while requesting no `id-token: write` — prefer OIDC | info |

New helper `linesByJob` in `yaml-helpers.ts`. Positive + negative fixture test per check. `npx vitest run` green for the github lexicon (227 tests at authoring); eslint clean; docs regenerated. Stacked on #290; rebased onto main after merge.