### PR TITLE
feat(temporal): live pipeline include/component audit Op (#303)

### DIFF
--- a/lexicons/temporal/src/composites/pipeline-audit-op.test.ts
+++ b/lexicons/temporal/src/composites/pipeline-audit-op.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "vitest";
+import { PipelineAuditOp } from "./pipeline-audit-op";
+
+describe("PipelineAuditOp composite (#303)", () => {
+  test("one-shot form: op only, no schedule", () => {
+    const { op, schedule } = PipelineAuditOp({ name: "pipeline-audit" });
+    expect(op).toBeDefined();
+    expect(schedule).toBeUndefined();
+  });
+
+  test("scheduled form: op + TemporalSchedule with merge-request finding mode", () => {
+    const { op, schedule } = PipelineAuditOp({
+      name: "pipeline-audit",
+      schedule: "0 6 * * *",
+      onFinding: "merge-request",
+    });
+    expect(op).toBeDefined();
+    expect(schedule).toBeDefined();
+    const props = (schedule as unknown as { props: Record<string, unknown> }).props;
+    expect(props.scheduleId).toBe("pipeline-audit-schedule");
+    expect((props.action as { workflowType: string }).workflowType).toBe("pipelineAuditWorkflow");
+  });
+});

--- a/lexicons/temporal/src/composites/pipeline-audit-op.ts
+++ b/lexicons/temporal/src/composites/pipeline-audit-op.ts
@@ -1,0 +1,100 @@
+/**
+ * PipelineAuditOp composite — the live include/component audit of GitLab
+ * pipelines as a chant Op + an optional TemporalSchedule (#303).
+ *
+ * The gitlab post-synth checks (#297) own everything answerable from the
+ * deterministic build. This Op owns *only* the checks that require live
+ * resolution against a moving upstream truth — a pinned component/include ref
+ * that no longer resolves, an archived or moved upstream project, or a new
+ * advisory covering a component/image in use. It sits at **observe** on the
+ * lifecycle dial, with a finding-mode (`report | issue | merge-request`) as the
+ * **reconcile** step — for GitLab the PR mode is a merge request.
+ *
+ * Runs one-shot on the local Op executor via `chant run`; on Temporal when a
+ * `schedule` is given.
+ *
+ * @example
+ * ```typescript
+ * export const { op, schedule } = PipelineAuditOp({
+ *   name: "pipeline-audit",
+ *   schedule: "0 6 * * *",
+ *   onFinding: "merge-request",
+ * });
+ * ```
+ *
+ * @see #297 — the deterministic counterpart this freshens.
+ */
+
+import { Op, phase, OpResource } from "@intentius/chant/op";
+import { TemporalSchedule } from "../resources";
+import type { PipelineAuditMode } from "../op/activities/pipeline-audit";
+
+function kebabToCamel(s: string): string {
+  return s.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+export interface PipelineAuditOpConfig {
+  /** Op name (kebab-case). Used as workflow function name, task queue, schedule id base. */
+  name: string;
+  /** Cron expression. When set, a TemporalSchedule fires the workflow; omit for one-shot. */
+  schedule?: string;
+  /**
+   * Path to the emitted `.gitlab-ci.yml` to audit at run time.
+   * @default ".gitlab-ci.yml"
+   */
+  pipelineFile?: string;
+  /**
+   * What to produce on findings. Default: "report".
+   * @default "report"
+   */
+  onFinding?: PipelineAuditMode;
+  /** Override the task queue. Defaults to `name`. */
+  taskQueue?: string;
+}
+
+export interface PipelineAuditOpResources {
+  /** Op resource — generates the audit workflow on `chant build`. */
+  op: InstanceType<typeof OpResource>;
+  /** Temporal schedule, present only when `schedule` was given. */
+  schedule?: InstanceType<typeof TemporalSchedule>;
+}
+
+export function PipelineAuditOp(config: PipelineAuditOpConfig): PipelineAuditOpResources {
+  const taskQueue = config.taskQueue ?? config.name;
+  const onFinding = config.onFinding ?? "report";
+
+  const op = Op({
+    name: config.name,
+    overview: "Resolve pipeline include/component/image references against live upstreams and report drift",
+    taskQueue,
+    searchAttributes: {
+      Audit: "true",
+      Surface: "gitlab-pipeline",
+    },
+    phases: [
+      phase("Audit", [
+        {
+          kind: "activity",
+          fn: "pipelineSupplyChainAudit",
+          args: { pipelineFile: config.pipelineFile ?? ".gitlab-ci.yml", mode: onFinding },
+          outcomeAttribute: { name: "Findings", from: "findings" },
+        },
+      ]),
+    ],
+  });
+
+  if (!config.schedule) {
+    return { op };
+  }
+
+  const schedule = new TemporalSchedule({
+    scheduleId: `${config.name}-schedule`,
+    spec: { cronExpressions: [config.schedule] },
+    action: {
+      workflowType: kebabToCamel(config.name) + "Workflow",
+      taskQueue,
+    },
+  } as Record<string, unknown>);
+
+  return { op, schedule };
+}

--- a/lexicons/temporal/src/index.ts
+++ b/lexicons/temporal/src/index.ts
@@ -33,6 +33,8 @@ export { ReconcileOp } from "./composites/reconcile-op";
 export type { ReconcileOpConfig, ReconcileOpResources } from "./composites/reconcile-op";
 export { WorkflowAuditOp } from "./composites/workflow-audit-op";
 export type { WorkflowAuditOpConfig, WorkflowAuditOpResources } from "./composites/workflow-audit-op";
+export { PipelineAuditOp } from "./composites/pipeline-audit-op";
+export type { PipelineAuditOpConfig, PipelineAuditOpResources } from "./composites/pipeline-audit-op";
 export { ApplyOp } from "./composites/apply-op";
 export type { ApplyOpConfig, ApplyOpResources } from "./composites/apply-op";
 

--- a/lexicons/temporal/src/op/activities/index.ts
+++ b/lexicons/temporal/src/op/activities/index.ts
@@ -44,3 +44,15 @@ export type {
   ActionRefResolver,
   ActionRefResolution,
 } from "./workflow-audit";
+
+export { pipelineSupplyChainAudit, collectPipelineRefs, defaultGitlabRefResolver } from "./pipeline-audit";
+export type {
+  PipelineAuditArgs,
+  PipelineAuditResult,
+  PipelineAuditMode,
+  PipelineAuditFinding,
+  PipelineAuditFindingKind,
+  PipelineRefKind,
+  GitlabRefResolver,
+  PipelineRefResolution,
+} from "./pipeline-audit";

--- a/lexicons/temporal/src/op/activities/pipeline-audit.test.ts
+++ b/lexicons/temporal/src/op/activities/pipeline-audit.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "vitest";
+import {
+  pipelineSupplyChainAudit,
+  collectPipelineRefs,
+  type PipelineRefResolution,
+  type GitlabRefResolver,
+} from "./pipeline-audit";
+
+const PIPELINE = `include:
+  - project: my-group/ci-templates
+    ref: v1.2.3
+    file: /build.yml
+  - component: gitlab.example.com/my-group/my-comp@1.0.0
+
+build:
+  image:
+    name: node:20
+  script:
+    - npm ci
+`;
+
+function recordedResolver(records: Record<string, PipelineRefResolution>): GitlabRefResolver {
+  return async (kind, identifier, ref) =>
+    records[`${kind}:${identifier}@${ref}`] ?? { exists: true, archived: false, advisories: [] };
+}
+
+describe("collectPipelineRefs (#303)", () => {
+  test("collects include:project, component, and image refs", () => {
+    const refs = collectPipelineRefs(PIPELINE);
+    const ids = refs.map((r) => `${r.refKind}:${r.identifier}`);
+    expect(ids).toContain("include:my-group/ci-templates");
+    expect(ids).toContain("component:gitlab.example.com/my-group/my-comp");
+    expect(ids).toContain("image:node:20");
+    expect(refs.find((r) => r.refKind === "include")?.ref).toBe("v1.2.3");
+    expect(refs.find((r) => r.refKind === "component")?.ref).toBe("1.0.0");
+  });
+
+  test("skips variable-based images", () => {
+    const refs = collectPipelineRefs(`build:\n  image:\n    name: $CI_REGISTRY_IMAGE:latest\n`);
+    expect(refs.filter((r) => r.refKind === "image")).toHaveLength(0);
+  });
+});
+
+describe("pipelineSupplyChainAudit (#303)", () => {
+  test("flags unresolved, archived, and moved references", async () => {
+    const resolver = recordedResolver({
+      "include:my-group/ci-templates@v1.2.3": { exists: true, archived: true, advisories: [] },
+      "component:gitlab.example.com/my-group/my-comp@1.0.0": { exists: false, archived: false, advisories: [] },
+      "image:node:20@20": { exists: true, archived: false, advisories: ["GHSA-img"], movedTo: undefined },
+    });
+    const result = await pipelineSupplyChainAudit({ yaml: PIPELINE, resolver, mode: "merge-request" });
+    const kinds = result.findings.map((f) => `${f.identifier}:${f.kind}`);
+
+    expect(kinds).toContain("my-group/ci-templates:archived");
+    expect(kinds).toContain("gitlab.example.com/my-group/my-comp:unresolved");
+    expect(kinds).toContain("node:20:advisory");
+    expect(result.mode).toBe("merge-request");
+    expect(result.summary).toContain("Pipeline include/component audit");
+  });
+
+  test("clean pipeline yields no findings", async () => {
+    const resolver = recordedResolver({});
+    const result = await pipelineSupplyChainAudit({ yaml: PIPELINE, resolver });
+    expect(result.findings).toHaveLength(0);
+    expect(result.summary).toContain("No live drift");
+  });
+});

--- a/lexicons/temporal/src/op/activities/pipeline-audit.ts
+++ b/lexicons/temporal/src/op/activities/pipeline-audit.ts
@@ -1,0 +1,201 @@
+/**
+ * pipelineSupplyChainAudit — the live counterpart to the gitlab post-synth
+ * include/component/image checks (#297).
+ *
+ * Some include/component checks can only be answered against a moving external
+ * truth: whether a pinned component/include ref still resolves upstream, whether
+ * the upstream project was archived or moved, or whether a new advisory now
+ * covers a component/image already in use. These change independent of the
+ * source, so they cannot live in the deterministic build — this activity owns
+ * *only* the checks that require live resolution.
+ *
+ * Dependency-free and primitives-only: it reads the emitted `.gitlab-ci.yml`
+ * (passed as a string) and resolves references through an injectable
+ * `GitlabRefResolver`, so Temporal/`chant run` can schedule it and tests can run
+ * it against recorded responses with no live network.
+ */
+
+/** What the audit produces on findings. For GitLab the PR mode is a merge request. */
+export type PipelineAuditMode = "report" | "issue" | "merge-request";
+
+/** The kind of reference being resolved. */
+export type PipelineRefKind = "include" | "component" | "image";
+
+/** Live resolution of a single pipeline reference against its upstream. */
+export interface PipelineRefResolution {
+  /** Does the project/component/image (at this ref/version) still resolve? */
+  exists: boolean;
+  /** Has the upstream project been archived? */
+  archived: boolean;
+  /** Has the upstream project moved (new path), if known. */
+  movedTo?: string;
+  /** Disclosed advisory identifiers affecting this reference. */
+  advisories: string[];
+}
+
+/** Pluggable upstream resolver — overridden in tests with recorded responses. */
+export type GitlabRefResolver = (kind: PipelineRefKind, identifier: string, ref: string) => Promise<PipelineRefResolution>;
+
+export type PipelineAuditFindingKind = "unresolved" | "archived" | "moved" | "advisory";
+
+export interface PipelineAuditFinding {
+  kind: PipelineAuditFindingKind;
+  refKind: PipelineRefKind;
+  /** project path / component address / image. */
+  identifier: string;
+  /** ref / version / tag. */
+  ref: string;
+  detail: string;
+}
+
+export interface PipelineAuditArgs {
+  /** One emitted `.gitlab-ci.yml` document. */
+  yaml?: string;
+  /** Several emitted documents. */
+  yamls?: string[];
+  /** Path to an emitted `.gitlab-ci.yml` to read at run time (default `.gitlab-ci.yml`). */
+  pipelineFile?: string;
+  /** What to produce. Default: report. */
+  mode?: PipelineAuditMode;
+  /** Injectable upstream resolver. Defaults to the live GitLab REST resolver. */
+  resolver?: GitlabRefResolver;
+}
+
+export interface PipelineAuditResult {
+  mode: PipelineAuditMode;
+  findings: PipelineAuditFinding[];
+  summary: string;
+}
+
+interface CollectedRef {
+  refKind: PipelineRefKind;
+  identifier: string;
+  ref: string;
+}
+
+/**
+ * Collect `include:project` (+ ref), `component:` (with @version), and `image:`
+ * references from a `.gitlab-ci.yml`.
+ */
+export function collectPipelineRefs(yaml: string): CollectedRef[] {
+  const out: CollectedRef[] = [];
+
+  // include:\n  - project: group/proj\n    ref: main
+  const projectRe = /-\s+project:\s*['"]?([^\s'"]+)['"]?[\s\S]*?ref:\s*['"]?([^\s'"]+)['"]?/g;
+  let m: RegExpExecArray | null;
+  while ((m = projectRe.exec(yaml)) !== null) {
+    out.push({ refKind: "include", identifier: m[1], ref: m[2] });
+  }
+
+  // - component: host/group/comp@1.0.0
+  const componentRe = /-\s+component:\s*['"]?([^\s'"@]+)@([^\s'"]+)['"]?/g;
+  while ((m = componentRe.exec(yaml)) !== null) {
+    out.push({ refKind: "component", identifier: m[1], ref: m[2] });
+  }
+
+  // Images: inline `image: name` or block `image:\n  name: ...` (and services).
+  const lines = yaml.split("\n");
+  const imgSeen = new Set<string>();
+  const addImage = (raw: string) => {
+    const image = raw.trim().replace(/^['"]|['"]$/g, "");
+    if (!image || image.includes("$") || imgSeen.has(image)) return;
+    imgSeen.add(image);
+    const at = image.lastIndexOf("@");
+    const colon = image.lastIndexOf(":");
+    const ref = at !== -1 ? image.slice(at + 1) : colon > image.lastIndexOf("/") ? image.slice(colon + 1) : "latest";
+    out.push({ refKind: "image", identifier: image, ref });
+  };
+  for (let i = 0; i < lines.length; i++) {
+    const inline = lines[i].match(/^\s+image:[ \t]+(\S.*)$/);
+    if (inline) { addImage(inline[1]); continue; }
+    if (/^\s+image:\s*$/.test(lines[i]) || /^\s+-\s+name:[ \t]+(\S.*)$/.test(lines[i])) {
+      const svcName = lines[i].match(/^\s+-\s+name:[ \t]+(\S.*)$/);
+      if (svcName) { addImage(svcName[1]); continue; }
+      const nameLine = lines.slice(i + 1, i + 4).find((l) => /^\s+name:[ \t]+/.test(l));
+      if (nameLine) addImage(nameLine.replace(/^\s+name:[ \t]+/, ""));
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Default resolver: query the GitLab REST API for project existence / archive /
+ * move status. Best-effort and resilient — errors yield an "unknown" resolution
+ * (exists=true, no findings) rather than a false positive. Component/image
+ * advisory lookups are left to a configured resolver.
+ */
+export const defaultGitlabRefResolver: GitlabRefResolver = async (kind, identifier) => {
+  const unknown: PipelineRefResolution = { exists: true, archived: false, advisories: [] };
+  if (kind === "image") return unknown; // image advisory feeds are resolver-specific
+  const host = "https://gitlab.com";
+  const project = kind === "component" ? identifier.split("/").slice(1, 3).join("/") : identifier;
+  try {
+    const resp = await fetch(`${host}/api/v4/projects/${encodeURIComponent(project)}`, {
+      headers: process.env.GITLAB_TOKEN ? { "PRIVATE-TOKEN": process.env.GITLAB_TOKEN } : {},
+    });
+    if (resp.status === 404) return { exists: false, archived: false, advisories: [] };
+    if (!resp.ok) return unknown;
+    const p = (await resp.json()) as { archived?: boolean };
+    return { exists: true, archived: !!p.archived, advisories: [] };
+  } catch {
+    return unknown;
+  }
+};
+
+function renderSummary(findings: PipelineAuditFinding[]): string {
+  if (findings.length === 0) return "## Pipeline include/component audit\n\nNo live drift detected against upstream references.\n";
+  let out = `## Pipeline include/component audit\n\n${findings.length} finding(s) against live upstream truth:\n\n`;
+  out += "| Reference | Ref | Finding | Detail |\n|---|---|---|---|\n";
+  for (const f of findings) out += `| ${f.identifier} (${f.refKind}) | ${f.ref} | ${f.kind} | ${f.detail} |\n`;
+  return out;
+}
+
+async function readFileBestEffort(path: string): Promise<string[]> {
+  try {
+    const { readFile } = await import("node:fs/promises");
+    return [await readFile(path, "utf-8")];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Resolve each include/component/image reference in the emitted pipeline against
+ * live upstreams and report drift.
+ */
+export async function pipelineSupplyChainAudit(args: PipelineAuditArgs): Promise<PipelineAuditResult> {
+  const resolver = args.resolver ?? defaultGitlabRefResolver;
+  const mode = args.mode ?? "report";
+  let yamls = args.yamls ?? (args.yaml ? [args.yaml] : []);
+  if (yamls.length === 0) {
+    yamls = await readFileBestEffort(args.pipelineFile ?? ".gitlab-ci.yml");
+  }
+
+  const findings: PipelineAuditFinding[] = [];
+  const seen = new Set<string>();
+  for (const yaml of yamls) {
+    for (const { refKind, identifier, ref } of collectPipelineRefs(yaml)) {
+      const key = `${refKind}:${identifier}@${ref}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const res = await resolver(refKind, identifier, ref);
+      if (!res.exists) {
+        findings.push({ kind: "unresolved", refKind, identifier, ref, detail: `${refKind} "${identifier}@${ref}" no longer resolves upstream` });
+        continue;
+      }
+      if (res.archived) {
+        findings.push({ kind: "archived", refKind, identifier, ref, detail: `${identifier} has been archived upstream` });
+      }
+      if (res.movedTo) {
+        findings.push({ kind: "moved", refKind, identifier, ref, detail: `${identifier} moved to ${res.movedTo}` });
+      }
+      for (const adv of res.advisories) {
+        findings.push({ kind: "advisory", refKind, identifier, ref, detail: `disclosed advisory ${adv} covers ${identifier}` });
+      }
+    }
+  }
+
+  return { mode, findings, summary: renderSummary(findings) };
+}


### PR DESCRIPTION
Closes #303. GitLab counterpart to #292; the live side of the gitlab post-synth checks (#297).

Some include/component checks can only be answered against a moving external truth (a pinned component/include ref that still resolves, an archived or moved upstream, a new advisory). These can't live in the deterministic build — they belong to the operational layer.

### Activity — `pipelineSupplyChainAudit`
Reads the emitted `.gitlab-ci.yml` and resolves each `include:project` ref, `component:` version, and `image:` through an **injectable `GitlabRefResolver`**, flagging **unresolved**, **archived**, **moved**, and **advisory** references. Default resolver hits the GitLab REST API; tests inject **recorded responses** (no live network in CI). Reads `.gitlab-ci.yml` at run time for the scheduled form. Variable-based images (`$CI_REGISTRY_IMAGE`) are skipped.

### Composite — `PipelineAuditOp`
Modeled on `ReconcileOp`: an `Op` + optional `TemporalSchedule`; finding modes `report | issue | merge-request` (GitLab's PR mode). One-shot via `chant run`; scheduled/durable via cron + paired schedule.

Activity unit tests (recorded upstreams) + composite test; full temporal lexicon `vitest` green (216+); eslint + core `tsc` clean.

This is the last child of the CI/CD security-audit milestone (#296 ↔ #305).