### PR TITLE
feat(github): remaining workflow hardening gaps (#295)

### DIFF
--- a/lexicons/github/docs/src/content/docs/index.mdx
+++ b/lexicons/github/docs/src/content/docs/index.mdx
@@ -52,7 +52,7 @@ The lexicon provides **2 resources** (Workflow, Job), **13 composites** (Checkou
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 51 |
+| Lint rules | 56 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitHub`

--- a/lexicons/github/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/github/docs/src/content/docs/lint-rules.mdx
@@ -297,6 +297,38 @@ Flags `actions/cache` under a privileged trigger (`pull_request_target`, `workfl
 
 Flags a publish/release job that uses a long-lived token secret while requesting no `id-token: write`. If the registry supports OIDC, mint a short-lived federated credential per run instead of holding a standing token.
 
+### GHA052 — Software fetched and piped to a shell
+
+**Severity:** warning
+
+Flags a `run:` step that pipes a network download straight into a shell (`curl ... | bash`). The fetched code is unpinned and unverified — download to a file, verify a checksum/signature, then run it.
+
+### GHA053 — Unsafe set-env / add-path opt-in
+
+**Severity:** error
+
+Flags re-enabling the `set-env` / `add-path` workflow commands removed for security (CVE-2020-15228) via `ACTIONS_ALLOW_UNSECURE_COMMANDS` or direct `::set-env::` / `::add-path::`. Use the `$GITHUB_ENV` / `$GITHUB_PATH` files instead.
+
+### GHA054 — Known-bad feature usage
+
+**Severity:** warning
+
+Catch-all, data-driven check flagging emitted content matching a vendored snapshot of risky features (deprecated workflow commands, unsafe runtime opt-ins). Advisory and necessarily incomplete.
+
+### GHA055 — Redundant runtime tool install
+
+**Severity:** info
+
+Flags a `run:` step that installs a tool GitHub-hosted runners already ship. The redundant install adds supply-chain surface for no benefit (irrelevant on self-hosted runners that may lack the tool).
+
+### GHA056 — Workflow without a name
+
+**Severity:** info
+
+Flags a workflow with no top-level `name:`. Without one, GitHub falls back to the file path in the UI and audit logs, making runs harder to identify.
+
+> Two items from issue #295 are intentionally not implemented at the post-synth layer: over-broad/unrevoked app-installation tokens (whether a minted token is scoped wider than used cannot be determined from emitted YAML) and a reference allowlist/denylist policy (configuration, overlapping the GHA029 trusted-owner allowlist).
+
 ## Running lint
 
 ```bash

--- a/lexicons/github/src/codegen/docs.ts
+++ b/lexicons/github/src/codegen/docs.ts
@@ -1114,6 +1114,38 @@ Flags \`actions/cache\` under a privileged trigger (\`pull_request_target\`, \`w
 
 Flags a publish/release job that uses a long-lived token secret while requesting no \`id-token: write\`. If the registry supports OIDC, mint a short-lived federated credential per run instead of holding a standing token.
 
+### GHA052 — Software fetched and piped to a shell
+
+**Severity:** warning
+
+Flags a \`run:\` step that pipes a network download straight into a shell (\`curl ... | bash\`). The fetched code is unpinned and unverified — download to a file, verify a checksum/signature, then run it.
+
+### GHA053 — Unsafe set-env / add-path opt-in
+
+**Severity:** error
+
+Flags re-enabling the \`set-env\` / \`add-path\` workflow commands removed for security (CVE-2020-15228) via \`ACTIONS_ALLOW_UNSECURE_COMMANDS\` or direct \`::set-env::\` / \`::add-path::\`. Use the \`$GITHUB_ENV\` / \`$GITHUB_PATH\` files instead.
+
+### GHA054 — Known-bad feature usage
+
+**Severity:** warning
+
+Catch-all, data-driven check flagging emitted content matching a vendored snapshot of risky features (deprecated workflow commands, unsafe runtime opt-ins). Advisory and necessarily incomplete.
+
+### GHA055 — Redundant runtime tool install
+
+**Severity:** info
+
+Flags a \`run:\` step that installs a tool GitHub-hosted runners already ship. The redundant install adds supply-chain surface for no benefit (irrelevant on self-hosted runners that may lack the tool).
+
+### GHA056 — Workflow without a name
+
+**Severity:** info
+
+Flags a workflow with no top-level \`name:\`. Without one, GitHub falls back to the file path in the UI and audit logs, making runs harder to identify.
+
+> Two items from issue #295 are intentionally not implemented at the post-synth layer: over-broad/unrevoked app-installation tokens (whether a minted token is scoped wider than used cannot be determined from emitted YAML) and a reference allowlist/denylist policy (configuration, overlapping the GHA029 trusted-owner allowlist).
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/github/src/lint/post-synth/gha052.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha052.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha052 } from "./gha052";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA052: curl | bash runtime execution", () => {
+  test("flags curl piped to bash", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -sSL https://example.com/install.sh | bash
+`;
+    const diags = gha052.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA052");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag download-then-verify", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -sSLo install.sh https://example.com/install.sh
+          echo "abc123  install.sh" | sha256sum -c
+          bash install.sh
+`;
+    const diags = gha052.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha052.ts
+++ b/lexicons/github/src/lint/post-synth/gha052.ts
@@ -1,0 +1,42 @@
+/**
+ * GHA052: Software Fetched and Executed at Runtime Without Verification
+ *
+ * Flags a `run:` step that pipes a network download straight into a shell
+ * (`curl ... | bash`, `wget ... | sh`, `iwr ... | iex`). The fetched script is
+ * unpinned and unverified, so whoever controls the URL controls what executes
+ * in the job. Download to a file, verify a checksum/signature, then run it.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractRunBlocks } from "./yaml-helpers";
+
+const PIPE_TO_SHELL = [
+  /\b(curl|wget)\b[^\n|]*\|\s*(sudo\s+)?(ba)?sh\b/i,
+  /\b(iwr|invoke-webrequest|irm|invoke-restmethod)\b[^\n|]*\|\s*(iex|invoke-expression)\b/i,
+];
+
+export const gha052: PostSynthCheck = {
+  id: "GHA052",
+  description: "Software fetched and piped to a shell without verification",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, run } of extractRunBlocks(yaml)) {
+        if (PIPE_TO_SHELL.some((re) => re.test(run))) {
+          diagnostics.push({
+            checkId: "GHA052",
+            severity: "warning",
+            message: `Job "${job}" pipes a network download directly into a shell — the fetched code is unpinned and unverified. Download to a file, verify a checksum or signature, then execute it.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha053.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha053.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha053 } from "./gha053";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA053: unsafe workflow-command opt-in", () => {
+  test("flags ACTIONS_ALLOW_UNSECURE_COMMANDS", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+    steps:
+      - run: echo build
+`;
+    const diags = gha053.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA053");
+    expect(diags[0].severity).toBe("error");
+  });
+
+  test("flags ::set-env:: emission", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::set-env name=FOO::bar"
+`;
+    const diags = gha053.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+  });
+
+  test("does not flag normal env file usage", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "FOO=bar" >> "$GITHUB_ENV"
+`;
+    const diags = gha053.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha053.ts
+++ b/lexicons/github/src/lint/post-synth/gha053.ts
@@ -1,0 +1,41 @@
+/**
+ * GHA053: Re-enabling Unsafe Workflow-Command Processing
+ *
+ * Flags opt-ins that reintroduce the `set-env` / `add-path` workflow commands
+ * removed for security (CVE-2020-15228) — `ACTIONS_ALLOW_UNSECURE_COMMANDS` and
+ * direct `::set-env::` / `::add-path::` emission. These let a logged string set
+ * arbitrary environment/PATH state for later steps, a code-execution path.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, linesByJob } from "./yaml-helpers";
+
+const UNSAFE_COMMANDS = /ACTIONS_ALLOW_UNSECURE_COMMANDS|::set-env\s|::add-path\s/;
+
+export const gha053: PostSynthCheck = {
+  id: "GHA053",
+  description: "Re-enables unsafe set-env / add-path workflow commands",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const seen = new Set<string>();
+      for (const [job, lines] of linesByJob(yaml)) {
+        if (lines.some((l) => UNSAFE_COMMANDS.test(l)) && !seen.has(job)) {
+          seen.add(job);
+          diagnostics.push({
+            checkId: "GHA053",
+            severity: "error",
+            message: `Job "${job}" re-enables the unsafe set-env/add-path workflow commands (ACTIONS_ALLOW_UNSECURE_COMMANDS or ::set-env::/::add-path::). Use $GITHUB_ENV / $GITHUB_PATH files instead — the legacy commands were removed for security.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha054.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha054.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha054 } from "./gha054";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA054: known-bad feature usage", () => {
+  test("flags deprecated ::set-output::", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::set-output name=version::1.0.0"
+`;
+    const diags = gha054.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA054");
+    expect(diags[0].message).toContain("set-output");
+  });
+
+  test("does not flag $GITHUB_OUTPUT usage", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "version=1.0.0" >> "$GITHUB_OUTPUT"
+`;
+    const diags = gha054.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha054.ts
+++ b/lexicons/github/src/lint/post-synth/gha054.ts
@@ -1,0 +1,41 @@
+/**
+ * GHA054: Use of a Feature with a Known Security Footgun
+ *
+ * Catch-all, data-driven check: flags emitted workflow content matching a
+ * vendored snapshot of known-risky GitHub Actions features (deprecated workflow
+ * commands, unsafe runtime opt-ins, masking footguns). Advisory; the dataset is
+ * necessarily incomplete.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, linesByJob } from "./yaml-helpers";
+import { RISKY_FEATURES } from "../rules/data/risky-features";
+
+export const gha054: PostSynthCheck = {
+  id: "GHA054",
+  description: "Use of a feature with a known security footgun",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job, lines] of linesByJob(yaml)) {
+        const text = lines.join("\n");
+        for (const feature of RISKY_FEATURES) {
+          if (feature.pattern.test(text)) {
+            diagnostics.push({
+              checkId: "GHA054",
+              severity: "warning",
+              message: `Job "${job}" uses ${feature.label} — ${feature.advice}.`,
+              entity: job,
+              lexicon: "github",
+            });
+          }
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha055.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha055.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha055 } from "./gha055";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA055: redundant runtime install", () => {
+  test("flags apt-get install of a preinstalled tool", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt-get install -y jq
+`;
+    const diags = gha055.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA055");
+    expect(diags[0].message).toContain("jq");
+  });
+
+  test("does not flag installing a tool not on the runner", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt-get install -y libpq-dev
+`;
+    const diags = gha055.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha055.ts
+++ b/lexicons/github/src/lint/post-synth/gha055.ts
@@ -1,0 +1,50 @@
+/**
+ * GHA055: Runtime Install of a Tool Already on the Runner
+ *
+ * Flags a `run:` step that installs (apt/brew/apk/choco) a tool that GitHub-
+ * hosted runners already ship. The redundant install adds a third-party
+ * download and supply-chain surface for no benefit and slows the job. Advisory;
+ * irrelevant on self-hosted runners that may lack the tool.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractRunBlocks } from "./yaml-helpers";
+import { PREINSTALLED_TOOLS } from "../rules/data/preinstalled-tools";
+
+const INSTALL_RE = /\b(?:apt(?:-get)?\s+install|brew\s+install|apk\s+add|choco\s+install)\b([^\n]*)/g;
+
+export const gha055: PostSynthCheck = {
+  id: "GHA055",
+  description: "Runtime install of a tool already present on the runner",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+    const preinstalled = new Set(PREINSTALLED_TOOLS);
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, run } of extractRunBlocks(yaml)) {
+        const redundant = new Set<string>();
+        let m: RegExpExecArray | null;
+        INSTALL_RE.lastIndex = 0;
+        while ((m = INSTALL_RE.exec(run)) !== null) {
+          for (const tok of m[1].split(/\s+/)) {
+            const name = tok.replace(/[^\w.+-]/g, "");
+            if (name && preinstalled.has(name)) redundant.add(name);
+          }
+        }
+        if (redundant.size > 0) {
+          diagnostics.push({
+            checkId: "GHA055",
+            severity: "info",
+            message: `Job "${job}" installs ${[...redundant].join(", ")} at runtime, but GitHub-hosted runners already ship ${redundant.size > 1 ? "these tools" : "this tool"}. Drop the redundant install (or rely on the preinstalled version) to reduce supply-chain surface.`,
+            entity: job,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha056.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha056.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { gha056 } from "./gha056";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA056: workflow without a name", () => {
+  test("flags a workflow with no name", () => {
+    const yaml = `on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha056.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA056");
+  });
+
+  test("does not flag a named workflow", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    const diags = gha056.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha056.ts
+++ b/lexicons/github/src/lint/post-synth/gha056.ts
@@ -1,0 +1,37 @@
+/**
+ * GHA056: Workflow Without a `name:`
+ *
+ * Flags an emitted workflow with no top-level `name:`. Without one, GitHub falls
+ * back to the file path in the Actions UI and audit logs, making runs harder to
+ * identify and review. A clear name improves observability and audit output.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractWorkflowName } from "./yaml-helpers";
+
+export const gha056: PostSynthCheck = {
+  id: "GHA056",
+  description: "Workflow without a name",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [lexicon, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      // Only inspect things that look like workflows (have a jobs: block).
+      if (!/^jobs:\s*$/m.test(yaml)) continue;
+      const name = extractWorkflowName(yaml);
+      if (!name) {
+        diagnostics.push({
+          checkId: "GHA056",
+          severity: "info",
+          message: `Workflow "${lexicon}" has no top-level name: — add one so runs are identifiable in the Actions UI and audit logs.`,
+          entity: "workflow",
+          lexicon: "github",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/rules/data/preinstalled-tools.ts
+++ b/lexicons/github/src/lint/rules/data/preinstalled-tools.ts
@@ -1,0 +1,36 @@
+/**
+ * Vendored snapshot of tools already present on GitHub-hosted runner images,
+ * used by GHA056 to flag redundant runtime installs that add third-party
+ * surface for no benefit.
+ *
+ * Advisory. Refresh source: the runner-images repository's installed-software
+ * manifests. Conservative on purpose — only tools that are reliably present
+ * across the common ubuntu/macos/windows images are listed.
+ */
+export const PREINSTALLED_TOOLS: readonly string[] = [
+  "git",
+  "curl",
+  "wget",
+  "jq",
+  "make",
+  "gcc",
+  "g++",
+  "zip",
+  "unzip",
+  "tar",
+  "docker",
+  "docker-compose",
+  "python3",
+  "pip3",
+  "node",
+  "npm",
+  "yarn",
+  "go",
+  "gh",
+  "aws",
+  "az",
+  "gcloud",
+  "kubectl",
+  "helm",
+  "terraform",
+];

--- a/lexicons/github/src/lint/rules/data/risky-features.ts
+++ b/lexicons/github/src/lint/rules/data/risky-features.ts
@@ -1,0 +1,39 @@
+/**
+ * Vendored snapshot of GitHub Actions features with a known security or
+ * safety footgun, matched against emitted workflow YAML by GHA054.
+ *
+ * Advisory and necessarily incomplete. Refresh source: GitHub changelog
+ * deprecations and security hardening guidance. Editing this list is the
+ * refresh mechanism; a stale entry only weakens detection, never blocks a build.
+ */
+export interface RiskyFeature {
+  /** Pattern matched against the emitted YAML. */
+  pattern: RegExp;
+  /** Short label for the footgun. */
+  label: string;
+  /** What to do instead. */
+  advice: string;
+}
+
+export const RISKY_FEATURES: readonly RiskyFeature[] = [
+  {
+    pattern: /::set-output\s/,
+    label: "deprecated ::set-output:: workflow command",
+    advice: "write to $GITHUB_OUTPUT instead",
+  },
+  {
+    pattern: /::save-state\s/,
+    label: "deprecated ::save-state:: workflow command",
+    advice: "write to $GITHUB_STATE instead",
+  },
+  {
+    pattern: /ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION/,
+    label: "opt-in to an end-of-life Node.js runtime",
+    advice: "upgrade the action to a supported Node runtime instead of forcing the unsupported one",
+  },
+  {
+    pattern: /::add-mask::\$\{\{/,
+    label: "masking a dynamic value after it may have already been logged",
+    advice: "mask secrets at their source; ::add-mask:: on an interpolated value can leak before the mask applies",
+  },
+];

--- a/lexicons/github/src/plugin.test.ts
+++ b/lexicons/github/src/plugin.test.ts
@@ -24,7 +24,7 @@ describe("githubPlugin", () => {
 
   test("provides post-synth checks", () => {
     const checks = githubPlugin.postSynthChecks!();
-    expect(checks.length).toBe(38);
+    expect(checks.length).toBe(43);
 
     const checkIds = checks.map((c) => c.id);
     expect(checkIds).toContain("GHA006");
@@ -57,6 +57,11 @@ describe("githubPlugin", () => {
     expect(checkIds).toContain("GHA049");
     expect(checkIds).toContain("GHA050");
     expect(checkIds).toContain("GHA051");
+    expect(checkIds).toContain("GHA052");
+    expect(checkIds).toContain("GHA053");
+    expect(checkIds).toContain("GHA054");
+    expect(checkIds).toContain("GHA055");
+    expect(checkIds).toContain("GHA056");
   });
 
   test("lint IDs are unique across rules and post-synth checks", () => {


### PR DESCRIPTION
Closes #295.

Catch-all hardening checks after the main security pass. Five post-synth checks on emitted workflow YAML:

| ID | Check | Severity |
|----|-------|----------|
| GHA052 | software fetched and piped to a shell (`curl \| bash`) without verification | warning |
| GHA053 | re-enabling unsafe `set-env`/`add-path` (`ACTIONS_ALLOW_UNSECURE_COMMANDS`, `::set-env::`) | error |
| GHA054 | known-bad feature usage, data-driven (`data/risky-features.ts`) | warning |
| GHA055 | redundant runtime install of a tool already on the runner (`data/preinstalled-tools.ts`) | info |
| GHA056 | workflow without a `name:` | info |

### Intentionally not post-synth checks (documented in `docs.ts`)
- **Over-broad/unrevoked app-installation tokens** — whether a minted token is scoped wider than used is not determinable from emitted YAML.
- **Reference allowlist/denylist policy** — configuration, overlapping the GHA029 trusted-owner allowlist.

Positive + negative fixture test per check. `npx vitest run` green for the github lexicon (238 tests); eslint clean; docs regenerated. Completes the GitHub static-check half of the epic (#286–#291, #293, #295).