### PR TITLE
fix(build): YAML output — extension-driven format + array-of-objects (#284)

### DIFF
--- a/packages/core/src/cli/commands/build.test.ts
+++ b/packages/core/src/cli/commands/build.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { buildCommand, type BuildOptions } from "./build";
+import { buildCommand, resolveBuildFormat, type BuildOptions } from "./build";
 import type { Serializer } from "../../serializer";
+import { parseYAML } from "../../yaml";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -198,5 +199,81 @@ export const testEntity = {
     expect(existsSync(join(testDir, "dist", "ops", "alb-deploy", "workflow.ts"))).toBe(true);
     expect(existsSync(join(testDir, "dist", "ops", "alb-deploy", "activities.ts"))).toBe(true);
     expect(existsSync(join(testDir, "dist", "ops", "alb-deploy", "worker.ts"))).toBe(true);
+  });
+
+  // ── #284 bug 2: array-of-objects must serialize to valid YAML ──────────
+  test("yaml format serializes an array of objects to valid, round-trippable YAML", async () => {
+    // A serializer that emits a CloudFormation-shaped template with a tag list.
+    const cfnSerializer: Serializer = {
+      name: "test",
+      rulePrefix: "TEST",
+      serialize: () =>
+        JSON.stringify({
+          Resources: {
+            Bucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: {
+                BucketName: "x",
+                Tags: [
+                  { Key: "team", Value: "infra" },
+                  { Key: "env", Value: "prod" },
+                ],
+              },
+            },
+          },
+        }),
+    };
+    await writeFile(
+      join(testDir, "test.infra.ts"),
+      `export const e = { lexicon: "test", entityType: "TestEntity", [Symbol.for("chant.declarable")]: true };`,
+    );
+    const yamlOut = join(testDir, "template.yaml");
+
+    const result = await buildCommand({
+      path: testDir,
+      output: yamlOut,
+      format: "yaml",
+      serializers: [cfnSerializer],
+    });
+
+    expect(result.success).toBe(true);
+    const content = readFileSync(yamlOut, "utf-8");
+    // The list item must not be inlined onto the `Tags:` line (same-line dash).
+    expect(content).not.toMatch(/Tags:[ \t]+-/);
+    // And it must round-trip through a real YAML parser to the intended shape.
+    const parsed = parseYAML(content) as {
+      Resources: { Bucket: { Properties: { Tags: Array<{ Key: string; Value: string }> } } };
+    };
+    expect(parsed.Resources.Bucket.Properties.Tags).toEqual([
+      { Key: "team", Value: "infra" },
+      { Key: "env", Value: "prod" },
+    ]);
+  });
+});
+
+// ── #284 bug 1: -o extension drives format when --format is absent ────────
+describe("resolveBuildFormat", () => {
+  test("infers yaml from .yaml / .yml extension", () => {
+    expect(resolveBuildFormat("", "template.yaml")).toEqual({ format: "yaml" });
+    expect(resolveBuildFormat("", "template.yml")).toEqual({ format: "yaml" });
+  });
+
+  test("infers json from .json extension", () => {
+    expect(resolveBuildFormat("", "template.json")).toEqual({ format: "json" });
+  });
+
+  test("defaults to json when there is no extension to infer from", () => {
+    expect(resolveBuildFormat("", undefined)).toEqual({ format: "json" });
+    expect(resolveBuildFormat("", "outdir")).toEqual({ format: "json" });
+  });
+
+  test("explicit --format wins, and a mismatch with the extension warns", () => {
+    const r = resolveBuildFormat("json", "template.yaml");
+    expect(r.format).toBe("json");
+    expect(r.warning).toMatch(/yaml/i);
+  });
+
+  test("explicit --format matching the extension does not warn", () => {
+    expect(resolveBuildFormat("yaml", "template.yaml")).toEqual({ format: "yaml" });
   });
 });

--- a/packages/core/src/cli/commands/build.ts
+++ b/packages/core/src/cli/commands/build.ts
@@ -34,6 +34,38 @@ export interface BuildOptions {
   env?: string;
 }
 
+/**
+ * Resolve the output format for `chant build`.
+ *
+ * When `--format` is not given, infer it from the `-o` file extension
+ * (`.yaml`/`.yml` → yaml, `.json` → json); fall back to json when there is no
+ * extension to infer from. An explicit `--format` always wins, but a mismatch
+ * with the output extension is surfaced as a warning.
+ */
+export function resolveBuildFormat(
+  explicit: string | undefined,
+  output: string | undefined,
+): { format: "json" | "yaml"; warning?: string } {
+  const inferred = output
+    ? /\.ya?ml$/i.test(output)
+      ? "yaml"
+      : /\.json$/i.test(output)
+        ? "json"
+        : undefined
+    : undefined;
+
+  if (explicit === "json" || explicit === "yaml") {
+    if (inferred && inferred !== explicit) {
+      return {
+        format: explicit,
+        warning: `Output file "${output}" looks like ${inferred} but --format ${explicit} was given; writing ${explicit}.`,
+      };
+    }
+    return { format: explicit };
+  }
+
+  return { format: inferred ?? "json" };
+}
 
 /**
  * Build command result
@@ -326,7 +358,12 @@ function jsonToYaml(obj: unknown, indent = 0): string {
     return entries
       .map(([key, value]) => {
         const yamlValue = jsonToYaml(value, indent + 1);
-        if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        // A non-empty container (object OR array) renders as a block: the key on
+        // its own line, the value indented beneath it. Arrays were previously
+        // excluded here, which inlined `Tags: - Key: t` as invalid YAML.
+        const isContainer = typeof value === "object" && value !== null;
+        const isEmpty = isContainer && (Array.isArray(value) ? value.length === 0 : Object.keys(value).length === 0);
+        if (isContainer && !isEmpty) {
           return `${spaces}${key}:\n${yamlValue}`;
         }
         return `${spaces}${key}: ${yamlValue.trimStart()}`;

--- a/packages/core/src/cli/handlers/build.ts
+++ b/packages/core/src/cli/handlers/build.ts
@@ -1,4 +1,4 @@
-import { buildCommand, buildCommandWatch, printErrors, printWarnings } from "../commands/build";
+import { buildCommand, buildCommandWatch, printErrors, printWarnings, resolveBuildFormat } from "../commands/build";
 import { formatError, formatInfo } from "../format";
 import type { CommandContext } from "../registry";
 
@@ -15,10 +15,15 @@ export async function runBuild(ctx: CommandContext): Promise<number> {
     }
   }
 
-  const buildFormat = (args.format || "json") as "json" | "yaml";
-  if (buildFormat !== "json" && buildFormat !== "yaml") {
-    console.error(formatError({ message: `Invalid format for build: ${buildFormat}. Expected 'json' or 'yaml'.` }));
+  if (args.format && args.format !== "json" && args.format !== "yaml") {
+    console.error(formatError({ message: `Invalid format for build: ${args.format}. Expected 'json' or 'yaml'.` }));
     return 1;
+  }
+  // Infer format from the -o extension when --format is not given; an explicit
+  // --format wins but a mismatch warns (#284 bug 1).
+  const { format: buildFormat, warning: formatWarningMsg } = resolveBuildFormat(args.format, args.output);
+  if (formatWarningMsg) {
+    console.error(formatInfo(formatWarningMsg));
   }
 
   if (args.watch) {


### PR DESCRIPTION
Closes #284. Two distinct defects in `chant build`'s YAML output, separate root causes.

### Bug 1 — `-o file.yaml` silently wrote JSON
Format was driven solely by `--format` (default `json`); the output extension was never consulted. New exported `resolveBuildFormat(explicit, output)`:
- infers `yaml`/`json` from the `-o` extension when `--format` is absent,
- an explicit `--format` still wins,
- a mismatch (`--format json` into `.yaml`) **warns**,
- no extension to infer from → `json` (unchanged default); invalid `--format` still errors.

Wired into `handlers/build.ts`. (`--format` is `""` when unset — `main.ts:31` — so explicit-vs-default is distinguishable.)

### Bug 2 — `--format yaml` produced invalid YAML for arrays of objects
The hand-rolled `jsonToYaml` object branch only block-formatted nested **objects**, so array values fell through to the inline path and emitted `Tags: - Key: t` (unparseable). Fix: any **non-empty container (object _or_ array)** renders as a block. Once the array isn't inlined, the existing item indentation is already correct:
```yaml
Tags:
  - Key: team
    Value: infra
```

### Tests (the gap that let bug 2 through)
The prior `"handles yaml format option"` test only asserted file existence. Added:
- `resolveBuildFormat` units — extension inference, default, and mismatch warning.
- An array-of-objects case that builds to a `.yaml` file and asserts the output **round-trips through `parseYAML`** to the intended structure (and that the list item isn't inlined onto the `Tags:` line).

JSON output unchanged. `npx vitest run packages/core/src/cli` green (401); eslint + core `tsc` clean.