### PR TITLE
docs: cover the CI/CD pipeline security audit milestone

### DIFF
--- a/docs/src/content/docs/guide/ops.mdx
+++ b/docs/src/content/docs/guide/ops.mdx
@@ -291,6 +291,28 @@ A destructive apply is exactly where durability matters, and where `ApplyOp` lea
 
 An ungated, additive apply needs none of this and runs on the local executor. See [Durable Workflows](/chant/concepts/durable-workflows/) for why infra apply wants durable execution — and why it stays optional.
 
+## Audit (supply-chain drift)
+
+Some CI/CD security checks can only be answered against a moving external truth: whether a pinned action SHA still corresponds to a real upstream tag, whether a referenced commit still exists, whether a new advisory now covers a dependency already in use, whether an upstream was archived since you pinned it. The reference was correct when authored — the external world moved. That is drift, not a synthesis error, so it cannot live in the pure `chant build`; it belongs in the operational layer, exactly like lifecycle observation. On the dial it sits at **observe**, with a finding-mode as the **reconcile** step.
+
+The github and gitlab lexicons each ship an audit Op for this. The deterministic post-synth checks ([GitHub GHA029–058](/chant/lexicons/github/lint-rules/), [GitLab WGL029–048](/chant/lexicons/gitlab/lint-rules/)) own everything answerable from the build; the audit Op owns *only* what needs live resolution.
+
+```typescript
+import { WorkflowAuditOp } from "@intentius/chant-lexicon-temporal";
+
+// One-shot on the local executor: chant run actions-audit
+export const { op } = WorkflowAuditOp({ name: "actions-audit" });
+
+// Scheduled daily on Temporal; open a PR that bumps a stale pin
+export const { op: scheduledOp, schedule } = WorkflowAuditOp({
+  name: "actions-audit",
+  schedule: "0 6 * * *",
+  onFinding: "pull-request",   // "report" (default) | "issue" | "pull-request"
+});
+```
+
+`PipelineAuditOp` is the GitLab counterpart — it audits `.gitlab-ci.yml` `include:` / `component:` / `image:` references, and its finding-modes are `report | issue | merge-request`. Both run one-shot on the local executor (`chant run <name>`) with no Temporal dependency; only the scheduled, durable form requires Temporal, and `report` mode needs no external services at all. See the [github](/chant/lexicons/github/) and [gitlab](/chant/lexicons/gitlab/) lexicon docs for the per-platform reference lists each audit resolves.
+
 ## Op dependencies
 
 `depends` declares Ops that must succeed before this one starts. `chant build` validates all referenced names exist at build time.

--- a/docs/src/content/docs/lexicons/overview.mdx
+++ b/docs/src/content/docs/lexicons/overview.mdx
@@ -14,7 +14,7 @@ A **lexicon** is a collection of types and semantic lint rules for an operationa
 | GCP Config Connector | `@intentius/chant-lexicon-gcp` | 150+ | [Reference](/chant/lexicons/gcp/) |
 | Kubernetes | `@intentius/chant-lexicon-k8s` | 50+ resources, 35+ properties | [Reference](/chant/lexicons/k8s/) |
 | Helm | `@intentius/chant-lexicon-helm` | 10+ resources | [Reference](/chant/lexicons/helm/) |
-| GitHub Actions | `@intentius/chant-lexicon-github` | 2 resources, 13 composites | [Reference](/chant/lexicons/github/) |
+| GitHub Actions | `@intentius/chant-lexicon-github` | 3 resources, 14 composites | [Reference](/chant/lexicons/github/) |
 | GitLab CI/CD | `@intentius/chant-lexicon-gitlab` | 3 resources, 16 properties | [Reference](/chant/lexicons/gitlab/) — also ships [GitHub Actions migration](/chant/lexicons/gitlab/migration/) |
 | Docker | `@intentius/chant-lexicon-docker` | 6 resources (Compose + Dockerfile) | [Reference](/chant/lexicons/docker/) |
 | Temporal | `@intentius/chant-lexicon-temporal` | 4 resources + Op workflow engine | [Reference](/chant/lexicons/temporal/) |

--- a/docs/src/content/docs/whats-new.mdx
+++ b/docs/src/content/docs/whats-new.mdx
@@ -1,11 +1,24 @@
 ---
 title: What's New
-description: Recent capabilities shipped in chant — live import, the lifecycle dial, ownership markers, reconcile/apply Ops, observation contracts, drift detection, and more
+description: Recent capabilities shipped in chant — the CI/CD pipeline security audit, live import, the lifecycle dial, ownership markers, reconcile/apply Ops, observation contracts, drift detection, and more
 ---
 
 A hand-curated rollup of capabilities shipped recently. If you learned chant before this lands, this page is the catch-up. Each entry links to the closing issue or PR for the full context.
 
 For the day-to-day reference docs see [Lifecycle Models](/chant/concepts/lifecycle-models/), [`chant lifecycle`](/chant/cli/lifecycle/), [Live Import](/chant/guide/live-import/), [Reconciling Lifecycle](/chant/guide/reconciling-lifecycle/), [Drift Detection](/chant/concepts/drift-detection/), and [Implementing Observation](/chant/lexicon-authoring/observation/).
+
+## CI/CD pipeline security audit
+
+A workflow/pipeline security pass across the github and gitlab lexicons, split along chant's architectural boundary: deterministic checks run in the pure build, live-resolution checks run in the operational layer. Both lexicons were abstracted to the **same core problems** — pin & vet external references, least-privilege tokens, trust boundaries against untrusted input, secret containment, unsound expressions, artifact/cache hygiene — so the GitHub → GitLab migration can map problem → problem and carry the security invariant across the edge.
+
+| # | Capability |
+|---|---|
+| [#296](https://github.com/INTENTIUS/chant/issues/296) | Epic: GitHub workflow security audit — [GHA029–058](/chant/lexicons/github/lint-rules/) post-synth checks generalize SHA-pinning to every `uses:`/`image:`, flag over-broad token scopes, taint untrusted input into `run:`, contain secrets, reject unsound/obfuscated expressions, and enforce artifact/cache hygiene |
+| [#305](https://github.com/INTENTIUS/chant/issues/305) | Epic: GitLab pipeline security audit — [WGL029–048](/chant/lexicons/gitlab/lint-rules/), the same problems on GitLab primitives (includes/components, `CI_JOB_TOKEN`/`id_tokens`, masked/protected variables, `rules:`) |
+| [#292](https://github.com/INTENTIUS/chant/issues/292), [#303](https://github.com/INTENTIUS/chant/issues/303) | [`WorkflowAuditOp` / `PipelineAuditOp`](/chant/guide/ops/#audit-supply-chain-drift) — the live, always-fresh half: resolve pinned refs against moving upstreams (stale SHAs, impostor refs, advisories, archived projects), one-shot on the local executor or scheduled on Temporal, reporting via `report` / `issue` / `pull-request` (or `merge-request`) |
+| [#294](https://github.com/INTENTIUS/chant/issues/294) | [`Dependabot`](/chant/lexicons/github/composites/#dependabot) composite + resource — models `.github/dependabot.yml` so it's emitted and lintable, with safe defaults (cooldown window, external code execution denied); checks GHA057/058 |
+| [#306](https://github.com/INTENTIUS/chant/issues/306) | [Security-aware migration](/chant/lexicons/gitlab/migration/#security-posture) — a security-fate classification (Translated / Approximated / NeedsReview / Lost) on the migration provenance model, new `MIG-*` security rules, and a `--validate` security backend that runs the GitLab checks against migrated output |
+| [#293](https://github.com/INTENTIUS/chant/issues/293) | Fixed a duplicate lint ID — the post-synth "missing job-level permissions" check moved to `GHA013`, freeing `GHA020` for the secret-detection rule |
 
 ## Live import & the lifecycle dial
 

--- a/lexicons/github/docs/src/content/docs/composites.mdx
+++ b/lexicons/github/docs/src/content/docs/composites.mdx
@@ -325,3 +325,23 @@ const noLint = GoCI({ lintCommand: null });
 ```
 
 **Props:** `goVersion?`, `testCommand?`, `buildCommand?`, `lintCommand?` (null to omit), `runsOn?`
+
+## Dependabot
+
+Models the repository's dependency-update configuration (`.github/dependabot.yml`) as a chant resource, so it is emitted and lintable like a workflow. The composite ships **safe defaults**: a cooldown window on every ecosystem (so a version published moments ago — including a compromised one — is not adopted before anyone can react) and external code execution explicitly denied.
+
+```typescript
+import { Dependabot } from "@intentius/chant-lexicon-github";
+
+export const dependabot = Dependabot({
+  ecosystems: [
+    { packageEcosystem: "npm", directory: "/" },
+    { packageEcosystem: "github-actions", directory: "/" },
+  ],
+  // cooldownDays defaults to 7, openPullRequestsLimit to 5
+});
+```
+
+**Props:** `ecosystems` (required — each `{ packageEcosystem, directory?, interval? }`), `cooldownDays?` (default 7), `openPullRequestsLimit?` (default 5)
+
+For full control, construct the `DependabotConfig` resource directly with raw `updates:` entries. Two post-synth checks validate the emitted config: **GHA057** (`insecure-external-code-execution: allow`) and **GHA058** (no cooldown). See [Lint Rules](/chant/lexicons/github/lint-rules/).

--- a/lexicons/github/docs/src/content/docs/getting-started.mdx
+++ b/lexicons/github/docs/src/content/docs/getting-started.mdx
@@ -103,4 +103,4 @@ GitHub automatically picks up any `.github/workflows/*.yml` files and runs them 
 - [Workflow Concepts](/chant/lexicons/github/workflow-concepts/) — resource types, triggers, permissions
 - [Expressions](/chant/lexicons/github/expressions/) — typed expression system and condition helpers
 - [Composites](/chant/lexicons/github/composites/) — pre-built action wrappers (Checkout, SetupNode, etc.)
-- [Lint Rules](/chant/lexicons/github/lint-rules/) — 13 lint rules and 6 post-synth checks
+- [Lint Rules](/chant/lexicons/github/lint-rules/) — 13 lint rules and 45 post-synth checks

--- a/lexicons/github/docs/src/content/docs/index.mdx
+++ b/lexicons/github/docs/src/content/docs/index.mdx
@@ -40,7 +40,7 @@ export const build = new Job({
 });
 ```
 
-The lexicon provides **2 resources** (Workflow, Job), **13 composites** (Checkout, SetupNode, SetupGo, SetupPython, CacheAction, UploadArtifact, DownloadArtifact, NodeCI, NodePipeline, PythonCI, DockerBuild, DeployEnvironment, GoCI) + **3 presets** (BunPipeline, PnpmPipeline, YarnPipeline), a typed **Expression** system with 24 GitHub and 5 Runner context variables, and **13 lint rules** + **6 post-synth checks**.
+The lexicon provides **3 resources** (Workflow, Job, Dependabot config), **14 composites** (Checkout, SetupNode, SetupGo, SetupPython, CacheAction, UploadArtifact, DownloadArtifact, NodeCI, NodePipeline, PythonCI, DockerBuild, DeployEnvironment, GoCI, Dependabot) + **3 presets** (BunPipeline, PnpmPipeline, YarnPipeline), a typed **Expression** system with 24 GitHub and 5 Runner context variables, and **13 lint rules** + **45 post-synth checks** (including a CI/CD supply-chain security pass, GHA029–058).
 
 
 ## At a Glance

--- a/lexicons/github/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/github/docs/src/content/docs/lint-rules.mdx
@@ -159,6 +159,60 @@ Flags workflows triggered by `pull_request_target` that include `actions/checkou
 
 Detects cycles in the `needs:` dependency graph. If job A needs B and B needs A (directly or transitively), GitHub rejects the workflow. Reports the full cycle chain in the diagnostic message.
 
+### GHA021 — Checkout action not pinned to a SHA
+
+**Severity:** warning
+
+Flags `actions/checkout` referenced by a tag (e.g. `@v4`) instead of a pinned commit SHA. The narrower precursor to GHA029, kept because checkout is the most common unpinned action.
+
+### GHA022 — Job without timeout-minutes
+
+**Severity:** info
+
+Flags jobs that omit `timeout-minutes`. A hung step otherwise runs to the runner's default cap, burning minutes — set an explicit ceiling.
+
+### GHA023 — Deprecated set-output command
+
+**Severity:** warning
+
+Flags `::set-output` in `run:` steps. The workflow command is deprecated and disabled on current runners — write to `$GITHUB_OUTPUT` instead.
+
+### GHA024 — Missing concurrency for deploy workflows
+
+**Severity:** info
+
+Flags deploy workflows without a `concurrency:` block. Without one, two pushes can deploy concurrently and race — add a concurrency group to serialize them.
+
+### GHA025 — pull_request_target without restrictions
+
+**Severity:** warning
+
+Flags `pull_request_target` used without a `types:` filter. The trigger runs with repository secrets in the base-branch context, so it should be scoped to the specific PR events that need it.
+
+### GHA026 — Secret used without environment protection
+
+**Severity:** info
+
+Flags workflows that reference `secrets.` in steps but declare no `environment:` on any job, so the secret skips the approval and scoping rules an environment gate provides.
+
+### GHA027 — Cleanup step missing if: always()
+
+**Severity:** info
+
+Flags steps named "cleanup" / "teardown" / "clean up" that lack an `if:` condition. Cleanup should run even when a prior step fails — add `if: always()`.
+
+### GHA028 — Workflow with no on: triggers
+
+**Severity:** error
+
+Flags a workflow file with no top-level `on:` key. Without a trigger the workflow can never run.
+
+## Supply-chain security pass (GHA029–058)
+
+GHA029 onward are a CI/CD supply-chain security pass: pin & vet external references, enforce least-privilege token scopes, guard trust boundaries against untrusted input, contain secrets, reject unsound expressions, and keep artifacts/caches honest. They run statically on the emitted YAML — everything answerable without leaving the build.
+
+The checks that need a *moving external truth* — whether a pinned SHA still maps to a real upstream tag, whether a ref still exists, whether a new advisory now covers an action in use — can't be deterministic, so they live in the operational layer instead. Schedule the [`WorkflowAuditOp`](/chant/guide/ops/#audit-supply-chain-drift) (temporal lexicon) for that live, always-fresh half; it reads the same emitted workflow references and reports drift via `report | issue | pull-request`.
+
 ### GHA029 — Action or reusable workflow not pinned to a commit SHA
 
 **Severity:** warning

--- a/lexicons/github/docs/src/content/docs/skills.mdx
+++ b/lexicons/github/docs/src/content/docs/skills.mdx
@@ -29,7 +29,7 @@ The inline `chant-github` skill covers the full workflow lifecycle:
 - **Validate** — `chant lint src/`
 - **Deploy** — commit and push the generated YAML
 - **Status** — GitHub Actions UI or `gh run list`
-- **Troubleshooting** — lint rule codes (GHA001–GHA020), post-synth checks (GHA006–GHA019)
+- **Troubleshooting** — lint rule codes (GHA001–GHA020), post-synth checks (GHA006–GHA058)
 
 The skill is invocable as a slash command: `/chant-github`
 

--- a/lexicons/github/src/codegen/docs.ts
+++ b/lexicons/github/src/codegen/docs.ts
@@ -25,7 +25,7 @@ npm install --save-dev @intentius/chant-lexicon-github
 
 {{file:docs-snippets/src/quickstart.ts}}
 
-The lexicon provides **2 resources** (Workflow, Job), **13 composites** (Checkout, SetupNode, SetupGo, SetupPython, CacheAction, UploadArtifact, DownloadArtifact, NodeCI, NodePipeline, PythonCI, DockerBuild, DeployEnvironment, GoCI) + **3 presets** (BunPipeline, PnpmPipeline, YarnPipeline), a typed **Expression** system with 24 GitHub and 5 Runner context variables, and **13 lint rules** + **6 post-synth checks**.
+The lexicon provides **3 resources** (Workflow, Job, Dependabot config), **14 composites** (Checkout, SetupNode, SetupGo, SetupPython, CacheAction, UploadArtifact, DownloadArtifact, NodeCI, NodePipeline, PythonCI, DockerBuild, DeployEnvironment, GoCI, Dependabot) + **3 presets** (BunPipeline, PnpmPipeline, YarnPipeline), a typed **Expression** system with 24 GitHub and 5 Runner context variables, and **13 lint rules** + **45 post-synth checks** (including a CI/CD supply-chain security pass, GHA029–058).
 `;
 
 const outputFormat = `The GitHub Actions lexicon serializes resources into **\`.github/workflows/*.yml\`** YAML files.
@@ -184,7 +184,7 @@ GitHub automatically picks up any \`.github/workflows/*.yml\` files and runs the
 - [Workflow Concepts](/chant/lexicons/github/workflow-concepts/) — resource types, triggers, permissions
 - [Expressions](/chant/lexicons/github/expressions/) — typed expression system and condition helpers
 - [Composites](/chant/lexicons/github/composites/) — pre-built action wrappers (Checkout, SetupNode, etc.)
-- [Lint Rules](/chant/lexicons/github/lint-rules/) — 13 lint rules and 6 post-synth checks`,
+- [Lint Rules](/chant/lexicons/github/lint-rules/) — 13 lint rules and 45 post-synth checks`,
       },
       {
         slug: "workflow-concepts",
@@ -838,7 +838,27 @@ const { workflow, buildJob, testJob, lintJob } = GoCI({
 const noLint = GoCI({ lintCommand: null });
 \`\`\`
 
-**Props:** \`goVersion?\`, \`testCommand?\`, \`buildCommand?\`, \`lintCommand?\` (null to omit), \`runsOn?\``,
+**Props:** \`goVersion?\`, \`testCommand?\`, \`buildCommand?\`, \`lintCommand?\` (null to omit), \`runsOn?\`
+
+## Dependabot
+
+Models the repository's dependency-update configuration (\`.github/dependabot.yml\`) as a chant resource, so it is emitted and lintable like a workflow. The composite ships **safe defaults**: a cooldown window on every ecosystem (so a version published moments ago — including a compromised one — is not adopted before anyone can react) and external code execution explicitly denied.
+
+\`\`\`typescript
+import { Dependabot } from "@intentius/chant-lexicon-github";
+
+export const dependabot = Dependabot({
+  ecosystems: [
+    { packageEcosystem: "npm", directory: "/" },
+    { packageEcosystem: "github-actions", directory: "/" },
+  ],
+  // cooldownDays defaults to 7, openPullRequestsLimit to 5
+});
+\`\`\`
+
+**Props:** \`ecosystems\` (required — each \`{ packageEcosystem, directory?, interval? }\`), \`cooldownDays?\` (default 7), \`openPullRequestsLimit?\` (default 5)
+
+For full control, construct the \`DependabotConfig\` resource directly with raw \`updates:\` entries. Two post-synth checks validate the emitted config: **GHA057** (\`insecure-external-code-execution: allow\`) and **GHA058** (no cooldown). See [Lint Rules](/chant/lexicons/github/lint-rules/).`,
       },
       {
         slug: "lint-rules",
@@ -975,6 +995,60 @@ Flags workflows triggered by \`pull_request_target\` that include \`actions/chec
 **Severity:** error
 
 Detects cycles in the \`needs:\` dependency graph. If job A needs B and B needs A (directly or transitively), GitHub rejects the workflow. Reports the full cycle chain in the diagnostic message.
+
+### GHA021 — Checkout action not pinned to a SHA
+
+**Severity:** warning
+
+Flags \`actions/checkout\` referenced by a tag (e.g. \`@v4\`) instead of a pinned commit SHA. The narrower precursor to GHA029, kept because checkout is the most common unpinned action.
+
+### GHA022 — Job without timeout-minutes
+
+**Severity:** info
+
+Flags jobs that omit \`timeout-minutes\`. A hung step otherwise runs to the runner's default cap, burning minutes — set an explicit ceiling.
+
+### GHA023 — Deprecated set-output command
+
+**Severity:** warning
+
+Flags \`::set-output\` in \`run:\` steps. The workflow command is deprecated and disabled on current runners — write to \`$GITHUB_OUTPUT\` instead.
+
+### GHA024 — Missing concurrency for deploy workflows
+
+**Severity:** info
+
+Flags deploy workflows without a \`concurrency:\` block. Without one, two pushes can deploy concurrently and race — add a concurrency group to serialize them.
+
+### GHA025 — pull_request_target without restrictions
+
+**Severity:** warning
+
+Flags \`pull_request_target\` used without a \`types:\` filter. The trigger runs with repository secrets in the base-branch context, so it should be scoped to the specific PR events that need it.
+
+### GHA026 — Secret used without environment protection
+
+**Severity:** info
+
+Flags workflows that reference \`secrets.\` in steps but declare no \`environment:\` on any job, so the secret skips the approval and scoping rules an environment gate provides.
+
+### GHA027 — Cleanup step missing if: always()
+
+**Severity:** info
+
+Flags steps named "cleanup" / "teardown" / "clean up" that lack an \`if:\` condition. Cleanup should run even when a prior step fails — add \`if: always()\`.
+
+### GHA028 — Workflow with no on: triggers
+
+**Severity:** error
+
+Flags a workflow file with no top-level \`on:\` key. Without a trigger the workflow can never run.
+
+## Supply-chain security pass (GHA029–058)
+
+GHA029 onward are a CI/CD supply-chain security pass: pin & vet external references, enforce least-privilege token scopes, guard trust boundaries against untrusted input, contain secrets, reject unsound expressions, and keep artifacts/caches honest. They run statically on the emitted YAML — everything answerable without leaving the build.
+
+The checks that need a *moving external truth* — whether a pinned SHA still maps to a real upstream tag, whether a ref still exists, whether a new advisory now covers an action in use — can't be deterministic, so they live in the operational layer instead. Schedule the [\`WorkflowAuditOp\`](/chant/guide/ops/#audit-supply-chain-drift) (temporal lexicon) for that live, always-fresh half; it reads the same emitted workflow references and reports drift via \`report | issue | pull-request\`.
 
 ### GHA029 — Action or reusable workflow not pinned to a commit SHA
 
@@ -1287,7 +1361,7 @@ The inline \`chant-github\` skill covers the full workflow lifecycle:
 - **Validate** — \`chant lint src/\`
 - **Deploy** — commit and push the generated YAML
 - **Status** — GitHub Actions UI or \`gh run list\`
-- **Troubleshooting** — lint rule codes (GHA001–GHA020), post-synth checks (GHA006–GHA019)
+- **Troubleshooting** — lint rule codes (GHA001–GHA020), post-synth checks (GHA006–GHA058)
 
 The skill is invocable as a slash command: \`/chant-github\`
 

--- a/lexicons/gitlab/docs/src/content/docs/index.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/index.mdx
@@ -30,7 +30,7 @@ export const testJob = new Job({
 });
 ```
 
-The lexicon provides **3 resources** (Job, Workflow, Default), **16 property types** (Image, Cache, Artifacts, Rule, Environment, Trigger, Need, Service, and more), the `CI` pseudo-parameter object for predefined variables, and the `reference()` intrinsic for YAML `!reference` tags.
+The lexicon provides **3 resources** (Job, Workflow, Default), **16 property types** (Image, Cache, Artifacts, Rule, Environment, Trigger, Need, Service, and more), the `CI` pseudo-parameter object for predefined variables, and the `reference()` intrinsic for YAML `!reference` tags. It also ships **4 lint rules** + **39 post-synth checks** (including a CI/CD supply-chain security pass, WGL029–048) and a [`chant migrate`](./migration) source for translating GitHub Actions workflows.
 
 
 ## At a Glance

--- a/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/lint-rules.mdx
@@ -158,6 +158,90 @@ Flags jobs whose `extends:` references a template or hidden job not defined in t
 
 Detects cycles in the `needs:` dependency graph. If job A needs B and B needs A (directly or transitively), GitLab rejects the pipeline. Reports the full cycle chain in the diagnostic message.
 
+### WGL016 — Secret in a variables block
+
+**Severity:** error
+
+Detects hardcoded passwords, tokens, or keys in a `variables:` block. Move them to CI/CD masked variables instead of committing them to the pipeline. The precursor to the WGL038–040 secret-scoping checks.
+
+### WGL017 — Insecure registry
+
+**Severity:** warning
+
+Flags Docker push/pull to a non-HTTPS registry in a job script. HTTP gives the registry traffic no transport integrity.
+
+### WGL018 — Missing timeout
+
+**Severity:** warning
+
+Flags jobs without an explicit `timeout:`. The instance default (often 1 hour) is too long for most jobs and lets a hung job hold a runner.
+
+### WGL019 — Missing retry on deploy jobs
+
+**Severity:** info
+
+Deploy-stage jobs benefit from a `retry:` strategy to ride out transient infrastructure failures. Informational, not required.
+
+### WGL020 — Duplicate job names
+
+**Severity:** error
+
+Detects multiple jobs that resolve to the same kebab-case key in the serialized YAML. GitLab silently merges duplicate keys, so one job's config quietly overwrites the other.
+
+### WGL021 — Unused variables
+
+**Severity:** warning
+
+Flags global `variables:` not referenced by any job script — usually stale configuration adding noise.
+
+### WGL022 — Missing artifacts expiry
+
+**Severity:** warning
+
+Flags `artifacts:` without `expire_in:`. Depending on instance config the default is "never expire," which bloats storage.
+
+### WGL023 — Overly broad rules
+
+**Severity:** info
+
+Flags a job whose only rule is `when: always` with no conditions (`if:`, `changes:`, …). That disables all pipeline filtering for the job, which is usually unintended.
+
+### WGL024 — Manual without allow_failure
+
+**Severity:** warning
+
+Flags `when: manual` jobs that don't set `allow_failure: true`. Without it the manual job blocks the pipeline from progressing past its stage until someone triggers it.
+
+### WGL025 — Missing cache key
+
+**Severity:** warning
+
+Flags `cache:` without a `key:`. GitLab falls back to the `default` key, causing cache collisions between unrelated jobs on the same runner.
+
+### WGL026 — Privileged services without TLS
+
+**Severity:** warning
+
+Flags Docker-in-Docker (DinD) services that don't set `DOCKER_TLS_CERTDIR`, leaving the Docker daemon on an unencrypted socket. Extended by WGL036 for the merge-request-reachable case.
+
+### WGL027 — Empty script
+
+**Severity:** error
+
+Detects jobs with `script: []` or only empty strings. GitLab rejects empty scripts at pipeline validation time.
+
+### WGL028 — Redundant needs
+
+**Severity:** info
+
+Detects `needs:` entries already implied by stage ordering. Not incorrect, but redundant needs add noise and make the pipeline harder to maintain.
+
+## Supply-chain security pass (WGL029–048)
+
+WGL029 onward are a CI/CD supply-chain security pass, the GitLab counterpart to the github lexicon's GHA029–058: pin & vet includes/components/images, scope `CI_JOB_TOKEN` and OIDC, guard trust boundaries against untrusted CI input, mask/protect/scope secrets, reject unsound `rules:` expressions, and keep artifacts/caches honest. They run statically on the emitted `.gitlab-ci.yml`.
+
+The checks that need a *moving external truth* — whether a pinned component/include ref still resolves, whether an upstream was archived or moved, whether a new advisory covers a component in use — live in the operational layer instead. Schedule the [`PipelineAuditOp`](/chant/guide/ops/#audit-supply-chain-drift) (temporal lexicon) for that live half; it reads the emitted `include:` / `component:` / `image:` references and reports drift via `report | issue | merge-request`.
+
 ### WGL029 — Unpinned include:project / component
 
 **Severity:** warning

--- a/lexicons/gitlab/docs/src/content/docs/migration.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/migration.mdx
@@ -147,12 +147,12 @@ Other shapes (Python, Docker, Go) are deferred follow-ups in the [umbrella issue
 
 ## Validating the output
 
-`--validate` shells out to a local validator:
+`--validate` runs two backends against the migrated pipeline:
 
-1. `glci lint` (preferred — offline, no auth)
-2. `glab ci lint` (fallback — requires `glab auth login`)
+1. **Syntax** — a local validator: `glci lint` (preferred — offline, no auth), falling back to `glab ci lint` (requires `glab auth login`). If neither tool is on PATH, syntax validation is skipped with a warning.
+2. **Security** — the GitLab security post-synth checks ([WGL029–048](/chant/lexicons/gitlab/lint-rules/)) run against the emitted `.gitlab-ci.yml`. The principle is *migrate, then prove the output clears the GitLab security bar* — anything lost in translation that lands as a concrete weakness on the target is caught here, and it composes for free since those checks already run on emitted GitLab YAML.
 
-If neither tool is on PATH, validation is skipped with a warning. Pair with `--strict` to make missing tools or validation failures hard-fail.
+Pair with `--strict` to hard-fail on missing tools, syntax errors, or error-severity security findings.
 
 Install `glci`:
 ```bash
@@ -170,6 +170,20 @@ chant migrate workflow.yml --output .gitlab-ci.yml --report migration.sarif
 ```
 
 The SARIF is v2.1.0 and ingests by GitHub's `codeql-action/upload-sarif` or GitLab's CI integrations. Each rule carries description + `helpUri` linking back to this page.
+
+## Security posture
+
+Migration is the edge between two security endpoints — the [github](/chant/lexicons/github/lint-rules/) and [gitlab](/chant/lexicons/gitlab/lint-rules/) supply-chain checks. Security properties do **not** translate 1:1: some carry across silently, some are lost, some need re-establishing on the GitLab side. Alongside the functional provenance (Translated / Approximated / NeedsReview / Lost), `chant migrate` classifies each security-relevant property's **fate** across the boundary and emits a *Security posture* section in the Markdown report.
+
+| Property (GH → GL) | Fate | Rule | Why |
+|---|---|---|---|
+| Pinned action SHA | **Lost** | `MIG-PIN-LOST` | A GitHub SHA pin has no meaning once the action maps to a GitLab include/image — re-pin the target (WGL029 / WGL031). |
+| Least-privilege `permissions:` | **NeedsReview** | `MIG-PERMISSIONS-001` | No per-job YAML equivalent; lives in project token settings + `id_tokens` scoping (WGL033). |
+| Secret reference | **NeedsReview** | `MIG-SECRET-UNSCOPED` | `${{ secrets.X }}` → `$X` assumes a masked + protected GitLab variable, set outside the YAML (WGL038). |
+| Untrusted-input injection | **Translated (silently)** | `MIG-INJECTION-CARRIED` | An injection site translates verbatim — the risk carries across (WGL035). |
+| Trigger / fork trust boundary | **NeedsReview** | `MIG-TRUST-BOUNDARY` | `pull_request_target` → MR/fork pipelines that fork contributors can trigger; re-establish protected refs / approvals (WGL034 / WGL036). |
+
+Because both lexicons abstracted their security work to the **same core problems**, migration maps problem → problem (pin → pin, least-privilege → least-privilege), preserving the invariant rather than the syntax. Where a problem has a primitive on one side but not the other, that gap *is* a NeedsReview. Run `--validate` (above) to additionally prove the migrated YAML clears the live GitLab security checks.
 
 ## Limitations (v1)
 

--- a/lexicons/gitlab/docs/src/content/docs/skills.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/skills.mdx
@@ -31,7 +31,7 @@ The `chant-gitlab` skill covers the full deployment lifecycle:
 - **Status** — GitLab UI or pipelines API
 - **Retry** — retry failed jobs via UI or API
 - **Cancel** — cancel running pipelines via API
-- **Troubleshooting** — job logs, lint rule codes (WGL001–WGL004), post-synth checks (WGL010–WGL015)
+- **Troubleshooting** — job logs, lint rule codes (WGL001–WGL004), post-synth checks (WGL010–WGL048)
 
 The skill is invocable as a slash command: `/chant-gitlab`
 

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -30,7 +30,7 @@ npm install --save-dev @intentius/chant-lexicon-gitlab
 
 {{file:docs-snippets/src/quickstart.ts}}
 
-The lexicon provides **3 resources** (Job, Workflow, Default), **16 property types** (Image, Cache, Artifacts, Rule, Environment, Trigger, Need, Service, and more), the \`CI\` pseudo-parameter object for predefined variables, and the \`reference()\` intrinsic for YAML \`!reference\` tags.
+The lexicon provides **3 resources** (Job, Workflow, Default), **16 property types** (Image, Cache, Artifacts, Rule, Environment, Trigger, Need, Service, and more), the \`CI\` pseudo-parameter object for predefined variables, and the \`reference()\` intrinsic for YAML \`!reference\` tags. It also ships **4 lint rules** + **39 post-synth checks** (including a CI/CD supply-chain security pass, WGL029–048) and a [\`chant migrate\`](./migration) source for translating GitHub Actions workflows.
 `;
 
 const outputFormat = `The GitLab lexicon serializes resources into **\`.gitlab-ci.yml\` YAML**. Keys are
@@ -435,6 +435,90 @@ Flags jobs whose \`extends:\` references a template or hidden job not defined in
 
 Detects cycles in the \`needs:\` dependency graph. If job A needs B and B needs A (directly or transitively), GitLab rejects the pipeline. Reports the full cycle chain in the diagnostic message.
 
+### WGL016 — Secret in a variables block
+
+**Severity:** error
+
+Detects hardcoded passwords, tokens, or keys in a \`variables:\` block. Move them to CI/CD masked variables instead of committing them to the pipeline. The precursor to the WGL038–040 secret-scoping checks.
+
+### WGL017 — Insecure registry
+
+**Severity:** warning
+
+Flags Docker push/pull to a non-HTTPS registry in a job script. HTTP gives the registry traffic no transport integrity.
+
+### WGL018 — Missing timeout
+
+**Severity:** warning
+
+Flags jobs without an explicit \`timeout:\`. The instance default (often 1 hour) is too long for most jobs and lets a hung job hold a runner.
+
+### WGL019 — Missing retry on deploy jobs
+
+**Severity:** info
+
+Deploy-stage jobs benefit from a \`retry:\` strategy to ride out transient infrastructure failures. Informational, not required.
+
+### WGL020 — Duplicate job names
+
+**Severity:** error
+
+Detects multiple jobs that resolve to the same kebab-case key in the serialized YAML. GitLab silently merges duplicate keys, so one job's config quietly overwrites the other.
+
+### WGL021 — Unused variables
+
+**Severity:** warning
+
+Flags global \`variables:\` not referenced by any job script — usually stale configuration adding noise.
+
+### WGL022 — Missing artifacts expiry
+
+**Severity:** warning
+
+Flags \`artifacts:\` without \`expire_in:\`. Depending on instance config the default is "never expire," which bloats storage.
+
+### WGL023 — Overly broad rules
+
+**Severity:** info
+
+Flags a job whose only rule is \`when: always\` with no conditions (\`if:\`, \`changes:\`, …). That disables all pipeline filtering for the job, which is usually unintended.
+
+### WGL024 — Manual without allow_failure
+
+**Severity:** warning
+
+Flags \`when: manual\` jobs that don't set \`allow_failure: true\`. Without it the manual job blocks the pipeline from progressing past its stage until someone triggers it.
+
+### WGL025 — Missing cache key
+
+**Severity:** warning
+
+Flags \`cache:\` without a \`key:\`. GitLab falls back to the \`default\` key, causing cache collisions between unrelated jobs on the same runner.
+
+### WGL026 — Privileged services without TLS
+
+**Severity:** warning
+
+Flags Docker-in-Docker (DinD) services that don't set \`DOCKER_TLS_CERTDIR\`, leaving the Docker daemon on an unencrypted socket. Extended by WGL036 for the merge-request-reachable case.
+
+### WGL027 — Empty script
+
+**Severity:** error
+
+Detects jobs with \`script: []\` or only empty strings. GitLab rejects empty scripts at pipeline validation time.
+
+### WGL028 — Redundant needs
+
+**Severity:** info
+
+Detects \`needs:\` entries already implied by stage ordering. Not incorrect, but redundant needs add noise and make the pipeline harder to maintain.
+
+## Supply-chain security pass (WGL029–048)
+
+WGL029 onward are a CI/CD supply-chain security pass, the GitLab counterpart to the github lexicon's GHA029–058: pin & vet includes/components/images, scope \`CI_JOB_TOKEN\` and OIDC, guard trust boundaries against untrusted CI input, mask/protect/scope secrets, reject unsound \`rules:\` expressions, and keep artifacts/caches honest. They run statically on the emitted \`.gitlab-ci.yml\`.
+
+The checks that need a *moving external truth* — whether a pinned component/include ref still resolves, whether an upstream was archived or moved, whether a new advisory covers a component in use — live in the operational layer instead. Schedule the [\`PipelineAuditOp\`](/chant/guide/ops/#audit-supply-chain-drift) (temporal lexicon) for that live half; it reads the emitted \`include:\` / \`component:\` / \`image:\` references and reports drift via \`report | issue | merge-request\`.
+
 ### WGL029 — Unpinned include:project / component
 
 **Severity:** warning
@@ -779,7 +863,7 @@ The \`chant-gitlab\` skill covers the full deployment lifecycle:
 - **Status** — GitLab UI or pipelines API
 - **Retry** — retry failed jobs via UI or API
 - **Cancel** — cancel running pipelines via API
-- **Troubleshooting** — job logs, lint rule codes (WGL001–WGL004), post-synth checks (WGL010–WGL015)
+- **Troubleshooting** — job logs, lint rule codes (WGL001–WGL004), post-synth checks (WGL010–WGL048)
 
 The skill is invocable as a slash command: \`/chant-gitlab\`
 

--- a/lexicons/temporal/docs/src/content/docs/ops.mdx
+++ b/lexicons/temporal/docs/src/content/docs/ops.mdx
@@ -173,6 +173,36 @@ chant graph
 | `activities.ts` | Re-exports all pre-built activities from the lexicon package |
 | `worker.ts` | Worker bootstrap — reads profile from `chant.config.js`, connects to Temporal |
 
+## Pre-built Op composites
+
+Beyond hand-written `Op({...})` definitions, the lexicon ships composites that assemble an Op (and an optional `TemporalSchedule`) for common operational patterns:
+
+| Composite | Purpose |
+|---|---|
+| `WatchOp` | Recurring drift detection — `chant lifecycle snapshot` / `diff --live` on a cron |
+| `ReconcileOp` | `cloud → code` — regenerate drifted TypeScript and open a PR |
+| `ApplyOp` | `code → cloud` — native apply (`kubectl apply` / CloudFormation / ARM), gated and compensated |
+| `WorkflowAuditOp` | Live supply-chain audit of GitHub workflows — resolve action/image references upstream, flag stale pins, impostor refs, advisories, archived upstreams |
+| `PipelineAuditOp` | Live audit of GitLab pipelines — resolve `include:` / `component:` / `image:` references upstream |
+
+The two audit composites are the always-fresh counterpart to the deterministic supply-chain checks in the github ([GHA029–058](/chant/lexicons/github/lint-rules/)) and gitlab ([WGL029–048](/chant/lexicons/gitlab/lint-rules/)) lexicons: the build owns everything answerable statically, the Op owns only what needs live resolution against a moving upstream.
+
+```typescript
+import { WorkflowAuditOp } from "@intentius/chant-lexicon-temporal";
+
+// One-shot on the local executor (no Temporal): chant run actions-audit
+export const { op } = WorkflowAuditOp({ name: "actions-audit" });
+
+// Scheduled daily on Temporal; open a PR bumping any stale pin
+export const { op: scheduled, schedule } = WorkflowAuditOp({
+  name: "actions-audit",
+  schedule: "0 6 * * *",
+  onFinding: "pull-request",   // "report" (default) | "issue" | "pull-request"
+});
+```
+
+`PipelineAuditOp` takes the same shape; its finding-modes are `report | issue | merge-request`. See [Ops (core guide)](/chant/guide/ops/#audit-supply-chain-drift) for the full lifecycle framing.
+
 ## chant run CLI
 
 ```bash


### PR DESCRIPTION
Brings core + lexicon docs to parity with the closed **CI/CD pipeline security audit** milestone (epics #296 GitHub, #305 GitLab) and the cross-cutting security-aware migration (#306). Audit found the new security lint checks (GHA029–058 / WGL029–048) were documented, but the surrounding features and a pre-existing lint band were not.

## Coverage fixes

- **Lint bands backfilled** — GitHub `GHA021–028` and GitLab `WGL016–028` were active but never documented (pre-existing gap). Source-vs-doc ID diff is now empty for both lexicons.
- **Supply-chain pass sections** — `GHA029–058` / `WGL029–048` now get a dedicated section in each lint page that splits the static post-synth checks from the live audit Op.
- **Dependabot** (#294) — new composites section documenting the `Dependabot` composite + `DependabotConfig` resource and its `GHA057`/`GHA058` checks.
- **Audit Ops** (#292, #303) — `WorkflowAuditOp` / `PipelineAuditOp` documented in core `guide/ops` (new "Audit (supply-chain drift)" section), the temporal lexicon `ops.mdx` (pre-built composites table), and cross-linked from both lexicon lint pages.
- **Security-aware migration** (#306) — new "Security posture" section in `gitlab/migration.mdx` (fate classification + `MIG-*` security rules table), and the `--validate` security backend is now documented.
- **whats-new** — added the milestone rollup.
- **Stale counts** — fixed resource/composite/check counts and ID ranges across lexicon summaries and the core lexicons overview.

## Mechanism note

Lexicon lint pages are generated from each lexicon's `src/codegen/docs.ts` (not the lint registry), so those edits were made to the codegen templates and regenerated via `docs-cli.ts`. `migration.mdx`, `whats-new.mdx`, core `guide/ops.mdx`, and temporal `ops.mdx` are hand-authored and edited directly.

## Verification

- Source-vs-doc lint-ID diff empty for both lexicons (GHA001–058, WGL001–048 all present)
- All added cross-link anchors resolve in built HTML
- Core docs + github/gitlab/temporal doc sites all build clean

Note: the `GHA021–028` / `WGL016–028` backfill predates this milestone — folded in here since it was the same surface, but flagging it as out-of-milestone scope.