### PR TITLE
feat(gitlab): artifact and cache hygiene (#302)

### DIFF
--- a/lexicons/gitlab/docs/src/content/docs/index.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/index.mdx
@@ -42,7 +42,7 @@ The lexicon provides **3 resources** (Job, Workflow, Default), **16 property typ
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 38 |
+| Lint rules | 41 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitLab`

--- a/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
@@ -254,6 +254,26 @@ Flags a `rules:if` whose `=~` regex matches every value (empty, dot-star, anchor
 
 > The auto-fix acceptance item is N/A at the post-synth layer (PostSynthDiagnostic has no fix channel); it belongs to the declarative source-lint rules.
 
+### WGL044 — Public artifacts
+
+**Severity:** warning
+
+Flags `artifacts:public: true`, which makes build output downloadable by anyone. Keep artifacts private unless they are meant to be world-readable.
+
+### WGL045 — Credential-bearing artifact path
+
+**Severity:** error
+
+Flags an `artifacts:paths:` entry that looks like a credential or sensitive file (`.env`, `*.pem`, `id_rsa`, `*.key`, `.npmrc`, `.netrc`, `credentials`). Artifacts flow downstream and are downloadable — exclude the file.
+
+### WGL046 — Cache poisoning from a merge-request pipeline
+
+**Severity:** warning
+
+Flags a job that writes a cache (push policy) and is reachable from merge-request pipelines. An MR can poison the cache for a later protected run that restores the same key. Restrict cache writes to protected refs or scope the key.
+
+> Artifact / `dependencies:` flow across a *protected* boundary depends on a ref's protected status, a project setting not present in emitted YAML — out of scope here.
+
 ## Running lint
 
 ```bash

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -531,6 +531,26 @@ Flags a \`rules:if\` whose \`=~\` regex matches every value (empty, dot-star, an
 
 > The auto-fix acceptance item is N/A at the post-synth layer (PostSynthDiagnostic has no fix channel); it belongs to the declarative source-lint rules.
 
+### WGL044 — Public artifacts
+
+**Severity:** warning
+
+Flags \`artifacts:public: true\`, which makes build output downloadable by anyone. Keep artifacts private unless they are meant to be world-readable.
+
+### WGL045 — Credential-bearing artifact path
+
+**Severity:** error
+
+Flags an \`artifacts:paths:\` entry that looks like a credential or sensitive file (\`.env\`, \`*.pem\`, \`id_rsa\`, \`*.key\`, \`.npmrc\`, \`.netrc\`, \`credentials\`). Artifacts flow downstream and are downloadable — exclude the file.
+
+### WGL046 — Cache poisoning from a merge-request pipeline
+
+**Severity:** warning
+
+Flags a job that writes a cache (push policy) and is reachable from merge-request pipelines. An MR can poison the cache for a later protected run that restores the same key. Restrict cache writes to protected refs or scope the key.
+
+> Artifact / \`dependencies:\` flow across a *protected* boundary depends on a ref's protected status, a project setting not present in emitted YAML — out of scope here.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/gitlab/src/lint/post-synth/wgl044.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl044.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl044 } from "./wgl044";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL044: public artifacts", () => {
+  test("flags artifacts:public: true", () => {
+    const yaml = `build:
+  artifacts:
+    public: true
+    paths:
+      - dist/
+  script:
+    - make
+`;
+    const diags = wgl044.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL044");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag private artifacts", () => {
+    const yaml = `build:
+  artifacts:
+    paths:
+      - dist/
+  script:
+    - make
+`;
+    const diags = wgl044.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl044.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl044.ts
@@ -1,0 +1,41 @@
+/**
+ * WGL044: Public Artifacts
+ *
+ * Flags `artifacts:public: true`. Public artifacts are downloadable by anyone,
+ * including unauthenticated users for public projects, exposing build output and
+ * anything swept into it. Keep artifacts private unless they are deliberately
+ * meant to be world-readable.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractJobs, extractJobSection } from "./yaml-helpers";
+
+const PUBLIC_ARTIFACTS = /^\s+public:\s*true\s*$/m;
+
+export const wgl044: PostSynthCheck = {
+  id: "WGL044",
+  description: "Public artifacts expose build output",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job] of extractJobs(yaml)) {
+        const section = extractJobSection(yaml, job);
+        if (!section || !/^\s+artifacts:/m.test(section)) continue;
+        if (PUBLIC_ARTIFACTS.test(section)) {
+          diagnostics.push({
+            checkId: "WGL044",
+            severity: "warning",
+            message: `Job "${job}" publishes public artifacts (artifacts:public: true), downloadable by anyone. Keep them private unless they are meant to be world-readable.`,
+            entity: job,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl045.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl045.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl045 } from "./wgl045";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL045: credential-bearing artifact path", () => {
+  test("flags an artifact path that captures .env", () => {
+    const yaml = `build:
+  artifacts:
+    paths:
+      - dist/
+      - .env
+  script:
+    - make
+`;
+    const diags = wgl045.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL045");
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].message).toContain(".env");
+  });
+
+  test("does not flag ordinary build output paths", () => {
+    const yaml = `build:
+  artifacts:
+    paths:
+      - dist/
+      - build/output.js
+  script:
+    - make
+`;
+    const diags = wgl045.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl045.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl045.ts
@@ -1,0 +1,57 @@
+/**
+ * WGL045: Credential-Bearing Artifact Path
+ *
+ * Flags an `artifacts:paths:` entry that looks like it would sweep a credential
+ * or sensitive file into the artifact (`.env`, `*.pem`, `id_rsa`, `*.key`,
+ * `.npmrc`, `.netrc`, `credentials`). Artifacts flow to later stages and are
+ * downloadable, so a captured credential leaks across the boundary. Exclude the
+ * sensitive file from the artifact path.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractJobs, extractJobSection } from "./yaml-helpers";
+
+const CREDENTIAL_PATH = /(^|\/)(\.env(\.|$)|\.npmrc|\.netrc|id_rsa|.*\.pem|.*\.key|.*\.p12|credentials?(\.|$))/i;
+
+export const wgl045: PostSynthCheck = {
+  id: "WGL045",
+  description: "Artifact path that may capture a credential file",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job] of extractJobs(yaml)) {
+        const section = extractJobSection(yaml, job);
+        if (!section) continue;
+        // Collect the lines under the artifacts: block (deeper indent than the key).
+        const lines = section.split("\n");
+        const artifactsIdx = lines.findIndex((l) => /^\s+artifacts:\s*$/.test(l));
+        if (artifactsIdx === -1) continue;
+        const artifactsIndent = lines[artifactsIdx].search(/\S/);
+        const blockLines: string[] = [];
+        for (let i = artifactsIdx + 1; i < lines.length; i++) {
+          if (lines[i].trim() === "") continue;
+          if (lines[i].search(/\S/) <= artifactsIndent) break;
+          blockLines.push(lines[i]);
+        }
+        const hit = blockLines
+          .filter((l) => /^\s+-\s+/.test(l))
+          .map((l) => l.replace(/^\s+-\s+/, "").trim().replace(/^['"]|['"]$/g, ""))
+          .find((p) => CREDENTIAL_PATH.test(p));
+        if (hit) {
+          diagnostics.push({
+            checkId: "WGL045",
+            severity: "error",
+            message: `Job "${job}" includes a credential-like file ("${hit}") in its artifacts. Exclude it — artifacts are passed downstream and are downloadable.`,
+            entity: job,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl046.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl046.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl046 } from "./wgl046";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL046: cache populated in a merge-request pipeline", () => {
+  test("flags a cache write reachable from merge requests", () => {
+    const yaml = `build:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  cache:
+    key: build-cache
+    paths:
+      - node_modules/
+  script:
+    - npm ci
+`;
+    const diags = wgl046.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL046");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag a pull-only cache", () => {
+    const yaml = `build:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  cache:
+    key: build-cache
+    paths:
+      - node_modules/
+    policy: pull
+  script:
+    - npm ci
+`;
+    const diags = wgl046.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag a cache on a protected-only job", () => {
+    const yaml = `build:
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  cache:
+    key: build-cache
+    paths:
+      - node_modules/
+  script:
+    - npm ci
+`;
+    const diags = wgl046.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl046.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl046.ts
@@ -1,0 +1,43 @@
+/**
+ * WGL046: Cache Populated in a Merge-Request Pipeline (Poisoning Risk)
+ *
+ * Flags a job that writes a cache (`cache:` with a push policy) and is reachable
+ * from merge-request pipelines. An outside contributor's MR can populate the
+ * cache; a later protected run that restores the same key then executes
+ * attacker-influenced contents. Restrict cache writes to protected refs, or
+ * scope cache keys so MR pipelines cannot write entries a protected run reads.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractJobs, extractJobSection, isMergeRequestReachable } from "./yaml-helpers";
+
+export const wgl046: PostSynthCheck = {
+  id: "WGL046",
+  description: "Cache populated in a merge-request pipeline (poisoning risk)",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job] of extractJobs(yaml)) {
+        const section = extractJobSection(yaml, job);
+        if (!section || !/^\s+cache:/m.test(section)) continue;
+        if (!isMergeRequestReachable(section)) continue;
+        // pull-only caches cannot poison; flag push/pull-push (the default when policy is absent)
+        const policyMatch = section.match(/^\s+policy:\s*(\S+)/m);
+        const policy = policyMatch ? policyMatch[1].replace(/^['"]|['"]$/g, "") : "pull-push";
+        if (policy === "pull") continue;
+        diagnostics.push({
+          checkId: "WGL046",
+          severity: "warning",
+          message: `Job "${job}" writes a cache and is reachable from merge-request pipelines. An MR can poison the cache for a later protected run that restores the same key — restrict cache writes to protected refs or scope the key.`,
+          entity: job,
+          lexicon: "gitlab",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/plugin.test.ts
+++ b/lexicons/gitlab/src/plugin.test.ts
@@ -83,7 +83,7 @@ describe("gitlabPlugin", () => {
 
   test("returns post-synth checks", () => {
     const checks = gitlabPlugin.postSynthChecks!();
-    expect(checks).toHaveLength(34);
+    expect(checks).toHaveLength(37);
     const ids = checks.map((c) => c.id);
     expect(ids).toContain("WGL010");
     expect(ids).toContain("WGL011");
@@ -119,6 +119,9 @@ describe("gitlabPlugin", () => {
     expect(ids).toContain("WGL041");
     expect(ids).toContain("WGL042");
     expect(ids).toContain("WGL043");
+    expect(ids).toContain("WGL044");
+    expect(ids).toContain("WGL045");
+    expect(ids).toContain("WGL046");
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #302. GitLab counterpart to #291.

| ID | Check | Severity |
|----|-------|----------|
| WGL044 | `artifacts:public: true` exposes build output to anyone | warning |
| WGL045 | artifact path that captures a credential-like file (`.env`, `*.pem`, `id_rsa`, `.npmrc`, …) | error |
| WGL046 | cache written by a merge-request-reachable job (poisoning risk); pull-only excluded | warning |

Artifact/`dependencies:` flow across a *protected* boundary depends on ref protected status (project setting, not YAML) — documented out of scope. Positive + negative tests; gitlab `vitest` green; eslint clean; docs regenerated. Stacked on #301; rebased onto main after merge.