### PR TITLE
feat(github): dependency-update configuration safety (#294)

### DIFF
--- a/lexicons/github/docs/src/content/docs/index.mdx
+++ b/lexicons/github/docs/src/content/docs/index.mdx
@@ -52,7 +52,7 @@ The lexicon provides **2 resources** (Workflow, Job), **13 composites** (Checkou
 | Services | 1 |
 | Intrinsic functions | 1 |
 | Pseudo-parameters | 0 |
-| Lint rules | 56 |
+| Lint rules | 58 |
 
 **Lexicon version:** 0.1.23  
 **Namespace:** `GitHub`

--- a/lexicons/github/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/github/docs/src/content/docs/lint-rules.mdx
@@ -329,6 +329,18 @@ Flags a workflow with no top-level `name:`. Without one, GitHub falls back to th
 
 > Two items from issue #295 are intentionally not implemented at the post-synth layer: over-broad/unrevoked app-installation tokens (whether a minted token is scoped wider than used cannot be determined from emitted YAML) and a reference allowlist/denylist policy (configuration, overlapping the GHA029 trusted-owner allowlist).
 
+### GHA057 — Dependency update executes untrusted code
+
+**Severity:** error
+
+Flags a Dependabot `updates:` entry with `insecure-external-code-execution: allow`, which runs a freshly-pulled dependency's lifecycle scripts during the update itself — a compromised release executes before any review. Set it to `deny`. Requires the `Dependabot` resource so the config is emitted (`.github/dependabot.yml`).
+
+### GHA058 — Dependency update without a cooldown
+
+**Severity:** warning
+
+Flags a Dependabot `updates:` entry with no cooldown — a version published moments ago (including a compromised one) is adopted immediately. Configure a `cooldown:` window. The `Dependabot` composite ships a 7-day default.
+
 ## Running lint
 
 ```bash

--- a/lexicons/github/src/codegen/docs.ts
+++ b/lexicons/github/src/codegen/docs.ts
@@ -1146,6 +1146,18 @@ Flags a workflow with no top-level \`name:\`. Without one, GitHub falls back to 
 
 > Two items from issue #295 are intentionally not implemented at the post-synth layer: over-broad/unrevoked app-installation tokens (whether a minted token is scoped wider than used cannot be determined from emitted YAML) and a reference allowlist/denylist policy (configuration, overlapping the GHA029 trusted-owner allowlist).
 
+### GHA057 — Dependency update executes untrusted code
+
+**Severity:** error
+
+Flags a Dependabot \`updates:\` entry with \`insecure-external-code-execution: allow\`, which runs a freshly-pulled dependency's lifecycle scripts during the update itself — a compromised release executes before any review. Set it to \`deny\`. Requires the \`Dependabot\` resource so the config is emitted (\`.github/dependabot.yml\`).
+
+### GHA058 — Dependency update without a cooldown
+
+**Severity:** warning
+
+Flags a Dependabot \`updates:\` entry with no cooldown — a version published moments ago (including a compromised one) is adopted immediately. Configure a \`cooldown:\` window. The \`Dependabot\` composite ships a 7-day default.
+
 ## Running lint
 
 \`\`\`bash

--- a/lexicons/github/src/composites/dependabot.test.ts
+++ b/lexicons/github/src/composites/dependabot.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "vitest";
+import { Dependabot, DependabotConfig } from "./dependabot";
+import { githubSerializer } from "../serializer";
+import type { SerializerResult } from "@intentius/chant/serializer";
+
+describe("Dependabot composite (#294)", () => {
+  test("ships safe defaults: cooldown + external code execution denied", () => {
+    const cfg = Dependabot({ ecosystems: [{ packageEcosystem: "npm" }, { packageEcosystem: "github-actions" }] });
+    expect(cfg).toBeInstanceOf(DependabotConfig);
+    expect(cfg.props.version).toBe(2);
+    expect(cfg.props.updates).toHaveLength(2);
+    for (const u of cfg.props.updates) {
+      expect(u.cooldown?.defaultDays).toBe(7);
+      expect(u.insecureExternalCodeExecution).toBe("deny");
+      expect(u.directory).toBe("/");
+      expect(u.schedule.interval).toBe("weekly");
+    }
+  });
+
+  test("serializes to a .github/dependabot.yml file (kebab-case keys)", () => {
+    const cfg = Dependabot({ ecosystems: [{ packageEcosystem: "npm" }] });
+    const result = githubSerializer.serialize(new Map([["deps", cfg]])) as SerializerResult;
+    expect(typeof result).toBe("object");
+    const yaml = result.files?.["dependabot.yml"];
+    expect(yaml).toBeDefined();
+    expect(yaml).toContain("version: 2");
+    expect(yaml).toContain("package-ecosystem: npm");
+    expect(yaml).toContain("open-pull-requests-limit: 5");
+    expect(yaml).toContain("insecure-external-code-execution: deny");
+    expect(yaml).toContain("default-days: 7");
+  });
+
+  test("emits dependabot.yml alongside a workflow", () => {
+    const cfg = Dependabot({ ecosystems: [{ packageEcosystem: "pip", interval: "daily" }] });
+    const wf = {
+      [Symbol.for("chant.declarable")]: true,
+      lexicon: "github",
+      entityType: "GitHub::Actions::Workflow",
+      kind: "resource" as const,
+      props: { name: "CI" },
+    };
+    const result = githubSerializer.serialize(
+      new Map<string, never>([["ci", wf as never], ["deps", cfg as never]]),
+    ) as SerializerResult;
+    expect(result.primary).toContain("name: CI");
+    expect(result.files?.["dependabot.yml"]).toContain("package-ecosystem: pip");
+  });
+});

--- a/lexicons/github/src/composites/dependabot.ts
+++ b/lexicons/github/src/composites/dependabot.ts
@@ -1,0 +1,91 @@
+/**
+ * Dependency-update configuration (`.github/dependabot.yml`) as a chant
+ * resource, so it is emitted and lintable like workflows (#294).
+ *
+ * Two failure modes the post-synth checks target:
+ *   - an update that executes untrusted code from a freshly-pulled dependency
+ *     during the update itself (`insecure-external-code-execution: allow`), and
+ *   - a configuration with no cooldown — a version published seconds ago
+ *     (including a compromised one) is adopted before anyone can react.
+ *
+ * The `Dependabot` composite ships safe defaults: a cooldown window and an
+ * explicit deny on external code execution.
+ */
+
+import { DECLARABLE_MARKER, type Declarable } from "@intentius/chant/declarable";
+
+/** A single `updates:` entry in dependabot.yml. */
+export interface DependabotUpdate {
+  /** e.g. "npm", "pip", "github-actions", "docker". */
+  packageEcosystem: string;
+  /** Directory to scan (defaults to "/"). */
+  directory?: string;
+  directories?: string[];
+  /** Update schedule. */
+  schedule: { interval: "daily" | "weekly" | "monthly"; day?: string; time?: string };
+  /** Cooldown window — delay adopting freshly-published versions. */
+  cooldown?: {
+    defaultDays?: number;
+    semverMajorDays?: number;
+    semverMinorDays?: number;
+    semverPatchDays?: number;
+  };
+  /** Cap on concurrent update PRs. */
+  openPullRequestsLimit?: number;
+  /** Whether to run a dependency's lifecycle scripts during the update. */
+  insecureExternalCodeExecution?: "allow" | "deny";
+  /** Passthrough for the rest of the dependabot update schema. */
+  [key: string]: unknown;
+}
+
+export interface DependabotConfigProps {
+  version?: number;
+  updates: DependabotUpdate[];
+  registries?: Record<string, unknown>;
+}
+
+/** The `.github/dependabot.yml` resource. */
+export class DependabotConfig implements Declarable {
+  readonly [DECLARABLE_MARKER] = true as const;
+  readonly lexicon = "github";
+  readonly entityType = "GitHub::Dependabot::Config";
+  readonly kind = "resource" as const;
+  readonly props: DependabotConfigProps;
+
+  constructor(props: DependabotConfigProps) {
+    this.props = { version: 2, ...props };
+  }
+}
+
+export interface DependabotEcosystem {
+  packageEcosystem: string;
+  directory?: string;
+  interval?: "daily" | "weekly" | "monthly";
+}
+
+export interface DependabotProps {
+  /** Ecosystems to keep updated. */
+  ecosystems: DependabotEcosystem[];
+  /** Cooldown window in days before adopting a freshly-published version (default 7). */
+  cooldownDays?: number;
+  /** Cap on concurrent update PRs per ecosystem (default 5). */
+  openPullRequestsLimit?: number;
+}
+
+/**
+ * Build a `DependabotConfig` with safe defaults: a cooldown window on every
+ * ecosystem and external code execution explicitly denied.
+ */
+export function Dependabot(props: DependabotProps): DependabotConfig {
+  const cooldownDays = props.cooldownDays ?? 7;
+  const limit = props.openPullRequestsLimit ?? 5;
+  const updates: DependabotUpdate[] = props.ecosystems.map((e) => ({
+    packageEcosystem: e.packageEcosystem,
+    directory: e.directory ?? "/",
+    schedule: { interval: e.interval ?? "weekly" },
+    cooldown: { defaultDays: cooldownDays },
+    openPullRequestsLimit: limit,
+    insecureExternalCodeExecution: "deny",
+  }));
+  return new DependabotConfig({ version: 2, updates });
+}

--- a/lexicons/github/src/composites/index.ts
+++ b/lexicons/github/src/composites/index.ts
@@ -24,3 +24,5 @@ export { DeployEnvironment } from "./deploy-environment";
 export type { DeployEnvironmentProps } from "./deploy-environment";
 export { GoCI } from "./go-ci";
 export type { GoCIProps } from "./go-ci";
+export { Dependabot, DependabotConfig } from "./dependabot";
+export type { DependabotProps, DependabotConfigProps, DependabotUpdate, DependabotEcosystem } from "./dependabot";

--- a/lexicons/github/src/index.ts
+++ b/lexicons/github/src/index.ts
@@ -30,6 +30,7 @@ export {
   DockerBuild,
   DeployEnvironment,
   GoCI,
+  Dependabot, DependabotConfig,
 } from "./composites/index";
 export type {
   CheckoutProps, SetupNodeProps, SetupGoProps, SetupPythonProps,
@@ -40,6 +41,7 @@ export type {
   DockerBuildProps,
   DeployEnvironmentProps,
   GoCIProps,
+  DependabotProps, DependabotConfigProps, DependabotUpdate, DependabotEcosystem,
 } from "./composites/index";
 
 // Spec utilities (for tooling)

--- a/lexicons/github/src/lint/post-synth/gha057.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha057.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import type { SerializerResult } from "@intentius/chant/serializer";
+import { gha057 } from "./gha057";
+
+function makeCtx(dependabotYaml: string): PostSynthContext {
+  const output: SerializerResult = { primary: "", files: { "dependabot.yml": dependabotYaml } };
+  return {
+    outputs: new Map([["github", output]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", output]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA057: dependency update executing untrusted code", () => {
+  test("flags insecure-external-code-execution: allow", () => {
+    const yaml = `version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    insecure-external-code-execution: allow
+`;
+    const diags = gha057.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA057");
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].entity).toBe("npm");
+  });
+
+  test("does not flag deny", () => {
+    const yaml = `version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    insecure-external-code-execution: deny
+`;
+    const diags = gha057.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("does not flag a workflow-only output", () => {
+    const ctx: PostSynthContext = {
+      outputs: new Map([["github", "name: CI\non:\n  push:\n"]]),
+      entities: new Map(),
+      buildResult: { outputs: new Map(), entities: new Map(), warnings: [], errors: [], sourceFileCount: 1 },
+    };
+    expect(gha057.check(ctx)).toHaveLength(0);
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha057.ts
+++ b/lexicons/github/src/lint/post-synth/gha057.ts
@@ -1,0 +1,40 @@
+/**
+ * GHA057: Dependency Update Executing Untrusted External Code
+ *
+ * Flags a dependabot `updates:` entry with
+ * `insecure-external-code-execution: allow`. That setting lets a freshly-pulled
+ * dependency run lifecycle scripts (e.g. npm `postinstall`) during the update
+ * itself — a compromised release executes in the update job before any review.
+ * Set it to `deny`, or isolate the ecosystem.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getDependabotYaml, extractDependabotUpdates } from "./yaml-helpers";
+
+export const gha057: PostSynthCheck = {
+  id: "GHA057",
+  description: "Dependency update allows executing untrusted external code",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const dependabot = getDependabotYaml(output);
+      if (!dependabot) continue;
+      for (const update of extractDependabotUpdates(dependabot)) {
+        if (update["insecure-external-code-execution"] === "allow") {
+          const eco = String(update["package-ecosystem"] ?? "?");
+          diagnostics.push({
+            checkId: "GHA057",
+            severity: "error",
+            message: `Dependabot update for "${eco}" sets insecure-external-code-execution: allow, running dependency lifecycle scripts during the update. Set it to deny.`,
+            entity: eco,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/gha058.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha058.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import type { SerializerResult } from "@intentius/chant/serializer";
+import { gha058 } from "./gha058";
+
+function makeCtx(dependabotYaml: string): PostSynthContext {
+  const output: SerializerResult = { primary: "", files: { "dependabot.yml": dependabotYaml } };
+  return {
+    outputs: new Map([["github", output]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", output]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("GHA058: dependency update without cooldown", () => {
+  test("flags an update with no cooldown", () => {
+    const yaml = `version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+`;
+    const diags = gha058.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("GHA058");
+    expect(diags[0].entity).toBe("npm");
+  });
+
+  test("does not flag an update with a cooldown window", () => {
+    const yaml = `version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+`;
+    const diags = gha058.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
+  test("flags an all-zero cooldown", () => {
+    const yaml = `version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 0
+`;
+    const diags = gha058.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].entity).toBe("pip");
+  });
+});

--- a/lexicons/github/src/lint/post-synth/gha058.ts
+++ b/lexicons/github/src/lint/post-synth/gha058.ts
@@ -1,0 +1,48 @@
+/**
+ * GHA058: Dependency Update Without a Cooldown
+ *
+ * Flags a dependabot `updates:` entry with no cooldown (or an all-zero one). A
+ * version published seconds ago — including a compromised one — is adopted
+ * immediately, with no window for the ecosystem to yank it or for anyone to
+ * react. Configure a `cooldown:` so freshly-published versions wait before they
+ * are proposed.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getDependabotYaml, extractDependabotUpdates } from "./yaml-helpers";
+
+const COOLDOWN_DAY_KEYS = ["default-days", "semver-major-days", "semver-minor-days", "semver-patch-days"];
+
+function hasEffectiveCooldown(cooldown: unknown): boolean {
+  if (!cooldown || typeof cooldown !== "object") return false;
+  const c = cooldown as Record<string, unknown>;
+  return COOLDOWN_DAY_KEYS.some((k) => typeof c[k] === "number" && (c[k] as number) > 0);
+}
+
+export const gha058: PostSynthCheck = {
+  id: "GHA058",
+  description: "Dependency update has no cooldown window",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+
+    for (const [, output] of ctx.outputs) {
+      const dependabot = getDependabotYaml(output);
+      if (!dependabot) continue;
+      for (const update of extractDependabotUpdates(dependabot)) {
+        if (!hasEffectiveCooldown(update.cooldown)) {
+          const eco = String(update["package-ecosystem"] ?? "?");
+          diagnostics.push({
+            checkId: "GHA058",
+            severity: "warning",
+            message: `Dependabot update for "${eco}" has no cooldown — a version published moments ago is adopted immediately. Add a cooldown window so fresh (possibly compromised) releases wait before they are proposed.`,
+            entity: eco,
+            lexicon: "github",
+          });
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/lexicons/github/src/lint/post-synth/yaml-helpers.ts
+++ b/lexicons/github/src/lint/post-synth/yaml-helpers.ts
@@ -3,8 +3,30 @@
  */
 
 import { parseYAML } from "@intentius/chant/yaml";
+import type { SerializerResult } from "@intentius/chant/serializer";
 
 export { getPrimaryOutput } from "@intentius/chant/lint/post-synth";
+
+/**
+ * Return the emitted `.github/dependabot.yml` content from a serializer output,
+ * if present (it rides as an additional file alongside the workflow output).
+ */
+export function getDependabotYaml(output: string | SerializerResult): string | undefined {
+  if (typeof output === "string") return undefined;
+  return output.files?.["dependabot.yml"];
+}
+
+/** Parse the `updates:` array from a dependabot.yml document. */
+export function extractDependabotUpdates(dependabotYaml: string): Array<Record<string, unknown>> {
+  let doc: Record<string, unknown>;
+  try {
+    doc = parseYAML(dependabotYaml);
+  } catch {
+    return [];
+  }
+  const updates = doc.updates;
+  return Array.isArray(updates) ? (updates as Array<Record<string, unknown>>) : [];
+}
 
 export interface ParsedJob {
   name: string;

--- a/lexicons/github/src/plugin.test.ts
+++ b/lexicons/github/src/plugin.test.ts
@@ -24,7 +24,7 @@ describe("githubPlugin", () => {
 
   test("provides post-synth checks", () => {
     const checks = githubPlugin.postSynthChecks!();
-    expect(checks.length).toBe(43);
+    expect(checks.length).toBe(45);
 
     const checkIds = checks.map((c) => c.id);
     expect(checkIds).toContain("GHA006");
@@ -62,6 +62,8 @@ describe("githubPlugin", () => {
     expect(checkIds).toContain("GHA054");
     expect(checkIds).toContain("GHA055");
     expect(checkIds).toContain("GHA056");
+    expect(checkIds).toContain("GHA057");
+    expect(checkIds).toContain("GHA058");
   });
 
   test("lint IDs are unique across rules and post-synth checks", () => {

--- a/lexicons/github/src/serializer.ts
+++ b/lexicons/github/src/serializer.ts
@@ -233,6 +233,7 @@ export const githubSerializer: Serializer = {
     const workflows: Array<[string, Declarable]> = [];
     const jobs: Array<[string, Declarable]> = [];
     const triggers: Array<[string, Declarable]> = [];
+    const dependabot: Array<[string, Declarable]> = [];
     const others: Array<[string, Declarable]> = [];
 
     for (const [name, entity] of entities) {
@@ -245,20 +246,52 @@ export const githubSerializer: Serializer = {
         jobs.push([name, entity]);
       } else if (isTriggerType(entityType)) {
         triggers.push([name, entity]);
+      } else if (entityType === "GitHub::Dependabot::Config") {
+        dependabot.push([name, entity]);
       } else {
         others.push([name, entity]);
       }
     }
 
-    // If multiple workflows, produce multiple files
-    if (workflows.length > 1) {
-      return serializeMultiWorkflow(workflows, jobs, triggers, entities, entityNames);
+    const workflowOut =
+      workflows.length > 1
+        ? serializeMultiWorkflow(workflows, jobs, triggers, entities, entityNames)
+        : serializeSingleWorkflow(workflows, jobs, triggers, entities, entityNames);
+
+    // A DependabotConfig emits an additional `.github/dependabot.yml` file
+    // alongside (or instead of) any workflow output.
+    if (dependabot.length > 0) {
+      const [, dep] = dependabot[0];
+      const depProps = (dep as unknown as Record<string, unknown>).props as Record<string, unknown>;
+      const dependabotYaml = emitDependabotYaml(depProps);
+      if (typeof workflowOut === "string") {
+        return { primary: workflowOut, files: { "dependabot.yml": dependabotYaml } };
+      }
+      return { ...workflowOut, files: { ...(workflowOut.files ?? {}), "dependabot.yml": dependabotYaml } };
     }
 
-    // Single workflow (or implicit workflow from jobs)
-    return serializeSingleWorkflow(workflows, jobs, triggers, entities, entityNames);
+    return workflowOut;
   },
 };
+
+/** Deep camelCase → kebab-case key conversion for dependabot props. */
+function deepKebabKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(deepKebabKeys);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[toKebabCase(k)] = deepKebabKeys(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Serialize a DependabotConfig's props into `.github/dependabot.yml`. */
+function emitDependabotYaml(props: Record<string, unknown>): string {
+  const doc = deepKebabKeys(props) as Record<string, unknown>;
+  return emitYAMLDocument(doc);
+}
 
 function serializeSingleWorkflow(
   workflows: Array<[string, Declarable]>,


### PR DESCRIPTION
Closes #294.

Automated dependency-update config carries its own security surface, separate from the workflows it spawns. chant didn't model it — so this adds the resource, then lints it.

### Prerequisite: model the config
- `DependabotConfig` resource (`GitHub::Dependabot::Config`) + a `Dependabot` composite with **safe defaults**: 7-day cooldown, `directory: /`, weekly schedule, `open-pull-requests-limit: 5`, and `insecure-external-code-execution: deny`.
- The serializer emits it as `.github/dependabot.yml` via `SerializerResult.files`, alongside any workflow output (existing string-only behavior is unchanged when no `DependabotConfig` is present — all 20 serializer tests still pass).

### Post-synth checks (on the emitted config)
| ID | Check | Severity |
|----|-------|----------|
| GHA057 | `insecure-external-code-execution: allow` — runs a dependency's lifecycle scripts during the update | error |
| GHA058 | no cooldown — a just-published (possibly compromised) version is adopted immediately | warning |

New helpers `getDependabotYaml` / `extractDependabotUpdates` read the emitted config from `ctx.outputs`. Positive + negative fixture test per check + composite/serializer tests. `npx vitest run` green for the github lexicon (374 tests); core `tsc --noEmit` clean; eslint clean; docs regenerated.