### PR TITLE
feat(gitlab): remaining pipeline hardening gaps (#304)

### DIFF
--- a/lexicons/gitlab/docs/src/content/docs/index.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/index.mdx
@@ -42,7 +42,7 @@ The lexicon provides **3 resources** (Job, Workflow, Default), **16 property typ
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 41 |
+| Lint rules | 43 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitLab`

--- a/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
@@ -274,6 +274,20 @@ Flags a job that writes a cache (push policy) and is reachable from merge-reques
 
 > Artifact / `dependencies:` flow across a *protected* boundary depends on a ref's protected status, a project setting not present in emitted YAML — out of scope here.
 
+### WGL047 — Software fetched and piped to a shell
+
+**Severity:** warning
+
+Flags a `script:` command that pipes a network download straight into a shell (`curl ... | bash`). The fetched code is unpinned and unverified — download to a file, verify a checksum/signature, then run it.
+
+### WGL048 — Pipeline without a name
+
+**Severity:** info
+
+Flags a pipeline that defines a `workflow:` block but no `workflow:name`. A pipeline name aids identification in the GitLab UI and audit output.
+
+> Two #304 items stay out of scope: a broad privileged-service / DinD check (already covered by WGL026 for DinD-TLS and WGL036 for MR-reachable DinD; a runner's privileged isolation is not in emitted YAML) and an optional include/component allowlist policy (configuration, overlapping WGL032's vendored source list).
+
 ## Running lint
 
 ```bash

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -551,6 +551,20 @@ Flags a job that writes a cache (push policy) and is reachable from merge-reques
 
 > Artifact / \`dependencies:\` flow across a *protected* boundary depends on a ref's protected status, a project setting not present in emitted YAML — out of scope here.
 
+### WGL047 — Software fetched and piped to a shell
+
+**Severity:** warning
+
+Flags a \`script:\` command that pipes a network download straight into a shell (\`curl ... | bash\`). The fetched code is unpinned and unverified — download to a file, verify a checksum/signature, then run it.
+
+### WGL048 — Pipeline without a name
+
+**Severity:** info
+
+Flags a pipeline that defines a \`workflow:\` block but no \`workflow:name\`. A pipeline name aids identification in the GitLab UI and audit output.
+
+> Two #304 items stay out of scope: a broad privileged-service / DinD check (already covered by WGL026 for DinD-TLS and WGL036 for MR-reachable DinD; a runner's privileged isolation is not in emitted YAML) and an optional include/component allowlist policy (configuration, overlapping WGL032's vendored source list).
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/gitlab/src/lint/post-synth/wgl047.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl047.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl047 } from "./wgl047";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL047: curl | bash runtime execution", () => {
+  test("flags curl piped to bash", () => {
+    const yaml = `build:
+  script:
+    - curl -sSL https://example.com/install.sh | bash
+`;
+    const diags = wgl047.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL047");
+    expect(diags[0].entity).toBe("build");
+  });
+
+  test("does not flag download-then-run on separate lines", () => {
+    const yaml = `build:
+  script:
+    - curl -sSLo install.sh https://example.com/install.sh
+    - bash install.sh
+`;
+    const diags = wgl047.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl047.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl047.ts
@@ -1,0 +1,41 @@
+/**
+ * WGL047: Software Fetched and Executed at Runtime Without Verification
+ *
+ * Flags a `script:` command that pipes a network download straight into a shell
+ * (`curl ... | bash`, `wget ... | sh`). The fetched script is unpinned and
+ * unverified, so whoever controls the URL controls what runs in the job.
+ * Download to a file, verify a checksum/signature, then execute it.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput, extractScriptCommands } from "./yaml-helpers";
+
+const PIPE_TO_SHELL = /\b(curl|wget)\b[^\n|]*\|\s*(sudo\s+)?(ba)?sh\b/i;
+
+export const wgl047: PostSynthCheck = {
+  id: "WGL047",
+  description: "Software fetched and piped to a shell without verification",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const seen = new Set<string>();
+      for (const { job, command } of extractScriptCommands(yaml)) {
+        if (PIPE_TO_SHELL.test(command) && !seen.has(job)) {
+          seen.add(job);
+          diagnostics.push({
+            checkId: "WGL047",
+            severity: "warning",
+            message: `Job "${job}" pipes a network download directly into a shell — the fetched code is unpinned and unverified. Download to a file, verify a checksum or signature, then execute it.`,
+            entity: job,
+            lexicon: "gitlab",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/lint/post-synth/wgl048.test.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl048.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wgl048 } from "./wgl048";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["gitlab", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["gitlab", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WGL048: pipeline without a name", () => {
+  test("flags a workflow: block with no name", () => {
+    const yaml = `workflow:
+  rules:
+    - if: $CI_COMMIT_BRANCH
+
+build:
+  script:
+    - make
+`;
+    const diags = wgl048.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WGL048");
+  });
+
+  test("does not flag a named workflow", () => {
+    const yaml = `workflow:
+  name: My Pipeline
+  rules:
+    - if: $CI_COMMIT_BRANCH
+
+build:
+  script:
+    - make
+`;
+    const diags = wgl048.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag a pipeline with no workflow block", () => {
+    const yaml = `build:
+  script:
+    - make
+`;
+    const diags = wgl048.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+});

--- a/lexicons/gitlab/src/lint/post-synth/wgl048.ts
+++ b/lexicons/gitlab/src/lint/post-synth/wgl048.ts
@@ -1,0 +1,37 @@
+/**
+ * WGL048: Pipeline Without a Name
+ *
+ * Flags a pipeline that defines a `workflow:` block but no `workflow:name:`.
+ * A pipeline name shows up in the GitLab UI and audit output; naming pipelines
+ * makes runs easier to identify and review. Only flags pipelines that already
+ * customize `workflow:` (where a name is cheap to add and most useful).
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput } from "./yaml-helpers";
+
+export const wgl048: PostSynthCheck = {
+  id: "WGL048",
+  description: "Pipeline defines workflow: but no workflow:name",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      const workflowSection = yaml.split("\n\n").find((s) => /^workflow:/.test(s));
+      if (!workflowSection) continue;
+      if (!/^\s+name:/m.test(workflowSection)) {
+        diagnostics.push({
+          checkId: "WGL048",
+          severity: "info",
+          message: `The pipeline defines a workflow: block but no workflow:name. Add a name so runs are identifiable in the GitLab UI and audit output.`,
+          entity: "workflow",
+          lexicon: "gitlab",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/gitlab/src/plugin.test.ts
+++ b/lexicons/gitlab/src/plugin.test.ts
@@ -83,7 +83,7 @@ describe("gitlabPlugin", () => {
 
   test("returns post-synth checks", () => {
     const checks = gitlabPlugin.postSynthChecks!();
-    expect(checks).toHaveLength(37);
+    expect(checks).toHaveLength(39);
     const ids = checks.map((c) => c.id);
     expect(ids).toContain("WGL010");
     expect(ids).toContain("WGL011");
@@ -122,6 +122,8 @@ describe("gitlabPlugin", () => {
     expect(ids).toContain("WGL044");
     expect(ids).toContain("WGL045");
     expect(ids).toContain("WGL046");
+    expect(ids).toContain("WGL047");
+    expect(ids).toContain("WGL048");
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #304. GitLab counterpart to #295.

| ID | Check | Severity |
|----|-------|----------|
| WGL047 | software fetched and piped to a shell (`curl \| bash`) without verification | warning |
| WGL048 | pipeline defines `workflow:` but no `workflow:name` | info |

Two issue items stay out of scope (documented): a broad privileged-service/DinD check (covered by WGL026 DinD-TLS + WGL036 MR-reachable DinD; runner isolation isn't in YAML) and an optional include/component allowlist policy (config, overlapping WGL032). Positive + negative tests; gitlab `vitest` green; eslint clean; docs regenerated. Completes the GitLab static-check epic (#297–304). Stacked on #302; rebased onto main after merge.