### PR TITLE
feat(temporal): live workflow supply-chain audit Op (#292)

### DIFF
--- a/lexicons/temporal/src/composites/workflow-audit-op.test.ts
+++ b/lexicons/temporal/src/composites/workflow-audit-op.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from "vitest";
+import { WorkflowAuditOp } from "./workflow-audit-op";
+
+describe("WorkflowAuditOp composite (#292)", () => {
+  test("one-shot form: op only, no schedule", () => {
+    const { op, schedule } = WorkflowAuditOp({ name: "actions-audit" });
+    expect(op).toBeDefined();
+    expect(schedule).toBeUndefined();
+  });
+
+  test("scheduled form: op + TemporalSchedule on the given cron", () => {
+    const { op, schedule } = WorkflowAuditOp({
+      name: "actions-audit",
+      schedule: "0 6 * * *",
+      onFinding: "pull-request",
+    });
+    expect(op).toBeDefined();
+    expect(schedule).toBeDefined();
+    const props = (schedule as unknown as { props: Record<string, unknown> }).props;
+    expect(props.scheduleId).toBe("actions-audit-schedule");
+    expect((props.spec as { cronExpressions: string[] }).cronExpressions).toEqual(["0 6 * * *"]);
+    expect((props.action as { workflowType: string }).workflowType).toBe("actionsAuditWorkflow");
+  });
+});

--- a/lexicons/temporal/src/composites/workflow-audit-op.ts
+++ b/lexicons/temporal/src/composites/workflow-audit-op.ts
@@ -1,0 +1,108 @@
+/**
+ * WorkflowAuditOp composite — the live supply-chain audit of GitHub workflows
+ * as a chant Op + an optional TemporalSchedule (#292).
+ *
+ * The github post-synth checks (#286-#291) own everything answerable from the
+ * deterministic build. This Op owns *only* the checks that require live
+ * resolution against a moving upstream truth — stale SHA pins, impostor refs,
+ * symbolic-ref confusion, pin/comment mismatch, advisories, archived upstreams.
+ * It sits at **observe** on the lifecycle dial, with a finding-mode (mirroring
+ * `ReconcileOp`: `report | issue | pull-request`) as the **reconcile** step.
+ *
+ * Runs one-shot on the local Op executor via `chant run`; on Temporal when a
+ * `schedule` is given, for continuous re-audit between change windows.
+ *
+ * @example
+ * ```typescript
+ * // one-shot, local executor
+ * export const { op } = WorkflowAuditOp({ name: "actions-audit" });
+ *
+ * // scheduled daily on Temporal, open a PR that bumps a stale pin
+ * export const { op, schedule } = WorkflowAuditOp({
+ *   name: "actions-audit",
+ *   schedule: "0 6 * * *",
+ *   onFinding: "pull-request",
+ * });
+ * ```
+ *
+ * @see #286 — the deterministic counterpart this freshens.
+ */
+
+import { Op, phase, activity, OpResource } from "@intentius/chant/op";
+import { TemporalSchedule } from "../resources";
+import type { WorkflowAuditMode } from "../op/activities/workflow-audit";
+
+function kebabToCamel(s: string): string {
+  return s.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+export interface WorkflowAuditOpConfig {
+  /** Op name (kebab-case). Used as workflow function name, task queue, schedule id base. */
+  name: string;
+  /**
+   * Cron expression. When set, a TemporalSchedule fires the workflow for
+   * continuous re-audit; omit for one-shot `chant run` on the local executor.
+   */
+  schedule?: string;
+  /**
+   * Directory of emitted workflow files to audit at run time.
+   * @default ".github/workflows"
+   */
+  workflowsDir?: string;
+  /**
+   * What to produce on findings. Default: "report".
+   * @default "report"
+   */
+  onFinding?: WorkflowAuditMode;
+  /** Override the task queue. Defaults to `name`. */
+  taskQueue?: string;
+}
+
+export interface WorkflowAuditOpResources {
+  /** Op resource — generates the audit workflow on `chant build`. */
+  op: InstanceType<typeof OpResource>;
+  /** Temporal schedule, present only when `schedule` was given. */
+  schedule?: InstanceType<typeof TemporalSchedule>;
+}
+
+export function WorkflowAuditOp(config: WorkflowAuditOpConfig): WorkflowAuditOpResources {
+  const taskQueue = config.taskQueue ?? config.name;
+  const onFinding = config.onFinding ?? "report";
+
+  const op = Op({
+    name: config.name,
+    overview: "Resolve workflow action references against live upstreams and report supply-chain drift",
+    taskQueue,
+    searchAttributes: {
+      Audit: "true",
+      Surface: "github-workflows",
+    },
+    phases: [
+      phase("Audit", [
+        {
+          kind: "activity",
+          fn: "workflowSupplyChainAudit",
+          args: { workflowsDir: config.workflowsDir ?? ".github/workflows", mode: onFinding },
+          // Surface the finding count as a workflow-level search attribute so
+          // "show me audits that found drift" is a one-filter UI query.
+          outcomeAttribute: { name: "Findings", from: "findings" },
+        },
+      ]),
+    ],
+  });
+
+  if (!config.schedule) {
+    return { op };
+  }
+
+  const schedule = new TemporalSchedule({
+    scheduleId: `${config.name}-schedule`,
+    spec: { cronExpressions: [config.schedule] },
+    action: {
+      workflowType: kebabToCamel(config.name) + "Workflow",
+      taskQueue,
+    },
+  } as Record<string, unknown>);
+
+  return { op, schedule };
+}

--- a/lexicons/temporal/src/index.ts
+++ b/lexicons/temporal/src/index.ts
@@ -31,6 +31,8 @@ export { WatchOp } from "./composites/watch-op";
 export type { WatchOpConfig, WatchOpResources } from "./composites/watch-op";
 export { ReconcileOp } from "./composites/reconcile-op";
 export type { ReconcileOpConfig, ReconcileOpResources } from "./composites/reconcile-op";
+export { WorkflowAuditOp } from "./composites/workflow-audit-op";
+export type { WorkflowAuditOpConfig, WorkflowAuditOpResources } from "./composites/workflow-audit-op";
 export { ApplyOp } from "./composites/apply-op";
 export type { ApplyOpConfig, ApplyOpResources } from "./composites/apply-op";
 

--- a/lexicons/temporal/src/op/activities/index.ts
+++ b/lexicons/temporal/src/op/activities/index.ts
@@ -33,3 +33,14 @@ export type { WaitForArgoSyncArgs, ArgoAppStatus, ArgoStatusFetcher } from "./ar
 
 export { policyGate } from "./policy";
 export type { PolicyGateArgs } from "./policy";
+
+export { workflowSupplyChainAudit, collectAuditRefs, defaultActionRefResolver } from "./workflow-audit";
+export type {
+  WorkflowAuditArgs,
+  WorkflowAuditResult,
+  WorkflowAuditMode,
+  WorkflowAuditFinding,
+  WorkflowAuditFindingKind,
+  ActionRefResolver,
+  ActionRefResolution,
+} from "./workflow-audit";

--- a/lexicons/temporal/src/op/activities/workflow-audit.test.ts
+++ b/lexicons/temporal/src/op/activities/workflow-audit.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from "vitest";
+import {
+  workflowSupplyChainAudit,
+  collectAuditRefs,
+  type ActionRefResolution,
+  type ActionRefResolver,
+} from "./workflow-audit";
+
+const SHA = "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b";
+
+const WORKFLOW = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@${SHA} # v4.1.0
+      - uses: evil/typo-action@v1
+      - uses: archived/old-action@v2
+`;
+
+/** Recorded upstream responses — no live network. */
+function recordedResolver(records: Record<string, ActionRefResolution>): ActionRefResolver {
+  return async (slug, ref) =>
+    records[`${slug}@${ref}`] ?? { exists: true, tags: [], archived: false, advisories: [] };
+}
+
+describe("collectAuditRefs (#292)", () => {
+  test("collects external refs with version comments, skipping local/docker", () => {
+    const yaml = `jobs:
+  a:
+    steps:
+      - uses: actions/checkout@${SHA} # v4.1.0
+      - uses: ./.github/actions/local
+      - uses: docker://alpine:3.19
+      - uses: org/reusable/.github/workflows/x.yml@v1
+`;
+    const refs = collectAuditRefs(yaml);
+    const slugs = refs.map((r) => r.slug);
+    expect(slugs).toContain("actions/checkout");
+    expect(slugs).toContain("org/reusable");
+    expect(slugs).not.toContain("./.github");
+    expect(refs.find((r) => r.slug === "actions/checkout")?.comment).toBe("v4.1.0");
+  });
+});
+
+describe("workflowSupplyChainAudit (#292)", () => {
+  test("flags stale pin, impostor, archived, and pin/comment mismatch", async () => {
+    const resolver = recordedResolver({
+      // SHA no longer on any tag → stale; actual tag differs from comment → mismatch
+      [`actions/checkout@${SHA}`]: { exists: true, tags: ["v4.2.0"], archived: false, advisories: [] },
+      "evil/typo-action@v1": { exists: false, tags: [], archived: false, advisories: [] },
+      "archived/old-action@v2": { exists: true, tags: ["v2"], archived: true, advisories: ["GHSA-xxxx"] },
+    });
+    const result = await workflowSupplyChainAudit({ yaml: WORKFLOW, resolver, mode: "issue" });
+    const kinds = result.findings.map((f) => `${f.slug}:${f.kind}`);
+
+    expect(kinds).toContain("evil/typo-action:impostor");
+    expect(kinds).toContain("archived/old-action:archived");
+    expect(kinds).toContain("archived/old-action:advisory");
+    expect(kinds).toContain("actions/checkout:pin-comment-mismatch");
+    expect(result.mode).toBe("issue");
+    expect(result.summary).toContain("Workflow supply-chain audit");
+  });
+
+  test("flags a stale SHA pin with no upstream tag", async () => {
+    const resolver = recordedResolver({
+      [`actions/checkout@${SHA}`]: { exists: true, tags: [], archived: false, advisories: [] },
+      "evil/typo-action@v1": { exists: true, tags: ["v1"], archived: false, advisories: [] },
+      "archived/old-action@v2": { exists: true, tags: ["v2"], archived: false, advisories: [] },
+    });
+    const result = await workflowSupplyChainAudit({ yaml: WORKFLOW, resolver });
+    expect(result.findings.some((f) => f.slug === "actions/checkout" && f.kind === "stale-pin")).toBe(true);
+  });
+
+  test("clean workflow yields no findings", async () => {
+    const yaml = `jobs:
+  build:
+    steps:
+      - uses: actions/checkout@${SHA}
+`;
+    const resolver = recordedResolver({
+      [`actions/checkout@${SHA}`]: { exists: true, tags: ["v4"], archived: false, advisories: [] },
+    });
+    const result = await workflowSupplyChainAudit({ yaml, resolver });
+    expect(result.findings).toHaveLength(0);
+    expect(result.summary).toContain("No live drift");
+  });
+});

--- a/lexicons/temporal/src/op/activities/workflow-audit.ts
+++ b/lexicons/temporal/src/op/activities/workflow-audit.ts
@@ -1,0 +1,203 @@
+/**
+ * workflowSupplyChainAudit — the live counterpart to the github post-synth
+ * supply-chain checks (#286-#291).
+ *
+ * Some workflow-reference checks can only be answered against a moving external
+ * truth: whether a pinned SHA still corresponds to a real tag/release upstream,
+ * whether a referenced commit exists in the repo it claims, whether a ref is
+ * confusable as both a tag and a branch, whether a pin matches its version
+ * comment, or whether a new advisory now covers an action already in use. These
+ * change over time independent of the source, so they cannot live in the
+ * deterministic build — this activity owns *only* the checks that require live
+ * resolution.
+ *
+ * It is dependency-free and primitives-only: it reads the emitted workflow YAML
+ * (passed as a string) and resolves references through an injectable
+ * `ActionRefResolver`, so Temporal/`chant run` can schedule it and tests can run
+ * it against recorded responses with no live network.
+ */
+
+/** What the audit produces on findings, mirroring ReconcileOp's modes. */
+export type WorkflowAuditMode = "report" | "issue" | "pull-request";
+
+/** Live resolution of a single action reference against its upstream. */
+export interface ActionRefResolution {
+  /** Does the ref/SHA exist in the claimed repo? */
+  exists: boolean;
+  /** Tag/release names that point at this commit (empty for a SHA ⇒ stale pin). */
+  tags: string[];
+  /** Is the upstream repository archived? */
+  archived: boolean;
+  /** Disclosed advisory identifiers affecting this action. */
+  advisories: string[];
+  /** Is the ref resolvable as BOTH a tag and a branch upstream? */
+  ambiguousRef?: boolean;
+}
+
+/** Pluggable upstream resolver — overridden in tests with recorded responses. */
+export type ActionRefResolver = (slug: string, ref: string) => Promise<ActionRefResolution>;
+
+export type WorkflowAuditFindingKind =
+  | "stale-pin"
+  | "impostor"
+  | "ambiguous-ref"
+  | "pin-comment-mismatch"
+  | "advisory"
+  | "archived";
+
+export interface WorkflowAuditFinding {
+  /** owner/repo slug. */
+  slug: string;
+  /** The pinned ref/SHA. */
+  ref: string;
+  kind: WorkflowAuditFindingKind;
+  detail: string;
+}
+
+export interface WorkflowAuditArgs {
+  /** One emitted workflow YAML document. */
+  yaml?: string;
+  /** Several emitted workflow YAML documents. */
+  yamls?: string[];
+  /**
+   * Directory of emitted workflow files (`*.yml`/`*.yaml`) to read at run time
+   * when no `yaml`/`yamls` is given — the form used inside a scheduled Op.
+   * Default `.github/workflows`.
+   */
+  workflowsDir?: string;
+  /** What to produce. Default: report. */
+  mode?: WorkflowAuditMode;
+  /** Injectable upstream resolver. Defaults to the live GitHub REST resolver. */
+  resolver?: ActionRefResolver;
+}
+
+/** Read `*.yml`/`*.yaml` files from a directory (best-effort). */
+async function readWorkflowDir(dir: string): Promise<string[]> {
+  try {
+    const { readdir, readFile } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const files = (await readdir(dir)).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+    return Promise.all(files.map((f) => readFile(join(dir, f), "utf-8")));
+  } catch {
+    return [];
+  }
+}
+
+export interface WorkflowAuditResult {
+  mode: WorkflowAuditMode;
+  findings: WorkflowAuditFinding[];
+  /** Markdown summary used as the PR/issue body or printed in report mode. */
+  summary: string;
+}
+
+interface CollectedRef {
+  slug: string;
+  ref: string;
+  /** Adjacent `# vX.Y.Z` comment, when present. */
+  comment?: string;
+}
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+/**
+ * Collect external action references (`uses: owner/repo@ref`, with an optional
+ * trailing version comment) from a workflow YAML. Local (`./`) and `docker://`
+ * references are excluded.
+ */
+export function collectAuditRefs(yaml: string): CollectedRef[] {
+  const out: CollectedRef[] = [];
+  const re = /uses:\s*['"]?([\w.-]+\/[\w.-]+(?:\/[\w./-]+)?)@([\w.-]+)['"]?\s*(?:#\s*(\S+))?/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(yaml)) !== null) {
+    out.push({ slug: m[1].split("/").slice(0, 2).join("/"), ref: m[2], comment: m[3] });
+  }
+  return out;
+}
+
+/**
+ * Default resolver: query the GitHub REST API for whether the ref exists, what
+ * tags point at it, archive status, and advisories. Best-effort and resilient —
+ * a network/HTTP error yields an "unknown" resolution (exists=true, no findings)
+ * rather than a false positive.
+ */
+export const defaultActionRefResolver: ActionRefResolver = async (slug, ref) => {
+  const base = `https://api.github.com/repos/${slug}`;
+  const headers: Record<string, string> = { Accept: "application/vnd.github+json" };
+  if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  const unknown: ActionRefResolution = { exists: true, tags: [], archived: false, advisories: [] };
+  try {
+    const repoResp = await fetch(base, { headers });
+    if (repoResp.status === 404) return { exists: false, tags: [], archived: false, advisories: [] };
+    if (!repoResp.ok) return unknown;
+    const repo = (await repoResp.json()) as { archived?: boolean };
+
+    const refResp = await fetch(`${base}/commits/${ref}`, { headers });
+    if (refResp.status === 404) return { exists: false, tags: [], archived: !!repo.archived, advisories: [] };
+
+    let tags: string[] = [];
+    if (SHA_RE.test(ref)) {
+      const tagsResp = await fetch(`${base}/tags?per_page=100`, { headers });
+      if (tagsResp.ok) {
+        const tagList = (await tagsResp.json()) as Array<{ name: string; commit?: { sha?: string } }>;
+        tags = tagList.filter((t) => t.commit?.sha === ref).map((t) => t.name);
+      }
+    }
+    return { exists: refResp.ok, tags, archived: !!repo.archived, advisories: [] };
+  } catch {
+    return unknown;
+  }
+};
+
+function renderSummary(findings: WorkflowAuditFinding[]): string {
+  if (findings.length === 0) return "## Workflow supply-chain audit\n\nNo live drift detected against upstream references.\n";
+  let out = `## Workflow supply-chain audit\n\n${findings.length} finding(s) against live upstream truth:\n\n`;
+  out += "| Action | Ref | Finding | Detail |\n|---|---|---|---|\n";
+  for (const f of findings) out += `| ${f.slug} | ${f.ref} | ${f.kind} | ${f.detail} |\n`;
+  return out;
+}
+
+/**
+ * Resolve each pinned external reference in the emitted workflows against live
+ * upstreams and report drift.
+ */
+export async function workflowSupplyChainAudit(args: WorkflowAuditArgs): Promise<WorkflowAuditResult> {
+  const resolver = args.resolver ?? defaultActionRefResolver;
+  const mode = args.mode ?? "report";
+  let yamls = args.yamls ?? (args.yaml ? [args.yaml] : []);
+  if (yamls.length === 0) {
+    yamls = await readWorkflowDir(args.workflowsDir ?? ".github/workflows");
+  }
+
+  const findings: WorkflowAuditFinding[] = [];
+  const seen = new Set<string>();
+  for (const yaml of yamls) {
+    for (const { slug, ref, comment } of collectAuditRefs(yaml)) {
+      const key = `${slug}@${ref}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const res = await resolver(slug, ref);
+      if (!res.exists) {
+        findings.push({ slug, ref, kind: "impostor", detail: `ref does not exist in ${slug} — possible impostor or deleted ref` });
+        continue;
+      }
+      if (SHA_RE.test(ref) && res.tags.length === 0) {
+        findings.push({ slug, ref, kind: "stale-pin", detail: "pinned SHA is no longer on any tag/release upstream" });
+      }
+      if (res.ambiguousRef) {
+        findings.push({ slug, ref, kind: "ambiguous-ref", detail: "ref resolves as both a tag and a branch upstream (symbolic-ref confusion)" });
+      }
+      if (comment && res.tags.length > 0 && !res.tags.includes(comment)) {
+        findings.push({ slug, ref, kind: "pin-comment-mismatch", detail: `pin comment "${comment}" does not match the SHA's actual tag(s): ${res.tags.join(", ")}` });
+      }
+      if (res.archived) {
+        findings.push({ slug, ref, kind: "archived", detail: `${slug} has been archived upstream since pinning` });
+      }
+      for (const adv of res.advisories) {
+        findings.push({ slug, ref, kind: "advisory", detail: `disclosed advisory ${adv} covers ${slug}` });
+      }
+    }
+  }
+
+  return { mode, findings, summary: renderSummary(findings) };
+}


### PR DESCRIPTION
Closes #292. The live counterpart to the github post-synth supply-chain checks (#286–#291).

Some workflow-reference checks can only be answered against a moving external truth (a pinned SHA still on a tag, a ref that exists in the claimed repo, an archived upstream, a new advisory). These can't live in the pure build — `chant build` stays reproducible — so they belong to the operational layer: **observe** on the lifecycle dial, with a finding-mode as the **reconcile** step.

### Activity — `workflowSupplyChainAudit`
Reads the emitted workflow YAML and resolves each pinned `uses:` reference through an **injectable `ActionRefResolver`**, flagging:
- **stale-pin** — SHA no longer on any tag/release upstream
- **impostor** — ref doesn't exist in the claimed repo
- **ambiguous-ref** — resolvable as both a tag and a branch
- **pin-comment-mismatch** — SHA's actual tag ≠ the `# vX` comment
- **advisory** / **archived** — disclosed issue or archived upstream

Default resolver hits the GitHub REST API; tests inject **recorded responses** (no live network in CI). Reads `.github/workflows` at run time for the scheduled form.

### Composite — `WorkflowAuditOp`
Modeled on `ReconcileOp`: an `Op` + optional `TemporalSchedule`; finding modes `report | issue | pull-request`. One-shot via `chant run` on the local executor; scheduled/durable via a cron + paired schedule (requires the temporal lexicon only for the durable form).

Activity unit tests (recorded upstreams) + composite test; full temporal lexicon `vitest` green (216); eslint + core `tsc` clean.