### PR TITLE
feat(gitlab): guard trust boundaries against untrusted CI input (#299)

### DIFF
--- a/lexicons/gitlab/docs/src/content/docs/index.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/index.mdx
@@ -42,7 +42,7 @@ The lexicon provides **3 resources** (Job, Workflow, Default), **16 property typ
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 29 |
+| Lint rules | 32 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitLab`

--- a/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
@@ -196,6 +196,24 @@ Flags a job that declares `id_tokens:` and is reachable from merge-request pipel
 
 > The project-level `CI_JOB_TOKEN` allowlist and a variable's protected status are project settings, not emitted pipeline YAML, so they are out of scope for these post-synth checks (see issue #298's caveat).
 
+### WGL035 — Untrusted CI variable in a script
+
+**Severity:** warning
+
+Flags an attacker-controllable predefined variable (branch/tag name, commit or MR title/description, author) referenced in a `script:` command, where a crafted value can inject shell commands. Quote it and avoid using it in sensitive commands.
+
+### WGL036 — Privileged DinD reachable from merge requests
+
+**Severity:** warning
+
+Flags a Docker-in-Docker (privileged) job reachable from merge-request pipelines, which outside contributors can trigger. Restrict privileged services to protected refs. Complements WGL026.
+
+### WGL037 — Regex gate on an untrusted ref
+
+**Severity:** warning
+
+Flags a `rules:if` that gates on a regex match (`=~`) over an attacker-controllable ref variable — a crafted branch/tag name can satisfy the pattern. Match the full ref with `==` or gate on a protected condition.
+
 ## Running lint
 
 ```bash

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -473,6 +473,24 @@ Flags a job that declares \`id_tokens:\` and is reachable from merge-request pip
 
 > The project-level \`CI_JOB_TOKEN\` allowlist and a variable's protected status are project settings, not emitted pipeline YAML, so they are out of scope for these post-synth checks (see issue #298's caveat).
 
+### WGL035 — Untrusted CI variable in a script
+
+**Severity:** warning
+
+Flags an attacker-controllable predefined variable (branch/tag name, commit or MR title/description, author) referenced in a \`script:\` command, where a crafted value can inject shell commands. Quote it and avoid using it in sensitive commands.
+
+### WGL036 — Privileged DinD reachable from merge requests
+
+**Severity:** warning
+
+Flags a Docker-in-Docker (privileged) job reachable from merge-request pipelines, which outside contributors can trigger. Restrict privileged services to protected refs. Complements WGL026.
+
+### WGL037 — Regex gate on an untrusted ref
+
+**Severity:** warning
+
+Flags a \`rules:if\` that gates on a regex match (\`=~\`) over an attacker-controllable ref variable — a crafted branch/tag name can satisfy the pattern. Match the full ref with \`==\` or gate on a protected condition.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/gitlab/src/lint/post-synth/wgl035.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl035.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl035 } from "./wgl035";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL035: untrusted CI variable in script", () => {
+  test("flags an untrusted ref name used in a script command", () => {
+    const yaml = `build:
+  stage: build
+  script:
+    - git checkout $CI_COMMIT_REF_NAME
+`;
+    const diags = wgl035.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL035");
+    expect(diags[0].entity).toBe("build");
+    expect(diags[0].message).toContain("CI_COMMIT_REF_NAME");
+  });
+
+  test("does not flag a trusted variable", () => {
+    const yaml = `build:
+  stage: build
+  script:
+    - echo "$CI_COMMIT_SHA"
+`;
+    const diags = wgl035.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl035.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl035.ts
@@ -1,0 +1,44 @@
+/**
+ * WGL035: Untrusted CI Variable Interpolated into a Script
+ *
+ * Flags an attacker-controllable predefined variable (branch/tag name, commit or
+ * merge-request title/description, author) referenced in a `script:` command. A
+ * crafted branch name or commit title containing shell metacharacters can break
+ * out of the command. Quote the reference and avoid using it in sensitive
+ * commands, or sanitize it first.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractScriptCommands } from "./yaml-helpers";
+import { UNTRUSTED_CI_VARIABLES, variableReferenced } from "../rules/data/untrusted-variables";
+
+export const wgl035: PostSynthCheck = {
+  id: "WGL035",
+  description: "Untrusted CI variable interpolated into a script command",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const seen = new Set<string>();
+      for (const { job, command } of extractScriptCommands(yaml)) {
+        for (const name of UNTRUSTED_CI_VARIABLES) {
+          if (!variableReferenced(command, name)) continue;
+          const key = `${job}:${name}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          diagnostics.push({
+            checkId: "WGL035",
+            severity: "warning",
+            message: `Job "${job}" uses the attacker-controllable variable $${name} in a script command. A crafted value can inject shell commands — quote it ("$${name}") and avoid using it in sensitive commands, or sanitize it first.`,
+            entity: job,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl036.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl036.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl036 } from "./wgl036";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL036: privileged DinD reachable from merge requests", () => {
+  test("flags DinD in a merge-request-reachable job", () => {
+    const yaml = `build:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  image: docker:24
+  services:
+    - docker:24-dind
+  script:
+    - docker build .
+`;
+    const diags = wgl036.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL036");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag DinD gated to a protected branch", () => {
+    const yaml = `build:
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  image: docker:24
+  services:
+    - docker:24-dind
+  script:
+    - docker build .
+`;
+    const diags = wgl036.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl036.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl036.ts
@@ -1,0 +1,44 @@
+/**
+ * WGL036: Privileged Service / Docker-in-Docker Reachable from Merge Requests
+ *
+ * Flags a job that uses Docker-in-Docker (a privileged service) and is reachable
+ * from merge-request pipelines. MR pipelines can run code from an outside
+ * contributor; a privileged DinD service shares the host daemon socket and can
+ * be used to escape the build and reach the runner. Restrict privileged services
+ * to protected refs, or require approval before such jobs run.
+ *
+ * Complements WGL026 (DinD without TLS) by adding the trust-boundary dimension.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractJobs, extractJobSection, isMergeRequestReachable } from "./yaml-helpers";
+
+const DIND_RE = /docker:[\w.-]*dind|dind|privileged:\s*true/;
+
+export const wgl036: PostSynthCheck = {
+  id: "WGL036",
+  description: "Privileged service / DinD reachable from merge-request pipelines",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job] of extractJobs(yaml)) {
+        const section = extractJobSection(yaml, job);
+        if (!section) continue;
+        if (DIND_RE.test(section) && isMergeRequestReachable(section)) {
+          diagnostics.push({
+            checkId: "WGL036",
+            severity: "warning",
+            message: `Job "${job}" runs a privileged Docker-in-Docker service and is reachable from merge-request pipelines, which outside contributors can trigger. Restrict privileged services to protected refs or require approval.`,
+            entity: job,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl037.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl037.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl037 } from "./wgl037";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL037: regex gate on untrusted ref", () => {
+  test("flags a =~ gate on the ref name", () => {
+    const yaml = `deploy:
+  stage: deploy
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /^release/
+  script:
+    - ./deploy.sh
+`;
+    const diags = wgl037.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL037");
+    expect(diags[0].entity).toBe("deploy");
+  });
+
+  test("does not flag an exact == match", () => {
+    const yaml = `deploy:
+  stage: deploy
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "main"
+  script:
+    - ./deploy.sh
+`;
+    const diags = wgl037.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl037.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl037.ts
@@ -1,0 +1,47 @@
+/**
+ * WGL037: Security Gate on a Regex Match of an Untrusted Ref
+ *
+ * Flags a `rules:if` that gates execution on a regex match (`=~`) over an
+ * attacker-controllable ref variable (e.g. `$CI_COMMIT_REF_NAME =~ /^release/`).
+ * An outside contributor can craft a branch name that satisfies the pattern
+ * (`release-evil`), passing a gate meant for trusted refs. Match the full ref
+ * with `==`, or gate on a protected condition instead.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractJobs, extractJobSection } from "./yaml-helpers";
+import { UNTRUSTED_CI_VARIABLES } from "../rules/data/untrusted-variables";
+
+const REF_VARS = ["CI_COMMIT_REF_NAME", "CI_COMMIT_REF_SLUG", "CI_COMMIT_BRANCH", "CI_COMMIT_TAG", "CI_MERGE_REQUEST_SOURCE_BRANCH_NAME"]
+  .filter((v) => UNTRUSTED_CI_VARIABLES.includes(v));
+
+export const wgl037: PostSynthCheck = {
+  id: "WGL037",
+  description: "Security gate on a regex match of an untrusted ref variable",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job] of extractJobs(yaml)) {
+        const section = extractJobSection(yaml, job);
+        if (!section) continue;
+        // Look at `if:` lines that use a regex match against an untrusted ref var.
+        const ifLines = section.split("\n").filter((l) => /if:\s/.test(l));
+        const flagged = ifLines.some((l) => /=~/.test(l) && REF_VARS.some((v) => l.includes(`$${v}`)));
+        if (flagged) {
+          diagnostics.push({
+            checkId: "WGL037",
+            severity: "warning",
+            message: `Job "${job}" gates on a regex match (=~) of an attacker-controllable ref variable. A crafted branch/tag name can satisfy the pattern — match the full ref with == or gate on a protected condition.`,
+            entity: job,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/yaml-helpers.ts
+++ b/lexicons/gitlab/src/lint/post-synth/yaml-helpers.ts
@@ -396,3 +396,44 @@ export function extractIdTokens(yaml: string): IdTokenDecl[] {
 export function isMergeRequestReachable(section: string): boolean {
   return /merge_request_event|CI_MERGE_REQUEST|CI_PIPELINE_SOURCE\s*==\s*['"]?merge_request/.test(section);
 }
+
+/** A shell command line from a `script:` / `before_script:` / `after_script:`. */
+export interface ScriptCommand {
+  job: string;
+  command: string;
+}
+
+/**
+ * Extract shell command lines from all `script:` family blocks, per job.
+ */
+export function extractScriptCommands(yaml: string): ScriptCommand[] {
+  const out: ScriptCommand[] = [];
+  for (const section of yaml.split("\n\n")) {
+    const lines = section.split("\n");
+    const top = lines[0]?.match(/^(\.?[a-z][a-z0-9_.-]*):/i);
+    if (!top) continue;
+    const job = top[1];
+
+    let inScript = false;
+    let scriptIndent = -1;
+    for (const line of lines) {
+      if (/^\s+(before_script|after_script|script):\s*$/.test(line)) {
+        inScript = true;
+        scriptIndent = line.search(/\S/);
+        continue;
+      }
+      // inline form `script: cmd`
+      const inlineScript = line.match(/^\s+(?:before_script|after_script|script):\s+(\S.*)$/);
+      if (inlineScript) {
+        out.push({ job, command: inlineScript[1].trim().replace(/^['"]|['"]$/g, "") });
+        continue;
+      }
+      if (!inScript) continue;
+      const indent = line.search(/\S/);
+      if (line.trim() !== "" && indent <= scriptIndent) { inScript = false; continue; }
+      const item = line.match(/^\s+-\s+(.*)$/);
+      if (item) out.push({ job, command: item[1].trim().replace(/^['"]|['"]$/g, "") });
+    }
+  }
+  return out;
+}

--- a/lexicons/gitlab/src/lint/rules/data/untrusted-variables.ts
+++ b/lexicons/gitlab/src/lint/rules/data/untrusted-variables.ts
@@ -1,0 +1,31 @@
+/**
+ * Vendored snapshot of GitLab CI predefined variables whose values are
+ * attacker-controllable — branch/tag names, commit and merge-request titles and
+ * descriptions, author identity. Interpolating these into a `script:` (or using
+ * them as a gate) lets a crafted branch name or commit title influence what runs.
+ *
+ * Source: GitLab "Predefined CI/CD variables" reference, filtered to the values
+ * an outside contributor can set on a fork or merge request. Advisory and
+ * necessarily incomplete; editing this list is the refresh mechanism.
+ */
+export const UNTRUSTED_CI_VARIABLES: readonly string[] = [
+  "CI_COMMIT_TITLE",
+  "CI_COMMIT_MESSAGE",
+  "CI_COMMIT_DESCRIPTION",
+  "CI_COMMIT_REF_NAME",
+  "CI_COMMIT_REF_SLUG",
+  "CI_COMMIT_BRANCH",
+  "CI_COMMIT_TAG",
+  "CI_COMMIT_AUTHOR",
+  "CI_MERGE_REQUEST_TITLE",
+  "CI_MERGE_REQUEST_DESCRIPTION",
+  "CI_MERGE_REQUEST_SOURCE_BRANCH_NAME",
+  "CI_MERGE_REQUEST_SOURCE_BRANCH_SHA",
+  "CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME",
+];
+
+/** Reference forms a variable can take in a script: `$VAR` or `${VAR}`. */
+export function variableReferenced(text: string, name: string): boolean {
+  const re = new RegExp(`\\$\\{?${name}\\}?(?![A-Z0-9_])`);
+  return re.test(text);
+}

--- a/lexicons/gitlab/src/plugin.test.ts
+++ b/lexicons/gitlab/src/plugin.test.ts
@@ -83,7 +83,7 @@ describe("gitlabPlugin", () => {
 
   test("returns post-synth checks", () => {
     const checks = gitlabPlugin.postSynthChecks!();
-    expect(checks).toHaveLength(25);
+    expect(checks).toHaveLength(28);
     const ids = checks.map((c) => c.id);
     expect(ids).toContain("WGL010");
     expect(ids).toContain("WGL011");
@@ -110,6 +110,9 @@ describe("gitlabPlugin", () => {
     expect(ids).toContain("WGL032");
     expect(ids).toContain("WGL033");
     expect(ids).toContain("WGL034");
+    expect(ids).toContain("WGL035");
+    expect(ids).toContain("WGL036");
+    expect(ids).toContain("WGL037");
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #299. GitLab counterpart to #288.

| ID | Check | Severity |
|----|-------|----------|
| WGL035 | attacker-controllable predefined variable (branch/tag name, commit/MR title, author) interpolated into a `script:` | warning |
| WGL036 | privileged Docker-in-Docker service in a merge-request-reachable job | warning |
| WGL037 | `rules:if` gating on a `=~` regex over an untrusted ref variable | warning |

New helper `extractScriptCommands` + vendored `data/untrusted-variables.ts`. WGL036 complements WGL026 (DinD-TLS) with the trust-boundary dimension. Positive + negative tests; gitlab lexicon `vitest` green; eslint clean; docs regenerated. Stacked on #298; rebased onto main after merge.