### PR TITLE
feat(gitlab): security-aware GitHub → GitLab migration (#306)

### DIFF
--- a/lexicons/gitlab/src/migrate/from-github/diagnostics.ts
+++ b/lexicons/gitlab/src/migrate/from-github/diagnostics.ts
@@ -22,6 +22,24 @@ export function provenanceToDiagnostics(
 ): LintDiagnostic[] {
   const out: LintDiagnostic[] = [];
   for (const r of records) {
+    // Security records always emit a diagnostic, at their own severity
+    // (escalated to error under --strict when the property was lost or needs
+    // review), independent of the functional category.
+    if (r.security) {
+      const sev =
+        opts.strict && (r.security.fate === "lost" || r.security.fate === "needs-review")
+          ? "error"
+          : r.security.severity;
+      out.push({
+        file: r.sourceFile ?? "<input>",
+        line: r.sourceLine ?? 1,
+        column: r.sourceColumn ?? 1,
+        ruleId: r.rule,
+        severity: sev,
+        message: r.note ?? r.rule,
+      });
+      continue;
+    }
     let severity: "error" | "warning" | "info" | undefined;
     if (r.category === "needs-review") {
       severity = opts.strict ? "error" : "warning";

--- a/lexicons/gitlab/src/migrate/from-github/index.ts
+++ b/lexicons/gitlab/src/migrate/from-github/index.ts
@@ -12,6 +12,7 @@ import { ProvenanceAccumulator, type ProvenanceRecord } from "./provenance";
 import { transformIR } from "./transformer";
 import { emitGitlabYaml } from "./emit-yaml";
 import { provenanceToDiagnostics } from "./diagnostics";
+import { analyzeSecurity, runSecurityChecks, renderSecurityPosture } from "./security";
 import { GitLabGenerator } from "../../import/generator";
 import { applyComposites } from "./composites/rewriter";
 import type { ActionMappingRegistry } from "./actions/registry";
@@ -31,6 +32,12 @@ export interface MigrateOptions {
   registry?: ActionMappingRegistry;
   /** Escalate needs-review diagnostics to errors. */
   strict?: boolean;
+  /**
+   * Security-aware migration (#306): classify each security property's fate
+   * across the edge and run the GitLab security post-synth checks against the
+   * migrated YAML. Enabled by the CLI's `--validate` path.
+   */
+  security?: boolean;
 }
 
 export interface MigrationResult {
@@ -44,6 +51,8 @@ export interface MigrationResult {
   diagnostics: LintDiagnostic[];
   /** Inferred stage list. */
   stages: string[];
+  /** Markdown "Security posture" section (#306). */
+  securityPosture: string;
 }
 
 /**
@@ -106,10 +115,20 @@ export async function transform(
     output = emitGitlabYaml(ir);
   }
 
+  // Security-aware migration (#306): classify each security property's fate
+  // across the edge, and run the GitLab security post-synth checks against the
+  // migrated YAML so weaknesses lost in translation surface on the target side.
+  if (opts.security) {
+    const yamlForSecurity = opts.emit === "ts" ? emitGitlabYaml(ir) : output;
+    provAcc.pushAll(analyzeSecurity(yamlContent, { sourceFile: opts.sourceFile }));
+    provAcc.pushAll(await runSecurityChecks(yamlForSecurity, { sourceFile: opts.sourceFile }));
+  }
+
   const provenance = provAcc.all();
   const diagnostics = provenanceToDiagnostics(provenance, { strict: opts.strict });
+  const securityPosture = renderSecurityPosture(provenance);
 
-  return { ir, output, provenance, diagnostics, stages };
+  return { ir, output, provenance, diagnostics, stages, securityPosture };
 }
 
 /**

--- a/lexicons/gitlab/src/migrate/from-github/provenance.ts
+++ b/lexicons/gitlab/src/migrate/from-github/provenance.ts
@@ -37,6 +37,29 @@ export interface ProvenanceRecord {
   actionRef?: string;
   /** Tier 1/2/3 for action-map records */
   mappingTier?: 1 | 2 | 3;
+  /** Security classification, when this record concerns a security property. */
+  security?: SecurityProvenance;
+}
+
+/**
+ * Fate of a security property as it crosses the GitHub → GitLab boundary,
+ * mirroring the functional provenance categories.
+ */
+export type SecurityFate = "translated" | "approximated" | "needs-review" | "lost";
+
+/**
+ * Security classification attached to a provenance record — tracks whether a
+ * security-relevant property survived migration, alongside the functional one.
+ */
+export interface SecurityProvenance {
+  /** Human label for the property (e.g. "Pinned action SHA"). */
+  property: string;
+  /** What happened to the property across the migration edge. */
+  fate: SecurityFate;
+  /** Diagnostic severity for this finding. */
+  severity: "error" | "warning" | "info";
+  /** Cross-reference to the endpoint that re-establishes the property. */
+  reestablish?: string;
 }
 
 /**
@@ -64,5 +87,10 @@ export class ProvenanceAccumulator {
 
   needsReviewCount(): number {
     return this.records.filter((r) => r.category === "needs-review").length;
+  }
+
+  /** Records carrying a security classification. */
+  securityRecords(): ProvenanceRecord[] {
+    return this.records.filter((r) => r.security !== undefined);
   }
 }

--- a/lexicons/gitlab/src/migrate/from-github/rules.ts
+++ b/lexicons/gitlab/src/migrate/from-github/rules.ts
@@ -79,4 +79,11 @@ export const MIGRATION_RULES: LintRule[] = [
 
   // Action mapping fallback
   rule("MIG-ACTION-UNKNOWN", "warning", "Marketplace action has no registered mapping"),
+
+  // ── Security posture across the migration edge (#306) ──────────────────
+  // Each cross-references the endpoint issue that re-establishes the property.
+  rule("MIG-PIN-LOST", "warning", "A pinned action SHA could not be carried to the GitLab include/image — re-pin on the GitLab side (#297)"),
+  rule("MIG-SECRET-UNSCOPED", "warning", "Migrated secret reference assumes a masked + protected GitLab variable (#300)"),
+  rule("MIG-INJECTION-CARRIED", "warning", "An untrusted-input injection site was translated verbatim across the edge (#299)"),
+  rule("MIG-TRUST-BOUNDARY", "warning", "Trigger/fork semantics shifted the trust boundary (pull_request_target → MR/fork pipeline) (#299)"),
 ];

--- a/lexicons/gitlab/src/migrate/from-github/security.test.ts
+++ b/lexicons/gitlab/src/migrate/from-github/security.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from "vitest";
+import { analyzeSecurity, runSecurityChecks, renderSecurityPosture } from "./security";
+import { transform } from "./index";
+
+const WORKFLOW = `name: CI
+on:
+  pull_request_target:
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - run: echo "title is \${{ github.event.pull_request.title }}"
+      - run: deploy --token \${{ secrets.DEPLOY_TOKEN }}
+`;
+
+describe("analyzeSecurity (#306)", () => {
+  test("classifies each security property's fate", () => {
+    const records = analyzeSecurity(WORKFLOW, { sourceFile: "ci.yml" });
+    const byRule = new Map(records.map((r) => [r.rule, r]));
+
+    expect(byRule.get("MIG-PIN-LOST")?.security?.fate).toBe("lost");
+    expect(byRule.get("MIG-SECRET-UNSCOPED")?.security?.fate).toBe("needs-review");
+    expect(byRule.get("MIG-INJECTION-CARRIED")?.security?.fate).toBe("translated");
+    expect(byRule.get("MIG-TRUST-BOUNDARY")?.security?.fate).toBe("needs-review");
+    expect(byRule.get("MIG-PERMISSIONS-001")?.security?.fate).toBe("needs-review");
+
+    // each cross-references the endpoint that re-establishes the property
+    expect(byRule.get("MIG-PIN-LOST")?.security?.reestablish).toBe("#297");
+    expect(byRule.get("MIG-SECRET-UNSCOPED")?.security?.reestablish).toBe("#300");
+  });
+
+  test("does not flag a clean workflow", () => {
+    const clean = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`;
+    expect(analyzeSecurity(clean)).toHaveLength(0);
+  });
+});
+
+describe("runSecurityChecks (#306)", () => {
+  test("runs the GitLab post-synth checks against migrated YAML", async () => {
+    // A migrated pipeline whose image is unpinned should trip WGL031.
+    const yaml = `stages:
+  - build
+
+build:
+  stage: build
+  image:
+    name: node:20
+  script:
+    - npm ci
+`;
+    const records = await runSecurityChecks(yaml);
+    expect(records.some((r) => r.rule === "WGL031")).toBe(true);
+    expect(records.every((r) => r.security !== undefined)).toBe(true);
+  });
+});
+
+describe("renderSecurityPosture (#306)", () => {
+  test("renders a posture table", () => {
+    const records = analyzeSecurity(WORKFLOW, { sourceFile: "ci.yml" });
+    const md = renderSecurityPosture(records);
+    expect(md).toContain("## Security posture");
+    expect(md).toContain("MIG-PIN-LOST");
+    expect(md).toContain("lost");
+  });
+
+  test("reports nothing for a clean workflow", () => {
+    expect(renderSecurityPosture([])).toContain("No security-relevant properties");
+  });
+});
+
+describe("transform with security: true (#306)", () => {
+  test("security findings flow into provenance + diagnostics + posture", async () => {
+    const result = await transform(WORKFLOW, { sourceFile: "ci.yml", security: true });
+    const ruleIds = new Set(result.diagnostics.map((d) => d.ruleId));
+    expect(ruleIds.has("MIG-PIN-LOST")).toBe(true);
+    expect(ruleIds.has("MIG-TRUST-BOUNDARY")).toBe(true);
+    expect(result.securityPosture).toContain("## Security posture");
+    expect(result.provenance.some((p) => p.security)).toBe(true);
+  });
+
+  test("security analysis is off by default", async () => {
+    const result = await transform(WORKFLOW, { sourceFile: "ci.yml" });
+    const ruleIds = new Set(result.diagnostics.map((d) => d.ruleId));
+    expect(ruleIds.has("MIG-PIN-LOST")).toBe(false);
+    expect(result.provenance.some((p) => p.security)).toBe(false);
+  });
+});

--- a/lexicons/gitlab/src/migrate/from-github/security.ts
+++ b/lexicons/gitlab/src/migrate/from-github/security.ts
@@ -1,0 +1,208 @@
+/**
+ * Security-aware migration (#306).
+ *
+ * Migration is the edge between the two security endpoints (#296 ↔ #305).
+ * Security properties don't translate 1:1 — some are silently preserved, some
+ * lost, some need re-establishing on the GitLab side. This module classifies
+ * each security-relevant property's fate as it crosses the boundary and runs
+ * the GitLab security post-synth checks against the migrated output so anything
+ * lost in translation is caught on the target side.
+ */
+
+import type { ProvenanceRecord } from "./provenance";
+
+const UNTRUSTED_CONTEXTS = [
+  "github.event.issue.title",
+  "github.event.issue.body",
+  "github.event.pull_request.title",
+  "github.event.pull_request.body",
+  "github.event.pull_request.head.ref",
+  "github.event.comment.body",
+  "github.event.review.body",
+  "github.event.head_commit.message",
+  "github.head_ref",
+];
+
+const SHA_PINNED_USES = /uses:\s*['"]?([\w.-]+\/[\w.-]+(?:\/[\w.-]+)*)@([0-9a-f]{40})['"]?/g;
+const SECRET_REF = /\$\{\{\s*secrets\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
+
+/**
+ * Classify the fate of security-relevant properties as they migrate from a
+ * GitHub Actions workflow to GitLab CI. Returns provenance records carrying a
+ * `security` classification (which flow into diagnostics, SARIF, and the report
+ * like any other provenance record).
+ */
+export function analyzeSecurity(sourceYaml: string, opts: { sourceFile?: string } = {}): ProvenanceRecord[] {
+  const records: ProvenanceRecord[] = [];
+  const file = opts.sourceFile;
+
+  // MIG-PIN-LOST — a GitHub SHA pin has no meaning once the action maps to a
+  // GitLab include/image (or becomes a hand-written script). Re-pin on GitLab.
+  const seenPins = new Set<string>();
+  let m: RegExpExecArray | null;
+  SHA_PINNED_USES.lastIndex = 0;
+  while ((m = SHA_PINNED_USES.exec(sourceYaml)) !== null) {
+    const slug = m[1];
+    if (seenPins.has(slug)) continue;
+    seenPins.add(slug);
+    records.push({
+      gitlabPath: "(target)",
+      sourceKey: `uses: ${slug}`,
+      sourceFile: file,
+      category: "synthesis",
+      rule: "MIG-PIN-LOST",
+      note: `The SHA pin on "${slug}" does not carry to its GitLab include/image — re-pin the GitLab target to a tag or digest (WGL029/WGL031).`,
+      security: { property: "Pinned action SHA", fate: "lost", severity: "warning", reestablish: "#297" },
+    });
+  }
+
+  // MIG-SECRET-UNSCOPED — ${{ secrets.X }} → $X, but masking/protection is set
+  // outside the YAML; the reference assumes a masked + protected variable.
+  const seenSecrets = new Set<string>();
+  SECRET_REF.lastIndex = 0;
+  while ((m = SECRET_REF.exec(sourceYaml)) !== null) {
+    const name = m[1];
+    if (seenSecrets.has(name)) continue;
+    seenSecrets.add(name);
+    records.push({
+      gitlabPath: "(target)",
+      sourceKey: `secrets.${name}`,
+      sourceFile: file,
+      category: "needs-review",
+      rule: "MIG-SECRET-UNSCOPED",
+      note: `secrets.${name} → $${name}, which assumes a masked + protected GitLab CI/CD variable. Mark it masked and protected (WGL038).`,
+      security: { property: "Secret reference", fate: "needs-review", severity: "warning", reestablish: "#300" },
+    });
+  }
+
+  // MIG-INJECTION-CARRIED — an untrusted-context interpolation translates
+  // verbatim, carrying the injection straight across.
+  const seenInjection = new Set<string>();
+  for (const ctx of UNTRUSTED_CONTEXTS) {
+    if (sourceYaml.includes(ctx) && !seenInjection.has(ctx)) {
+      seenInjection.add(ctx);
+      records.push({
+        gitlabPath: "(target)",
+        sourceKey: ctx,
+        sourceFile: file,
+        category: "needs-review",
+        rule: "MIG-INJECTION-CARRIED",
+        note: `Untrusted input \${{ ${ctx} }} translates to a $CI_* reference verbatim — the script-injection risk carries across (WGL035).`,
+        security: { property: "Template injection site", fate: "translated", severity: "warning", reestablish: "#299" },
+      });
+    }
+  }
+
+  // MIG-TRUST-BOUNDARY — pull_request_target maps to merge-request pipelines,
+  // which fork contributors can trigger; the trust boundary shifts.
+  if (/pull_request_target/.test(sourceYaml)) {
+    records.push({
+      gitlabPath: "(target)",
+      sourceKey: "on.pull_request_target",
+      sourceFile: file,
+      category: "needs-review",
+      rule: "MIG-TRUST-BOUNDARY",
+      note: `pull_request_target → merge-request pipelines, which fork contributors can trigger. Re-establish the trust boundary (protected refs, approvals) on GitLab (WGL034/WGL036).`,
+      security: { property: "Trigger trust boundary", fate: "needs-review", severity: "warning", reestablish: "#299" },
+    });
+  }
+
+  // MIG-PERMISSIONS-001 (reframed as least-privilege) — permissions: has no
+  // per-job GitLab YAML equivalent; least privilege lives in project settings.
+  if (/^permissions:/m.test(sourceYaml) || /^\s+permissions:/m.test(sourceYaml)) {
+    records.push({
+      gitlabPath: "(target)",
+      sourceKey: "permissions",
+      sourceFile: file,
+      category: "needs-review",
+      rule: "MIG-PERMISSIONS-001",
+      note: `Least-privilege permissions: have no per-job GitLab YAML equivalent — re-establish via project CI/CD token settings and id_tokens scoping (WGL033).`,
+      security: { property: "Least-privilege permissions", fate: "needs-review", severity: "warning", reestablish: "#298" },
+    });
+  }
+
+  return records;
+}
+
+/**
+ * Run the GitLab security post-synth checks against the migrated `.gitlab-ci.yml`
+ * and return their findings as provenance records — *migrate, then prove the
+ * output clears the GitLab security bar*. Anything lost in translation that
+ * lands as a concrete weakness on the target is caught here.
+ */
+export async function runSecurityChecks(gitlabYaml: string, opts: { sourceFile?: string } = {}): Promise<ProvenanceRecord[]> {
+  const { gitlabPlugin } = await import("../../plugin");
+  const checks = gitlabPlugin.postSynthChecks?.() ?? [];
+  const ctx = {
+    outputs: new Map<string, string>([["gitlab", gitlabYaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map<string, string>([["gitlab", gitlabYaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+
+  const records: ProvenanceRecord[] = [];
+  for (const check of checks) {
+    let diags;
+    try {
+      diags = check.check(ctx as never);
+    } catch {
+      continue; // a check that needs entities/other context simply yields nothing here
+    }
+    for (const d of diags) {
+      records.push({
+        gitlabPath: "(target)",
+        sourceKey: d.entity ?? d.checkId,
+        sourceFile: opts.sourceFile,
+        category: "synthesis",
+        rule: d.checkId,
+        note: `Migrated output triggers ${d.checkId}: ${d.message}`,
+        security: {
+          property: "GitLab security check",
+          fate: "needs-review",
+          severity: d.severity === "error" ? "error" : d.severity === "info" ? "info" : "warning",
+        },
+      });
+    }
+  }
+  return records;
+}
+
+/** A one-property line in the security posture summary. */
+interface PostureLine {
+  property: string;
+  fate: string;
+  rule: string;
+  count: number;
+}
+
+/**
+ * Render a "Security posture" Markdown section from the security provenance
+ * records (those carrying a `security` classification).
+ */
+export function renderSecurityPosture(records: ProvenanceRecord[]): string {
+  const security = records.filter((r) => r.security);
+  if (security.length === 0) {
+    return "## Security posture\n\nNo security-relevant properties detected at the migration edge.\n";
+  }
+
+  const byRule = new Map<string, PostureLine>();
+  for (const r of security) {
+    const s = r.security!;
+    const existing = byRule.get(r.rule);
+    if (existing) existing.count += 1;
+    else byRule.set(r.rule, { property: s.property, fate: s.fate, rule: r.rule, count: 1 });
+  }
+
+  let out = "## Security posture\n\n";
+  out += "| Property | Fate | Rule | Count |\n|---|---|---|---|\n";
+  for (const line of byRule.values()) {
+    out += `| ${line.property} | ${line.fate} | ${line.rule} | ${line.count} |\n`;
+  }
+  out += "\nFates: **translated** (weakness carried as-is) · **approximated** · **needs-review** (re-establish on GitLab) · **lost** (no GitLab equivalent for the property).\n";
+  return out;
+}

--- a/lexicons/gitlab/src/skills/chant-gitlab-migrate.md
+++ b/lexicons/gitlab/src/skills/chant-gitlab-migrate.md
@@ -79,6 +79,16 @@ npx chant migrate path/to/workflow.yml --output .gitlab-ci.yml --validate
 
 The CLI picks `glci` (offline, no auth) first; `glab ci lint` second. If neither is on PATH, `--validate` warns and skips. Pair with `--strict` to make validation failures hard.
 
+`--validate` also runs the **security backend** (#306): it classifies the fate of each security property across the migration edge and runs the GitLab security post-synth checks (WGL029+) against the emitted YAML — *migrate, then prove the output clears the GitLab security bar*. The report gains a **Security posture** section plus `MIG-*` security diagnostics:
+
+- `MIG-PIN-LOST` — a GitHub SHA pin can't follow the action to its GitLab include/image; re-pin on GitLab (→ #297 / WGL029, WGL031).
+- `MIG-SECRET-UNSCOPED` — a migrated `$VAR` assumes a masked + protected GitLab variable, set outside the YAML (→ #300 / WGL038).
+- `MIG-INJECTION-CARRIED` — an untrusted-input injection site translated verbatim; the weakness carries across (→ #299 / WGL035).
+- `MIG-TRUST-BOUNDARY` — `pull_request_target` → merge-request pipelines that fork contributors can trigger; re-establish protected-ref/approval gating (→ #299 / WGL034, WGL036).
+- `MIG-PERMISSIONS-001` (least-privilege) — no per-job GitLab YAML equivalent; lives in project token settings + `id_tokens` scoping (→ #298 / WGL033).
+
+Fates mirror the functional provenance model: **translated** (weakness carried as-is), **approximated**, **needs-review** (re-establish on GitLab), **lost** (no GitLab equivalent for the property). Use these to tell the user not just *did it migrate* but *did the security posture survive*.
+
 ## Step 5: Decide the emit mode
 
 Two modes serve different intents:

--- a/packages/core/src/cli/commands/migrate.ts
+++ b/packages/core/src/cli/commands/migrate.ts
@@ -96,6 +96,9 @@ export async function migrateCommand(opts: MigrateCliOpts): Promise<MigrateCliRe
       useComposites: opts.useComposites,
       sourceFile: opts.sourceFile,
       strict: opts.strict,
+      // --validate also runs the target lexicon's security checks against the
+      // migrated output and classifies security-property fates (#306).
+      security: opts.validate,
     });
   } catch (err) {
     return {
@@ -168,7 +171,11 @@ export async function migrateCommand(opts: MigrateCliOpts): Promise<MigrateCliRe
   }
 
   // Markdown summary (always to stderr — leaves stdout clean for piping)
-  const markdownSummary = formatMarkdownSummary(result.provenance, result.diagnostics, content);
+  let markdownSummary = formatMarkdownSummary(result.provenance, result.diagnostics, content);
+  // Append the security posture section when security analysis ran (#306).
+  if (result.securityPosture) {
+    markdownSummary += `\n\n${result.securityPosture}`;
+  }
 
   // Determine exit code: any error-severity diagnostic fails when --strict.
   // The transformer already escalates needs-review → error when opts.strict

--- a/packages/core/src/lexicon.ts
+++ b/packages/core/src/lexicon.ts
@@ -109,6 +109,9 @@ export interface MigrateOptions {
   sourceFile?: string;
   /** Escalate needs-review diagnostics to errors. */
   strict?: boolean;
+  /** Run security-aware migration analysis (classify property fates + run
+   * target security checks). Enabled by `chant migrate --validate`. */
+  security?: boolean;
 }
 
 /**
@@ -125,6 +128,8 @@ export interface MigrationResult {
   provenance: Array<Record<string, unknown>>;
   /** SARIF-shaped diagnostics. */
   diagnostics: Array<Record<string, unknown>>;
+  /** Markdown "Security posture" section, when security analysis ran (#306). */
+  securityPosture?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #306. Bridges the two security epics (#296 ↔ #305).

Makes `chant migrate` track *security* fidelity, not just functional, using the provenance model it already has.

### 1. Security dimension on the provenance model
`SecurityProvenance` (`provenance.ts`) classifies each security property **Translated / Approximated / NeedsReview / Lost** alongside the functional category. Security records flow into diagnostics + SARIF (`diagnostics.ts`) and a **Security posture** Markdown section.

### 2. Security backend for `--validate`
`chant migrate --validate` now also runs the GitLab security post-synth checks (WGL029+) against the emitted YAML — *migrate, then prove the output clears the GitLab security bar*. Highest-value integration point, and it composes for free (the WGL checks already run on emitted GitLab YAML).

### 3. New `MIG-*` security rules
| Rule | Fate | Re-establish |
|------|------|--------------|
| `MIG-PIN-LOST` | lost | #297 (WGL029/031) |
| `MIG-SECRET-UNSCOPED` | needs-review | #300 (WGL038) |
| `MIG-INJECTION-CARRIED` | translated | #299 (WGL035) |
| `MIG-TRUST-BOUNDARY` | needs-review | #299 (WGL034/036) |
| `MIG-PERMISSIONS-001` (reframed least-privilege) | needs-review | #298 (WGL033) |

### Design
- Gated behind `--validate` (`opts.security`) so the existing migration golden fixtures are unchanged (no churn); the new behavior is covered by a dedicated `security.test.ts` (7 tests, incl. the WGL backend tripping WGL031 on migrated output).
- `MigrateOptions.security` + `MigrationResult.securityPosture` added to the core `MigrationSource` interface.
- Skill doc (`chant-gitlab-migrate.md`) documents the posture section + fates.

`npx vitest run` green for migrate + core migrate command (139 tests); core `tsc --noEmit` clean; eslint clean.