### PR TITLE
feat(gitlab): scope CI_JOB_TOKEN and OIDC to least privilege (#298)

### DIFF
--- a/lexicons/gitlab/docs/src/content/docs/index.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/index.mdx
@@ -42,7 +42,7 @@ The lexicon provides **3 resources** (Job, Workflow, Default), **16 property typ
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 27 |
+| Lint rules | 29 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitLab`

--- a/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
@@ -182,6 +182,20 @@ Flags `image:` and `services:` references not pinned to an immutable `@sha256:` 
 
 Flags an `include:project` / `component:` source that is a near-miss (edit distance 1–2) of a well-known GitLab CI source but not an exact match — a likely typo or impersonation. Backed by a vendored reference list.
 
+### WGL033 — OIDC id_token without a scoped audience
+
+**Severity:** warning
+
+Flags an `id_tokens:` declaration with no `aud:` or a wildcard audience. The audience binds the minted OIDC token to a relying party; without it a leaked token is accepted anywhere.
+
+### WGL034 — OIDC id_token mintable from a merge-request pipeline
+
+**Severity:** warning
+
+Flags a job that declares `id_tokens:` and is reachable from merge-request pipelines, which outside contributors can trigger. Restrict OIDC jobs to protected refs or require approval.
+
+> The project-level `CI_JOB_TOKEN` allowlist and a variable's protected status are project settings, not emitted pipeline YAML, so they are out of scope for these post-synth checks (see issue #298's caveat).
+
 ## Running lint
 
 ```bash

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -459,6 +459,20 @@ Flags \`image:\` and \`services:\` references not pinned to an immutable \`@sha2
 
 Flags an \`include:project\` / \`component:\` source that is a near-miss (edit distance 1–2) of a well-known GitLab CI source but not an exact match — a likely typo or impersonation. Backed by a vendored reference list.
 
+### WGL033 — OIDC id_token without a scoped audience
+
+**Severity:** warning
+
+Flags an \`id_tokens:\` declaration with no \`aud:\` or a wildcard audience. The audience binds the minted OIDC token to a relying party; without it a leaked token is accepted anywhere.
+
+### WGL034 — OIDC id_token mintable from a merge-request pipeline
+
+**Severity:** warning
+
+Flags a job that declares \`id_tokens:\` and is reachable from merge-request pipelines, which outside contributors can trigger. Restrict OIDC jobs to protected refs or require approval.
+
+> The project-level \`CI_JOB_TOKEN\` allowlist and a variable's protected status are project settings, not emitted pipeline YAML, so they are out of scope for these post-synth checks (see issue #298's caveat).
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/gitlab/src/lint/post-synth/wgl033.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl033.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl033 } from "./wgl033";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL033: OIDC id_token audience scoping", () => {
+  test("flags a wildcard audience", () => {
+    const yaml = `deploy:
+  stage: deploy
+  id_tokens:
+    GCP_TOKEN:
+      aud: '*'
+  script:
+    - echo deploy
+`;
+    const diags = wgl033.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL033");
+    expect(diags[0].entity).toBe("deploy");
+  });
+
+  test("flags an empty audience", () => {
+    const yaml = `deploy:
+  id_tokens:
+    GCP_TOKEN:
+      aud: ''
+  script:
+    - echo deploy
+`;
+    const diags = wgl033.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+  });
+
+  test("does not flag a scoped audience", () => {
+    const yaml = `deploy:
+  id_tokens:
+    GCP_TOKEN:
+      aud: https://iam.googleapis.com
+  script:
+    - echo deploy
+`;
+    const diags = wgl033.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl033.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl033.ts
@@ -1,0 +1,38 @@
+/**
+ * WGL033: OIDC id_token Without a Scoped Audience
+ *
+ * Flags an `id_tokens:` declaration with no `aud:` or a wildcard audience. The
+ * audience binds the minted OIDC token to a specific relying party; without it
+ * (or with `*`), a leaked token is accepted anywhere, defeating the point of
+ * short-lived federated identity. Set `aud:` to the exact audience(s) needed.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractIdTokens } from "./yaml-helpers";
+
+export const wgl033: PostSynthCheck = {
+  id: "WGL033",
+  description: "OIDC id_token without a scoped audience",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const { job, name, aud } of extractIdTokens(yaml)) {
+        const broad = aud.length === 0 || aud.some((a) => a === "*" || a === "" || a.includes("*"));
+        if (broad) {
+          diagnostics.push({
+            checkId: "WGL033",
+            severity: "warning",
+            message: `Job "${job}" id_token "${name}" has ${aud.length === 0 ? "no aud:" : "a wildcard audience"}. Scope it to the exact audience the relying party expects so a leaked token cannot be used elsewhere.`,
+            entity: job,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl034.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl034.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl034 } from "./wgl034";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL034: OIDC token mintable from a merge-request pipeline", () => {
+  test("flags an OIDC job reachable from merge requests", () => {
+    const yaml = `deploy:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  id_tokens:
+    GCP_TOKEN:
+      aud: https://iam.googleapis.com
+  script:
+    - echo deploy
+`;
+    const diags = wgl034.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL034");
+    expect(diags[0].entity).toBe("deploy");
+  });
+
+  test("does not flag an OIDC job gated to a protected branch", () => {
+    const yaml = `deploy:
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  id_tokens:
+    GCP_TOKEN:
+      aud: https://iam.googleapis.com
+  script:
+    - echo deploy
+`;
+    const diags = wgl034.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag a merge-request job without OIDC", () => {
+    const yaml = `test:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - echo test
+`;
+    const diags = wgl034.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl034.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl034.ts
@@ -1,0 +1,42 @@
+/**
+ * WGL034: OIDC id_token Mintable from a Merge-Request Pipeline
+ *
+ * Flags a job that declares an `id_tokens:` (OIDC) and is reachable from
+ * merge-request pipelines. MR pipelines can be triggered by outside
+ * contributors, so a job that mints a cloud-federated token there hands fork
+ * code a path to your cloud roles. Gate OIDC jobs to protected refs, or require
+ * approval before they run.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractIdTokens, extractJobSection, isMergeRequestReachable } from "./yaml-helpers";
+
+export const wgl034: PostSynthCheck = {
+  id: "WGL034",
+  description: "OIDC id_token mintable from a merge-request pipeline",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const seen = new Set<string>();
+      for (const { job } of extractIdTokens(yaml)) {
+        if (seen.has(job)) continue;
+        const section = extractJobSection(yaml, job);
+        if (section && isMergeRequestReachable(section)) {
+          seen.add(job);
+          diagnostics.push({
+            checkId: "WGL034",
+            severity: "warning",
+            message: `Job "${job}" mints an OIDC id_token and is reachable from merge-request pipelines, which outside contributors can trigger. Restrict it to protected refs or require approval before it runs.`,
+            entity: job,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/yaml-helpers.ts
+++ b/lexicons/gitlab/src/lint/post-synth/yaml-helpers.ts
@@ -327,3 +327,72 @@ export function isPinnedRef(ref: string): boolean {
   if (/^v?\d+\.\d+\.\d+$/.test(ref)) return true;
   return false;
 }
+
+/** An `id_tokens:` OIDC token declaration within a job. */
+export interface IdTokenDecl {
+  job: string;
+  /** Token variable name (e.g. `GCP_ID_TOKEN`). */
+  name: string;
+  /** Declared audiences (`aud:`), empty if none. */
+  aud: string[];
+}
+
+/**
+ * Extract `id_tokens:` declarations (OIDC) per job, with their audiences.
+ */
+export function extractIdTokens(yaml: string): IdTokenDecl[] {
+  const out: IdTokenDecl[] = [];
+  for (const section of yaml.split("\n\n")) {
+    const lines = section.split("\n");
+    const top = lines[0]?.match(/^(\.?[a-z][a-z0-9_.-]*):/i);
+    if (!top) continue;
+    const job = top[1];
+
+    let inIdTokens = false;
+    let idTokensIndent = -1;
+    let current: IdTokenDecl | undefined;
+    const flush = () => { if (current) out.push(current); current = undefined; };
+
+    for (const line of lines) {
+      if (/^\s+id_tokens:\s*$/.test(line)) {
+        inIdTokens = true;
+        idTokensIndent = line.search(/\S/);
+        continue;
+      }
+      if (!inIdTokens) continue;
+      const indent = line.search(/\S/);
+      if (line.trim() !== "" && indent <= idTokensIndent) { flush(); inIdTokens = false; continue; }
+
+      const tokenName = line.match(/^\s+([A-Z_][A-Z0-9_]*):\s*$/);
+      if (tokenName && indent === idTokensIndent + 2) {
+        flush();
+        current = { job, name: tokenName[1], aud: [] };
+        continue;
+      }
+      const audInline = line.match(/^\s+aud:\s+(\S.*)$/);
+      if (audInline && current) {
+        const v = audInline[1].trim();
+        if (v.startsWith("[")) {
+          for (const p of v.replace(/^\[|\]$/g, "").split(",")) {
+            const t = p.trim().replace(/^['"]|['"]$/g, "");
+            if (t) current.aud.push(t);
+          }
+        } else {
+          current.aud.push(v.replace(/^['"]|['"]$/g, ""));
+        }
+        continue;
+      }
+      const audItem = line.match(/^\s+-\s+(\S.*)$/);
+      if (audItem && current) {
+        current.aud.push(audItem[1].trim().replace(/^['"]|['"]$/g, ""));
+      }
+    }
+    flush();
+  }
+  return out;
+}
+
+/** True if a job section's rules make it reachable from merge-request pipelines. */
+export function isMergeRequestReachable(section: string): boolean {
+  return /merge_request_event|CI_MERGE_REQUEST|CI_PIPELINE_SOURCE\s*==\s*['"]?merge_request/.test(section);
+}

--- a/lexicons/gitlab/src/plugin.test.ts
+++ b/lexicons/gitlab/src/plugin.test.ts
@@ -83,7 +83,7 @@ describe("gitlabPlugin", () => {
 
   test("returns post-synth checks", () => {
     const checks = gitlabPlugin.postSynthChecks!();
-    expect(checks).toHaveLength(23);
+    expect(checks).toHaveLength(25);
     const ids = checks.map((c) => c.id);
     expect(ids).toContain("WGL010");
     expect(ids).toContain("WGL011");
@@ -108,6 +108,8 @@ describe("gitlabPlugin", () => {
     expect(ids).toContain("WGL030");
     expect(ids).toContain("WGL031");
     expect(ids).toContain("WGL032");
+    expect(ids).toContain("WGL033");
+    expect(ids).toContain("WGL034");
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #298. GitLab counterpart to #287.

The token-scoping that actually lives in pipeline YAML is `id_tokens` (OIDC). Two post-synth checks:

| ID | Check | Severity |
|----|-------|----------|
| WGL033 | `id_tokens` with no `aud:` or a wildcard audience | warning |
| WGL034 | OIDC `id_tokens` in a job reachable from merge-request pipelines | warning |

### Scope
Per the issue's own caveat, the project-level `CI_JOB_TOKEN` allowlist and a variable's protected status are **project settings, not emitted pipeline YAML** — out of scope for post-synth checks and documented as such in `docs.ts`.

New helpers `extractIdTokens`, `isMergeRequestReachable`. Positive + negative tests; `npx vitest run` green for the gitlab lexicon; eslint clean; docs regenerated. Stacked on #297; rebased onto main after merge.