### PR TITLE
feat(gitlab): mask, protect, and scope secrets and variables (#300)

### DIFF
--- a/lexicons/gitlab/docs/src/content/docs/index.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/index.mdx
@@ -42,7 +42,7 @@ The lexicon provides **3 resources** (Job, Workflow, Default), **16 property typ
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 32 |
+| Lint rules | 35 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitLab`

--- a/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
@@ -214,6 +214,26 @@ Flags a Docker-in-Docker (privileged) job reachable from merge-request pipelines
 
 Flags a `rules:if` that gates on a regex match (`=~`) over an attacker-controllable ref variable — a crafted branch/tag name can satisfy the pattern. Match the full ref with `==` or gate on a protected condition.
 
+### WGL038 — Secret reachable from a merge-request pipeline
+
+**Severity:** warning
+
+Flags a user-defined secret-like variable read by a job reachable from merge-request pipelines, which can run untrusted code. Gate the job to protected refs or mark the variable protected. (Built-in `CI_*` variables are excluded.)
+
+### WGL039 — Secret echoed to job logs
+
+**Severity:** warning
+
+Flags a `script:` command that prints a secret-like variable (`echo`/`printf`/`cat`). Logs are broadly readable and masking can be defeated by transforms.
+
+### WGL040 — Hardcoded registry credential
+
+**Severity:** error
+
+Flags a `docker login` (or compatible) passing a literal password via `-p`/`--password` instead of a variable or `--password-stdin`. Extends WGL016 to scripts.
+
+> Variable *masking* and *protected* status are GitLab project/CI-settings, not emitted YAML — WGL016 already nudges toward masked variables; this group covers the exposure paths visible in the pipeline.
+
 ## Running lint
 
 ```bash

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -491,6 +491,26 @@ Flags a Docker-in-Docker (privileged) job reachable from merge-request pipelines
 
 Flags a \`rules:if\` that gates on a regex match (\`=~\`) over an attacker-controllable ref variable — a crafted branch/tag name can satisfy the pattern. Match the full ref with \`==\` or gate on a protected condition.
 
+### WGL038 — Secret reachable from a merge-request pipeline
+
+**Severity:** warning
+
+Flags a user-defined secret-like variable read by a job reachable from merge-request pipelines, which can run untrusted code. Gate the job to protected refs or mark the variable protected. (Built-in \`CI_*\` variables are excluded.)
+
+### WGL039 — Secret echoed to job logs
+
+**Severity:** warning
+
+Flags a \`script:\` command that prints a secret-like variable (\`echo\`/\`printf\`/\`cat\`). Logs are broadly readable and masking can be defeated by transforms.
+
+### WGL040 — Hardcoded registry credential
+
+**Severity:** error
+
+Flags a \`docker login\` (or compatible) passing a literal password via \`-p\`/\`--password\` instead of a variable or \`--password-stdin\`. Extends WGL016 to scripts.
+
+> Variable *masking* and *protected* status are GitLab project/CI-settings, not emitted YAML — WGL016 already nudges toward masked variables; this group covers the exposure paths visible in the pipeline.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/gitlab/src/lint/post-synth/wgl038.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl038.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl038 } from "./wgl038";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL038: secret reachable from merge requests", () => {
+  test("flags a user secret used in a merge-request-reachable job", () => {
+    const yaml = `deploy:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - curl -H "Auth: $DEPLOY_TOKEN" https://api.example.com
+`;
+    const diags = wgl038.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL038");
+    expect(diags[0].message).toContain("DEPLOY_TOKEN");
+  });
+
+  test("does not flag a built-in CI_ token", () => {
+    const yaml = `deploy:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - echo "$CI_JOB_TOKEN" | docker login --password-stdin
+`;
+    const diags = wgl038.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag a secret gated to a protected branch", () => {
+    const yaml = `deploy:
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  script:
+    - curl -H "Auth: $DEPLOY_TOKEN" https://api.example.com
+`;
+    const diags = wgl038.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl038.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl038.ts
@@ -1,0 +1,48 @@
+/**
+ * WGL038: Secret Reachable from a Merge-Request Pipeline
+ *
+ * Flags a user-defined secret-like variable (`*_PASSWORD`, `*_SECRET`,
+ * `*_TOKEN`, `*_API_KEY`, …) referenced in a job reachable from merge-request
+ * pipelines. Those pipelines can run an outside contributor's code, so a secret
+ * they can read is a secret they can exfiltrate. Gate secret-using jobs to
+ * protected refs, or make the variable protected so MR pipelines can't see it.
+ *
+ * Built-in `CI_*` variables are project-managed and excluded.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractJobs, extractJobSection, isMergeRequestReachable } from "./yaml-helpers";
+
+const SECRET_VAR = /\$\{?((?!CI_)[A-Z][A-Z0-9_]*(?:PASSWORD|SECRET|TOKEN|API[_-]?KEY|PRIVATE[_-]?KEY|CREDENTIALS?))\}?/g;
+
+export const wgl038: PostSynthCheck = {
+  id: "WGL038",
+  description: "Secret-like variable reachable from a merge-request pipeline",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job] of extractJobs(yaml)) {
+        const section = extractJobSection(yaml, job);
+        if (!section || !isMergeRequestReachable(section)) continue;
+        const found = new Set<string>();
+        let m: RegExpExecArray | null;
+        SECRET_VAR.lastIndex = 0;
+        while ((m = SECRET_VAR.exec(section)) !== null) found.add(m[1]);
+        if (found.size > 0) {
+          diagnostics.push({
+            checkId: "WGL038",
+            severity: "warning",
+            message: `Job "${job}" reads secret-like variable(s) ${[...found].map((v) => `$${v}`).join(", ")} and is reachable from merge-request pipelines, which can run untrusted code. Gate it to protected refs or mark the variable protected.`,
+            entity: job,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl039.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl039.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl039 } from "./wgl039";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL039: secret echoed to logs", () => {
+  test("flags echo of a secret variable", () => {
+    const yaml = `debug:
+  script:
+    - echo $API_TOKEN
+`;
+    const diags = wgl039.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL039");
+    expect(diags[0].entity).toBe("debug");
+  });
+
+  test("does not flag a normal echo", () => {
+    const yaml = `build:
+  script:
+    - echo "building the project"
+`;
+    const diags = wgl039.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl039.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl039.ts
@@ -1,0 +1,41 @@
+/**
+ * WGL039: Secret Echoed to Job Logs
+ *
+ * Flags a `script:` command that prints a secret-like variable (`echo`,
+ * `printf`, `print`, `cat`) — even masked variables leak when transformed
+ * (base64, reversed) before printing, and job logs are broadly readable.
+ * Remove the debug print or pipe the value where it is needed without echoing it.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractScriptCommands } from "./yaml-helpers";
+
+const PRINT_SECRET = /\b(echo|printf|print|cat)\b[^\n]*\$\{?[A-Z][A-Z0-9_]*(?:PASSWORD|SECRET|TOKEN|API[_-]?KEY|PRIVATE[_-]?KEY|CREDENTIALS?)\}?/i;
+
+export const wgl039: PostSynthCheck = {
+  id: "WGL039",
+  description: "Secret-like variable printed to job logs",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const seen = new Set<string>();
+      for (const { job, command } of extractScriptCommands(yaml)) {
+        if (PRINT_SECRET.test(command) && !seen.has(job)) {
+          seen.add(job);
+          diagnostics.push({
+            checkId: "WGL039",
+            severity: "warning",
+            message: `Job "${job}" prints a secret-like variable to the job log. Logs are broadly readable and masking can be defeated by transforms — remove the print.`,
+            entity: job,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl040.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl040.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl040 } from "./wgl040";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL040: hardcoded registry credential", () => {
+  test("flags docker login with a literal password", () => {
+    const yaml = `publish:
+  script:
+    - docker login -u ci -p hunter2 registry.example.com
+`;
+    const diags = wgl040.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL040");
+    expect(diags[0].severity).toBe("error");
+  });
+
+  test("does not flag a variable password", () => {
+    const yaml = `publish:
+  script:
+    - docker login -u ci -p $CI_REGISTRY_PASSWORD registry.example.com
+`;
+    const diags = wgl040.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag --password-stdin", () => {
+    const yaml = `publish:
+  script:
+    - echo "$REG_PASS" | docker login -u ci --password-stdin registry.example.com
+`;
+    const diags = wgl040.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl040.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl040.ts
@@ -1,0 +1,42 @@
+/**
+ * WGL040: Hardcoded Credential in a Registry Login
+ *
+ * Flags a `docker login` (or compatible) in a `script:` that passes a literal
+ * password via `-p` / `--password` instead of a variable or `--password-stdin`.
+ * An inlined credential sits in the committed pipeline and the job log. Use a
+ * masked CI/CD variable and `--password-stdin`. Extends WGL016 to scripts.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractScriptCommands } from "./yaml-helpers";
+
+// docker/podman/buildah/helm login with -p/--password followed by a non-variable literal
+const LITERAL_LOGIN = /\b(?:docker|podman|buildah|helm|crane|skopeo)\b[^\n]*\blogin\b[^\n]*(?:-p|--password)[=\s]+(?!["']?\$)["']?[^\s"']+/i;
+
+export const wgl040: PostSynthCheck = {
+  id: "WGL040",
+  description: "Hardcoded credential in a registry login command",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const seen = new Set<string>();
+      for (const { job, command } of extractScriptCommands(yaml)) {
+        if (LITERAL_LOGIN.test(command) && !seen.has(job)) {
+          seen.add(job);
+          diagnostics.push({
+            checkId: "WGL040",
+            severity: "error",
+            message: `Job "${job}" passes a hardcoded password to a registry login. Use a masked CI/CD variable with --password-stdin instead of inlining the credential.`,
+            entity: job,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/plugin.test.ts
+++ b/lexicons/gitlab/src/plugin.test.ts
@@ -83,7 +83,7 @@ describe("gitlabPlugin", () => {
 
   test("returns post-synth checks", () => {
     const checks = gitlabPlugin.postSynthChecks!();
-    expect(checks).toHaveLength(28);
+    expect(checks).toHaveLength(31);
     const ids = checks.map((c) => c.id);
     expect(ids).toContain("WGL010");
     expect(ids).toContain("WGL011");
@@ -113,6 +113,9 @@ describe("gitlabPlugin", () => {
     expect(ids).toContain("WGL035");
     expect(ids).toContain("WGL036");
     expect(ids).toContain("WGL037");
+    expect(ids).toContain("WGL038");
+    expect(ids).toContain("WGL039");
+    expect(ids).toContain("WGL040");
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #300. GitLab counterpart to #289.

The secret-exposure paths visible in pipeline YAML, complementing WGL016 (hardcoded secrets in `variables:`):

| ID | Check | Severity |
|----|-------|----------|
| WGL038 | user-defined secret-like variable read by a merge-request-reachable job (`CI_*` excluded) | warning |
| WGL039 | secret-like variable printed to job logs (`echo`/`printf`/`cat`) | warning |
| WGL040 | hardcoded password in a `docker login` / registry-login script | error |

Variable *masking* and *protected* status are project/CI settings, not emitted YAML — out of scope and documented. Positive + negative tests; gitlab `vitest` green; eslint clean; docs regenerated. Stacked on #299; rebased onto main after merge.