### PR TITLE
feat(gitlab): reject unsound and obfuscated rules expressions (#301)

### DIFF
--- a/lexicons/gitlab/docs/src/content/docs/index.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/index.mdx
@@ -42,7 +42,7 @@ The lexicon provides **3 resources** (Job, Workflow, Default), **16 property typ
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 35 |
+| Lint rules | 38 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitLab`

--- a/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
@@ -234,6 +234,26 @@ Flags a `docker login` (or compatible) passing a literal password via `-p`/`--pa
 
 > Variable *masking* and *protected* status are GitLab project/CI-settings, not emitted YAML — WGL016 already nudges toward masked variables; this group covers the exposure paths visible in the pipeline.
 
+### WGL041 — Unsound rules:if condition
+
+**Severity:** warning
+
+Flags a tautological `rules:if` where both sides of `==`/`!=` are identical, so the condition is always true or always false. Generalizes WGL011 to conditions presented as gates.
+
+### WGL042 — Unreachable rules after an unconditional match
+
+**Severity:** warning
+
+Flags rules listed after an unconditional rule (no `if:`, not `when: never`). GitLab takes the first matching rule, so a catch-all makes everything after it dead. Put specific rules first.
+
+### WGL043 — Match-anything regex gate
+
+**Severity:** warning
+
+Flags a `rules:if` whose `=~` regex matches every value (empty, dot-star, anchored dot-star) — a filter that admits everything. Tighten the pattern or remove the gate.
+
+> The auto-fix acceptance item is N/A at the post-synth layer (PostSynthDiagnostic has no fix channel); it belongs to the declarative source-lint rules.
+
 ## Running lint
 
 ```bash

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -511,6 +511,26 @@ Flags a \`docker login\` (or compatible) passing a literal password via \`-p\`/\
 
 > Variable *masking* and *protected* status are GitLab project/CI-settings, not emitted YAML — WGL016 already nudges toward masked variables; this group covers the exposure paths visible in the pipeline.
 
+### WGL041 — Unsound rules:if condition
+
+**Severity:** warning
+
+Flags a tautological \`rules:if\` where both sides of \`==\`/\`!=\` are identical, so the condition is always true or always false. Generalizes WGL011 to conditions presented as gates.
+
+### WGL042 — Unreachable rules after an unconditional match
+
+**Severity:** warning
+
+Flags rules listed after an unconditional rule (no \`if:\`, not \`when: never\`). GitLab takes the first matching rule, so a catch-all makes everything after it dead. Put specific rules first.
+
+### WGL043 — Match-anything regex gate
+
+**Severity:** warning
+
+Flags a \`rules:if\` whose \`=~\` regex matches every value (empty, dot-star, anchored dot-star) — a filter that admits everything. Tighten the pattern or remove the gate.
+
+> The auto-fix acceptance item is N/A at the post-synth layer (PostSynthDiagnostic has no fix channel); it belongs to the declarative source-lint rules.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/gitlab/src/lint/post-synth/wgl041.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl041.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl041, tautologyReason } from "./wgl041";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL041: unsound rules:if", () => {
+  test("tautologyReason classifies identical operands", () => {
+    expect(tautologyReason('$CI_COMMIT_BRANCH == $CI_COMMIT_BRANCH')).toContain("always true");
+    expect(tautologyReason('$X != $X')).toContain("always false");
+    expect(tautologyReason('$CI_COMMIT_BRANCH == "main"')).toBeUndefined();
+  });
+
+  test("flags a tautological rule condition", () => {
+    const yaml = `deploy:
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_COMMIT_BRANCH
+  script:
+    - echo deploy
+`;
+    const diags = wgl041.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL041");
+    expect(diags[0].entity).toBe("deploy");
+  });
+
+  test("does not flag a real condition", () => {
+    const yaml = `deploy:
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  script:
+    - echo deploy
+`;
+    const diags = wgl041.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl041.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl041.ts
@@ -1,0 +1,57 @@
+/**
+ * WGL041: Logically Unsound rules:if Condition
+ *
+ * Flags a `rules:if` that reads like a gate but is a constant — both sides of an
+ * `==`/`!=` are identical, so the condition is always true or always false.
+ * Generalizes WGL011 (rules that always evaluate to never) to tautological
+ * conditions presented as gates.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractJobs, extractJobSection, extractJobRules } from "./yaml-helpers";
+
+function strip(s: string): string {
+  return s.trim().replace(/^['"]|['"]$/g, "").trim();
+}
+
+/** Classify an `if:` expression as a tautology, returning a reason or undefined. */
+export function tautologyReason(expr: string): string | undefined {
+  const e = strip(expr).replace(/^\$\{?/, "$").trim();
+  const eq = e.match(/^(\S.*?)\s*==\s*(\S.*?)$/);
+  if (eq && strip(eq[1]) === strip(eq[2])) return "always true (both sides of == are identical)";
+  const ne = e.match(/^(\S.*?)\s*!=\s*(\S.*?)$/);
+  if (ne && strip(ne[1]) === strip(ne[2])) return "always false (both sides of != are identical)";
+  return undefined;
+}
+
+export const wgl041: PostSynthCheck = {
+  id: "WGL041",
+  description: "Logically unsound (tautological) rules:if condition",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job] of extractJobs(yaml)) {
+        const section = extractJobSection(yaml, job);
+        if (!section) continue;
+        for (const rule of extractJobRules(section)) {
+          if (!rule.if) continue;
+          const reason = tautologyReason(rule.if);
+          if (reason) {
+            diagnostics.push({
+              checkId: "WGL041",
+              severity: "warning",
+              message: `Job "${job}" has a rules:if that is ${reason}: "${rule.if}". A gate that does not constrain anything is misleading — write the real condition or remove it.`,
+              entity: job,
+              lexicon: "gitlab",
+            });
+          }
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl042.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl042.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl042 } from "./wgl042";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL042: unreachable rules after unconditional match", () => {
+  test("flags a rule after an unconditional catch-all", () => {
+    const yaml = `deploy:
+  rules:
+    - when: always
+    - if: $CI_COMMIT_BRANCH == "main"
+  script:
+    - echo deploy
+`;
+    const diags = wgl042.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL042");
+    expect(diags[0].entity).toBe("deploy");
+  });
+
+  test("does not flag a trailing when: never default", () => {
+    const yaml = `deploy:
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+    - when: never
+  script:
+    - echo deploy
+`;
+    const diags = wgl042.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl042.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl042.ts
@@ -1,0 +1,46 @@
+/**
+ * WGL042: Unreachable rules After an Unconditional Match
+ *
+ * GitLab evaluates `rules:` top-down and the first match wins. A rule with no
+ * `if:` (and not `when: never`) matches every pipeline, so any rule listed after
+ * it is dead — it can never be reached. Such dead rules usually mean the gate
+ * the author intended is not actually applied. Reorder so specific rules precede
+ * the catch-all.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractJobs, extractJobSection, extractJobRules } from "./yaml-helpers";
+
+export const wgl042: PostSynthCheck = {
+  id: "WGL042",
+  description: "Unreachable rules after an unconditional match",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job] of extractJobs(yaml)) {
+        const section = extractJobSection(yaml, job);
+        if (!section) continue;
+        const rules = extractJobRules(section);
+        for (let i = 0; i < rules.length - 1; i++) {
+          const r = rules[i];
+          const unconditional = !r.if && r.when !== "never";
+          if (unconditional) {
+            diagnostics.push({
+              checkId: "WGL042",
+              severity: "warning",
+              message: `Job "${job}" has an unconditional rule at position ${i + 1} that matches every pipeline, making the ${rules.length - i - 1} rule(s) after it unreachable. Put specific rules before the catch-all.`,
+              entity: job,
+              lexicon: "gitlab",
+            });
+            break;
+          }
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl043.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl043.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl043 } from "./wgl043";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL043: match-anything regex gate", () => {
+  test("flags a =~ /.*/ gate", () => {
+    const yaml = `deploy:
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /.*/
+  script:
+    - echo deploy
+`;
+    const diags = wgl043.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL043");
+    expect(diags[0].entity).toBe("deploy");
+  });
+
+  test("does not flag a specific regex", () => {
+    const yaml = `deploy:
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /^release/
+  script:
+    - echo deploy
+`;
+    const diags = wgl043.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl043.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl043.ts
@@ -1,0 +1,45 @@
+/**
+ * WGL043: Match-Anything Regex Gate
+ *
+ * Flags a `rules:if` whose regex match (`=~`) uses a pattern that matches every
+ * value — an empty regex, dot-star, or an anchored dot-star. The condition reads
+ * like a filter on a ref or variable but admits everything, so it gates nothing.
+ * This is how an unsound condition is obscured behind a regex. Tighten the
+ * pattern or remove the gate.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractJobs, extractJobSection, extractJobRules } from "./yaml-helpers";
+
+// `=~` followed by a regex literal that matches anything.
+const MATCH_ANYTHING = /=~\s*\/(?:|\.\*|\^\.\*\$|\^\.\*|\.\*\$)\//;
+
+export const wgl043: PostSynthCheck = {
+  id: "WGL043",
+  description: "Match-anything regex gate in rules:if",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job] of extractJobs(yaml)) {
+        const section = extractJobSection(yaml, job);
+        if (!section) continue;
+        for (const rule of extractJobRules(section)) {
+          if (rule.if && MATCH_ANYTHING.test(rule.if)) {
+            diagnostics.push({
+              checkId: "WGL043",
+              severity: "warning",
+              message: `Job "${job}" gates on a regex that matches everything ("${rule.if}") — the rule reads like a filter but admits every value. Tighten the pattern or remove the gate.`,
+              entity: job,
+              lexicon: "gitlab",
+            });
+          }
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/plugin.test.ts
+++ b/lexicons/gitlab/src/plugin.test.ts
@@ -83,7 +83,7 @@ describe("gitlabPlugin", () => {
 
   test("returns post-synth checks", () => {
     const checks = gitlabPlugin.postSynthChecks!();
-    expect(checks).toHaveLength(31);
+    expect(checks).toHaveLength(34);
     const ids = checks.map((c) => c.id);
     expect(ids).toContain("WGL010");
     expect(ids).toContain("WGL011");
@@ -116,6 +116,9 @@ describe("gitlabPlugin", () => {
     expect(ids).toContain("WGL038");
     expect(ids).toContain("WGL039");
     expect(ids).toContain("WGL040");
+    expect(ids).toContain("WGL041");
+    expect(ids).toContain("WGL042");
+    expect(ids).toContain("WGL043");
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #301. GitLab counterpart to #290.

| ID | Check | Severity |
|----|-------|----------|
| WGL041 | tautological `rules:if` (`X == X` / `X != X`) presented as a gate (generalizes WGL011) | warning |
| WGL042 | rules after an unconditional rule, made unreachable by first-match evaluation | warning |
| WGL043 | `=~` regex gate that matches everything (empty / dot-star / anchored dot-star) | warning |

Auto-fix is N/A at the post-synth layer (no fix channel) — documented. Positive + negative tests; gitlab `vitest` green; eslint clean; docs regenerated. Stacked on #300; rebased onto main after merge.