### PR TITLE
feat(gitlab): pin & vet includes, components, and images (#297)

### DIFF
--- a/lexicons/gitlab/docs/src/content/docs/index.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/index.mdx
@@ -42,9 +42,9 @@ The lexicon provides **3 resources** (Job, Workflow, Default), **16 property typ
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 23 |
+| Lint rules | 27 |
 
-**Lexicon version:** 0.1.14  
+**Lexicon version:** 0.1.23  
 **Namespace:** `GitLab`
 
 - [Pipeline Concepts](./pipeline-concepts)

--- a/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
@@ -158,6 +158,30 @@ Flags jobs whose `extends:` references a template or hidden job not defined in t
 
 Detects cycles in the `needs:` dependency graph. If job A needs B and B needs A (directly or transitively), GitLab rejects the pipeline. Reports the full cycle chain in the diagnostic message.
 
+### WGL029 — Unpinned include:project / component
+
+**Severity:** warning
+
+Flags an `include:project` or CI/CD `component:` resolved by a moving ref — a branch, a missing `ref:` (defaults to the default branch), or a floating component version — instead of a pinned tag or commit SHA.
+
+### WGL030 — Mutable or insecure include:remote
+
+**Severity:** error (HTTP) / warning (HTTPS)
+
+Flags `include:remote` URLs fetched over HTTP (no transport integrity) or over HTTPS but inherently mutable. Prefer a pinned `include:project` or component. Generalizes WGL017 to includes.
+
+### WGL031 — Container image without a digest
+
+**Severity:** warning
+
+Flags `image:` and `services:` references not pinned to an immutable `@sha256:` digest. Variable-based references (e.g. `$CI_REGISTRY_IMAGE:tag`) are skipped.
+
+### WGL032 — Look-alike include/component source
+
+**Severity:** warning
+
+Flags an `include:project` / `component:` source that is a near-miss (edit distance 1–2) of a well-known GitLab CI source but not an exact match — a likely typo or impersonation. Backed by a vendored reference list.
+
 ## Running lint
 
 ```bash

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -435,6 +435,30 @@ Flags jobs whose \`extends:\` references a template or hidden job not defined in
 
 Detects cycles in the \`needs:\` dependency graph. If job A needs B and B needs A (directly or transitively), GitLab rejects the pipeline. Reports the full cycle chain in the diagnostic message.
 
+### WGL029 — Unpinned include:project / component
+
+**Severity:** warning
+
+Flags an \`include:project\` or CI/CD \`component:\` resolved by a moving ref — a branch, a missing \`ref:\` (defaults to the default branch), or a floating component version — instead of a pinned tag or commit SHA.
+
+### WGL030 — Mutable or insecure include:remote
+
+**Severity:** error (HTTP) / warning (HTTPS)
+
+Flags \`include:remote\` URLs fetched over HTTP (no transport integrity) or over HTTPS but inherently mutable. Prefer a pinned \`include:project\` or component. Generalizes WGL017 to includes.
+
+### WGL031 — Container image without a digest
+
+**Severity:** warning
+
+Flags \`image:\` and \`services:\` references not pinned to an immutable \`@sha256:\` digest. Variable-based references (e.g. \`$CI_REGISTRY_IMAGE:tag\`) are skipped.
+
+### WGL032 — Look-alike include/component source
+
+**Severity:** warning
+
+Flags an \`include:project\` / \`component:\` source that is a near-miss (edit distance 1–2) of a well-known GitLab CI source but not an exact match — a likely typo or impersonation. Backed by a vendored reference list.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/gitlab/src/lint/post-synth/wgl029.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl029.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl029 } from "./wgl029";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL029: unpinned include:project / component", () => {
+  test("flags include:project on a branch ref", () => {
+    const yaml = `include:
+  - project: my-group/ci-templates
+    ref: main
+    file: /templates/build.yml
+
+stages:
+  - build
+`;
+    const diags = wgl029.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL029");
+    expect(diags[0].message).toContain("main");
+  });
+
+  test("flags include:project with no ref", () => {
+    const yaml = `include:
+  - project: my-group/ci-templates
+    file: /templates/build.yml
+
+stages:
+  - build
+`;
+    const diags = wgl029.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain("default branch");
+  });
+
+  test("does not flag a pinned tag ref", () => {
+    const yaml = `include:
+  - project: my-group/ci-templates
+    ref: v1.2.3
+    file: /templates/build.yml
+
+stages:
+  - build
+`;
+    const diags = wgl029.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("flags a floating component version and not a pinned one", () => {
+    const floating = `include:
+  - component: gitlab.example.com/my-group/my-comp@main
+
+stages:
+  - build
+`;
+    const pinned = `include:
+  - component: gitlab.example.com/my-group/my-comp@1.0.0
+
+stages:
+  - build
+`;
+    expect(wgl029.check(makeCtx(floating))).toHaveLength(1);
+    expect(wgl029.check(makeCtx(pinned))).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl029.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl029.ts
@@ -1,0 +1,59 @@
+/**
+ * WGL029: Unpinned include:project / component Reference
+ *
+ * Flags an `include:project` or CI/CD `component:` resolved by a moving ref — a
+ * branch, no `ref:` at all (defaults to the project's default branch), or a
+ * floating component version — instead of a pinned tag or commit SHA. A
+ * repointed ref turns the included configuration into a supply-chain entry point.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractIncludes, isPinnedRef } from "./yaml-helpers";
+
+export const wgl029: PostSynthCheck = {
+  id: "WGL029",
+  description: "include:project / component resolved by a moving ref instead of a pinned tag or SHA",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const entry of extractIncludes(yaml)) {
+        if (entry.kind === "project") {
+          if (!entry.ref) {
+            diagnostics.push({
+              checkId: "WGL029",
+              severity: "warning",
+              message: `include:project "${entry.value}" has no ref: and resolves to the project's default branch (a moving target). Pin it to a tag or commit SHA.`,
+              entity: entry.value,
+              lexicon: "gitlab",
+            });
+          } else if (!isPinnedRef(entry.ref)) {
+            diagnostics.push({
+              checkId: "WGL029",
+              severity: "warning",
+              message: `include:project "${entry.value}" is pinned to the moving ref "${entry.ref}". Pin it to a tag or commit SHA.`,
+              entity: entry.value,
+              lexicon: "gitlab",
+            });
+          }
+        } else if (entry.kind === "component") {
+          const at = entry.value.lastIndexOf("@");
+          const version = at === -1 ? "" : entry.value.slice(at + 1);
+          if (!version || !isPinnedRef(version)) {
+            diagnostics.push({
+              checkId: "WGL029",
+              severity: "warning",
+              message: `component "${entry.value}" uses ${version ? `the moving version "${version}"` : "no pinned version"}. Pin it to a released version tag or commit SHA.`,
+              entity: entry.value,
+              lexicon: "gitlab",
+            });
+          }
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl030.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl030.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl030 } from "./wgl030";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL030: mutable or insecure include:remote", () => {
+  test("errors on an HTTP remote include", () => {
+    const yaml = `include:
+  - remote: http://example.com/ci.yml
+
+stages:
+  - build
+`;
+    const diags = wgl030.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL030");
+    expect(diags[0].severity).toBe("error");
+  });
+
+  test("warns on an HTTPS remote include", () => {
+    const yaml = `include:
+  - remote: https://example.com/ci.yml
+
+stages:
+  - build
+`;
+    const diags = wgl030.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("warning");
+  });
+
+  test("does not flag a project include", () => {
+    const yaml = `include:
+  - project: my-group/ci-templates
+    ref: v1.0.0
+    file: /x.yml
+
+stages:
+  - build
+`;
+    const diags = wgl030.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl030.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl030.ts
@@ -1,0 +1,48 @@
+/**
+ * WGL030: Mutable or Insecure include:remote
+ *
+ * Flags `include:remote` URLs that are fetched over HTTP (no transport
+ * integrity) or over HTTPS but inherently mutable (a raw URL can be repointed
+ * at any time). Prefer `include:project` pinned to a tag/SHA, or a pinned
+ * component, over a remote URL. Generalizes WGL017 (non-HTTPS) to includes.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractIncludes } from "./yaml-helpers";
+
+export const wgl030: PostSynthCheck = {
+  id: "WGL030",
+  description: "include:remote is insecure (HTTP) or mutable",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const entry of extractIncludes(yaml)) {
+        const isRemote = entry.kind === "remote" || (entry.kind === "string" && /^https?:\/\//.test(entry.value));
+        if (!isRemote) continue;
+
+        if (/^http:\/\//.test(entry.value)) {
+          diagnostics.push({
+            checkId: "WGL030",
+            severity: "error",
+            message: `include:remote "${entry.value}" is fetched over HTTP — an attacker on the network can swap the included config. Use HTTPS, and prefer a pinned include:project or component.`,
+            entity: entry.value,
+            lexicon: "gitlab",
+          });
+        } else {
+          diagnostics.push({
+            checkId: "WGL030",
+            severity: "warning",
+            message: `include:remote "${entry.value}" is a mutable URL — its contents can change after review. Prefer include:project pinned to a tag/SHA, or a pinned component.`,
+            entity: entry.value,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl031.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl031.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl031 } from "./wgl031";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL031: container image without digest", () => {
+  test("flags an image pinned to a tag", () => {
+    const yaml = `build-job:
+  image:
+    name: node:20
+  script:
+    - echo build
+`;
+    const diags = wgl031.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL031");
+    expect(diags[0].message).toContain("node:20");
+  });
+
+  test("flags a service image pinned to a tag", () => {
+    const yaml = `build-job:
+  services:
+    - name: postgres:16
+  script:
+    - echo build
+`;
+    const diags = wgl031.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain("postgres:16");
+  });
+
+  test("does not flag an image pinned to a digest", () => {
+    const yaml = `build-job:
+  image:
+    name: node@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  script:
+    - echo build
+`;
+    const diags = wgl031.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag a variable-based image reference", () => {
+    const yaml = `build-job:
+  image:
+    name: $CI_REGISTRY_IMAGE:latest
+  script:
+    - echo build
+`;
+    const diags = wgl031.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl031.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl031.ts
@@ -1,0 +1,37 @@
+/**
+ * WGL031: Container Image Without an Immutable Digest
+ *
+ * Flags `image:` and `services:` references that are not pinned to an immutable
+ * `@sha256:` digest. A mutable tag can be repointed to a different image after
+ * review. Images built from a variable (e.g. `$CI_REGISTRY_IMAGE:tag`) are
+ * skipped — their concrete reference is not knowable from the static config.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractImageRefs } from "./yaml-helpers";
+
+export const wgl031: PostSynthCheck = {
+  id: "WGL031",
+  description: "Container image not pinned to an immutable digest",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, image, source } of extractImageRefs(yaml)) {
+        if (image.includes("@sha256:")) continue;
+        if (image.includes("$")) continue; // variable-based reference — not statically knowable
+        diagnostics.push({
+          checkId: "WGL031",
+          severity: "warning",
+          message: `Job "${job}" ${source === "service" ? "service image" : "image"} "${image}" is not pinned to a digest — reference it by @sha256:... so the image cannot change after review.`,
+          entity: job,
+          lexicon: "gitlab",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl032.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl032.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl032, nearestKnownSource } from "./wgl032";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL032: look-alike include source", () => {
+  test("nearestKnownSource flags a near-miss", () => {
+    expect(nearestKnownSource("gitlab-org/gitlab")).toBeUndefined();
+    expect(nearestKnownSource("gitlab-org/gitlabb")).toBe("gitlab-org/gitlab");
+    expect(nearestKnownSource("totally/unrelated")).toBeUndefined();
+  });
+
+  test("flags a typo-squatted include:project", () => {
+    const yaml = `include:
+  - project: gitlab-org/gitlabb
+    ref: v1.0.0
+    file: /x.yml
+
+stages:
+  - build
+`;
+    const diags = wgl032.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL032");
+    expect(diags[0].message).toContain("gitlab-org/gitlab");
+  });
+
+  test("does not flag an exact known source", () => {
+    const yaml = `include:
+  - project: gitlab-org/gitlab
+    ref: v1.0.0
+    file: /x.yml
+
+stages:
+  - build
+`;
+    const diags = wgl032.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl032.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl032.ts
@@ -1,0 +1,68 @@
+/**
+ * WGL032: Include/Component Source Resembling a Well-Known Project
+ *
+ * Flags an `include:project` path or `component:` source that is a near-miss
+ * (edit distance 1–2) of a well-known GitLab CI source but not an exact match —
+ * a likely typo or an impersonation of the trusted project. Advisory; backed by
+ * a vendored reference list.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractIncludes } from "./yaml-helpers";
+import { KNOWN_INCLUDE_SOURCES, editDistance } from "../rules/data/known-include-sources";
+
+const KNOWN = new Set(KNOWN_INCLUDE_SOURCES);
+
+/** Reduce a component address (`host/group/name@ver`) or project path to its group/name path. */
+function sourcePath(value: string, kind: string): string {
+  let v = value;
+  if (kind === "component") {
+    const at = v.lastIndexOf("@");
+    if (at !== -1) v = v.slice(0, at);
+    const slash = v.indexOf("/");
+    if (slash !== -1 && v.slice(0, slash).includes(".")) v = v.slice(slash + 1); // drop host
+  }
+  return v;
+}
+
+export function nearestKnownSource(path: string): string | undefined {
+  if (KNOWN.has(path)) return undefined;
+  let best: string | undefined;
+  let bestDist = 3;
+  for (const known of KNOWN) {
+    const d = editDistance(path, known, 2);
+    if (d >= 1 && d <= 2 && d < bestDist) {
+      best = known;
+      bestDist = d;
+    }
+  }
+  return best;
+}
+
+export const wgl032: PostSynthCheck = {
+  id: "WGL032",
+  description: "Include/component source resembles a well-known project (possible impersonation)",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const entry of extractIncludes(yaml)) {
+        if (entry.kind !== "project" && entry.kind !== "component") continue;
+        const path = sourcePath(entry.value, entry.kind);
+        const lookAlike = nearestKnownSource(path);
+        if (!lookAlike) continue;
+        diagnostics.push({
+          checkId: "WGL032",
+          severity: "warning",
+          message: `Include source "${path}" closely resembles the well-known "${lookAlike}". Confirm the source is who you intend — this may be a typo or impersonation.`,
+          entity: entry.value,
+          lexicon: "gitlab",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/yaml-helpers.ts
+++ b/lexicons/gitlab/src/lint/post-synth/yaml-helpers.ts
@@ -223,3 +223,107 @@ export function extractJobRules(section: string): ParsedRule[] {
 
   return rules;
 }
+
+/** A container image reference (job/default `image:` or a `services:` entry). */
+export interface ImageRef {
+  /** Owning job name, or "default" for the global image. */
+  job: string;
+  /** The image reference (e.g. `node:20`). */
+  image: string;
+  /** Where the image was declared. */
+  source: "image" | "service";
+}
+
+/**
+ * Extract container image references from `image:` and `services:` across the
+ * pipeline. Handles both the object form (`image:\n  name: ...`) and the inline
+ * string form (`image: ...`).
+ */
+export function extractImageRefs(yaml: string): ImageRef[] {
+  const refs: ImageRef[] = [];
+  for (const section of yaml.split("\n\n")) {
+    const lines = section.split("\n");
+    const top = lines[0]?.match(/^(\.?[a-z][a-z0-9_.-]*):/i);
+    const job = top ? top[1] : "default";
+
+    for (let i = 0; i < lines.length; i++) {
+      // image: as object (next indented `name:`) or inline string
+      const imgInline = lines[i].match(/^\s+image:\s+(\S.*)$/);
+      if (imgInline) {
+        refs.push({ job, image: imgInline[1].trim().replace(/^['"]|['"]$/g, ""), source: "image" });
+        continue;
+      }
+      if (/^\s+image:\s*$/.test(lines[i])) {
+        const nameLine = lines.slice(i + 1, i + 4).find((l) => /^\s+name:\s+/.test(l));
+        if (nameLine) {
+          const v = nameLine.replace(/^\s+name:\s+/, "").trim().replace(/^['"]|['"]$/g, "");
+          refs.push({ job, image: v, source: "image" });
+        }
+        continue;
+      }
+      // services: list entries — `- name:` or `- 'image'`
+      const svcName = lines[i].match(/^\s+-\s+name:\s+(\S.*)$/);
+      if (svcName) {
+        refs.push({ job, image: svcName[1].trim().replace(/^['"]|['"]$/g, ""), source: "service" });
+      }
+    }
+  }
+  return refs;
+}
+
+/** An `include:` entry from the top-level include block. */
+export interface IncludeEntry {
+  kind: "project" | "remote" | "component" | "local" | "template" | "string";
+  /** The primary value (project path, URL, component address, …). */
+  value: string;
+  /** `ref:` for project includes, if present. */
+  ref?: string;
+}
+
+/**
+ * Parse the top-level `include:` block into structured entries.
+ */
+export function extractIncludes(yaml: string): IncludeEntry[] {
+  const entries: IncludeEntry[] = [];
+  const section = yaml.split("\n\n").find((s) => /^include:/.test(s));
+  if (!section) return entries;
+
+  // Inline string form: `include: <value>` (value on the same line, not a list)
+  const inline = section.match(/^include:[ \t]+(\S.*)$/m);
+  if (inline) {
+    entries.push({ kind: "string", value: inline[1].trim().replace(/^['"]|['"]$/g, "") });
+    return entries;
+  }
+
+  const lines = section.split("\n");
+  let current: IncludeEntry | undefined;
+  const push = () => { if (current) entries.push(current); current = undefined; };
+  for (const line of lines) {
+    const start = line.match(/^\s+-\s+(project|remote|component|local|template):\s*(.*)$/);
+    if (start) {
+      push();
+      current = { kind: start[1] as IncludeEntry["kind"], value: start[2].trim().replace(/^['"]|['"]$/g, "") };
+      continue;
+    }
+    const refLine = line.match(/^\s+ref:\s+(.+)$/);
+    if (refLine && current) {
+      current.ref = refLine[1].trim().replace(/^['"]|['"]$/g, "");
+    }
+    // A bare `- 'https://...'` short remote form
+    const bare = line.match(/^\s+-\s+(['"]?https?:\/\/\S+['"]?)\s*$/);
+    if (bare) {
+      push();
+      entries.push({ kind: "remote", value: bare[1].replace(/^['"]|['"]$/g, "") });
+    }
+  }
+  push();
+  return entries;
+}
+
+/** True if a git ref is an immutable pin (40-hex SHA or a vN.N.N-style tag). */
+export function isPinnedRef(ref: string): boolean {
+  if (/^[0-9a-f]{40}$/.test(ref)) return true;
+  // Semver-ish tag with all components fixed (v1.2.3 / 1.2.3)
+  if (/^v?\d+\.\d+\.\d+$/.test(ref)) return true;
+  return false;
+}

--- a/lexicons/gitlab/src/lint/rules/data/known-include-sources.ts
+++ b/lexicons/gitlab/src/lint/rules/data/known-include-sources.ts
@@ -1,0 +1,41 @@
+/**
+ * Vendored snapshot of well-known GitLab CI include/component source projects,
+ * used by the look-alike check (WGL032) as the reference set: an `include` or
+ * `component` source that is a near-miss (edit distance 1–2) of one of these —
+ * but not an exact match — is likely a typo or an impersonation.
+ *
+ * Advisory only. Refresh source: GitLab-maintained CI templates and the popular
+ * CI/CD Catalog components. Accept staleness — a stale entry only weakens
+ * look-alike detection, it never blocks a build.
+ */
+export const KNOWN_INCLUDE_SOURCES: readonly string[] = [
+  "gitlab-org/gitlab",
+  "gitlab-org/security-products/ci-templates",
+  "components/sast",
+  "components/secret-detection",
+  "components/dependency-scanning",
+  "components/container-scanning",
+  "components/code-quality",
+  "gitlab-org/components/sast",
+  "gitlab-org/components/secret-detection",
+];
+
+/** Levenshtein edit distance, capped: returns early once it exceeds `max`. */
+export function editDistance(a: string, b: string, max: number): number {
+  if (a === b) return 0;
+  if (Math.abs(a.length - b.length) > max) return max + 1;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    let rowMin = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      const val = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+      curr.push(val);
+      if (val < rowMin) rowMin = val;
+    }
+    if (rowMin > max) return max + 1;
+    prev = curr;
+  }
+  return prev[b.length];
+}

--- a/lexicons/gitlab/src/plugin.test.ts
+++ b/lexicons/gitlab/src/plugin.test.ts
@@ -83,7 +83,7 @@ describe("gitlabPlugin", () => {
 
   test("returns post-synth checks", () => {
     const checks = gitlabPlugin.postSynthChecks!();
-    expect(checks).toHaveLength(19);
+    expect(checks).toHaveLength(23);
     const ids = checks.map((c) => c.id);
     expect(ids).toContain("WGL010");
     expect(ids).toContain("WGL011");
@@ -104,6 +104,10 @@ describe("gitlabPlugin", () => {
     expect(ids).toContain("WGL026");
     expect(ids).toContain("WGL027");
     expect(ids).toContain("WGL028");
+    expect(ids).toContain("WGL029");
+    expect(ids).toContain("WGL030");
+    expect(ids).toContain("WGL031");
+    expect(ids).toContain("WGL032");
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #297. GitLab counterpart to #286.

GitLab pipelines pull external config and images and trust whoever controls the reference. Four post-synth checks on emitted `.gitlab-ci.yml`:

| ID | Check | Severity |
|----|-------|----------|
| WGL029 | `include:project` / `component:` resolved by a moving ref (branch, missing `ref:`, floating version) | warning |
| WGL030 | `include:remote` over HTTP (error) or mutable HTTPS (warning) | error/warning |
| WGL031 | `image:` / `services:` without an `@sha256:` digest | warning |
| WGL032 | look-alike include/component source (typo/impersonation) | warning |

### Notes
- **WGL030 generalizes WGL017** (non-HTTPS registry) to includes; WGL017 stays for `docker push/pull` in scripts.
- **WGL031** skips variable-based references (`$CI_REGISTRY_IMAGE:tag`) — not statically knowable.
- **WGL032** uses a vendored `data/known-include-sources.ts` snapshot + Levenshtein, mirroring the GitHub GHA031 approach.
- New helpers `extractImageRefs`, `extractIncludes`, `isPinnedRef` in `yaml-helpers.ts` (handles both inline `image: x` and object `image:\n  name: x` forms the serializer emits).

Positive + negative fixture test per check. `npx vitest run` green for the gitlab lexicon (178 tests); eslint clean; docs regenerated.