### PR TITLE
feat(gitlab): read-only context MCP tools (#327, closes #328)

### DIFF
--- a/docs/src/content/docs/guide/agent-integration.mdx
+++ b/docs/src/content/docs/guide/agent-integration.mdx
@@ -71,6 +71,22 @@ To configure manually, add the chant MCP server to your IDE's MCP config:
 
 Lexicon plugins can contribute additional tools and resources.
 
+### Read-only context tools
+
+Some lexicons add **read-only context tools** that build from your source and return what chant already computes — without touching any live system. They give an agent a *before-it-runs* view of your infrastructure: what a change does, what it pulls in, and whether it is safe, **before it runs or merges**. This is the window live tooling can't see.
+
+The GitLab lexicon ships the first set:
+
+| MCP tool | Answers |
+|----------|---------|
+| `gitlab:checks` | Is there anything risky in this pipeline? (returns the security findings) |
+| `gitlab:pipeline` | What does this pipeline do? (stages, jobs, run order) |
+| `gitlab:references` | What does it pull in from outside, and is it pinned? |
+| `gitlab:affected` | If I change this job, what re-runs? |
+| `gitlab:pipeline-yaml` | The generated `.gitlab-ci.yml` |
+
+Every one of these reads the build only — no live instance, no run history, no writes. That boundary is deliberate: chant is a context *producer*, complementary to (not a copy of) the live tooling an agent already uses.
+
 ## Ops
 
 Ops are named, phased Temporal workflows defined in `*.op.ts` files. They run durable deployments — phases, gate steps that pause for human signals, compensation on failure — and surface progress in the Temporal UI.

--- a/lexicons/gitlab/docs/src/content/docs/skills.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/skills.mdx
@@ -54,6 +54,13 @@ The lexicon also provides MCP (Model Context Protocol) tools and resources that 
 | `search` | Search available resource types |
 | `gitlab:diff` | Compare current build output against previous |
 | `gitlab:migrate` | Translate a GitHub Actions workflow into GitLab CI/CD (see [Migration](../migration)) |
+| `gitlab:checks` | Build and return the pipeline's security/correctness findings (the WGL checks) |
+| `gitlab:pipeline` | Build and return the pipeline's stages and jobs (name, stage, run order), as written |
+| `gitlab:references` | Build and list what the pipeline pulls in (includes, components, images) and whether each is pinned |
+| `gitlab:affected` | Given a job, list the jobs that would re-run because they depend on it |
+| `gitlab:pipeline-yaml` | Build and return the generated `.gitlab-ci.yml` |
+
+The `gitlab:checks` / `gitlab:pipeline` / `gitlab:references` / `gitlab:affected` / `gitlab:pipeline-yaml` tools are **read-only**: they build from source and never touch the live GitLab instance. They give an agent a *before-it-runs* view of the pipeline — what it does, what it pulls in, and whether it is safe — to complement the *after-it-ran* view it gets from the instance.
 
 | MCP resource | Description |
 |--------------|-------------|

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -886,6 +886,13 @@ The lexicon also provides MCP (Model Context Protocol) tools and resources that 
 | \`search\` | Search available resource types |
 | \`gitlab:diff\` | Compare current build output against previous |
 | \`gitlab:migrate\` | Translate a GitHub Actions workflow into GitLab CI/CD (see [Migration](../migration)) |
+| \`gitlab:checks\` | Build and return the pipeline's security/correctness findings (the WGL checks) |
+| \`gitlab:pipeline\` | Build and return the pipeline's stages and jobs (name, stage, run order), as written |
+| \`gitlab:references\` | Build and list what the pipeline pulls in (includes, components, images) and whether each is pinned |
+| \`gitlab:affected\` | Given a job, list the jobs that would re-run because they depend on it |
+| \`gitlab:pipeline-yaml\` | Build and return the generated \`.gitlab-ci.yml\` |
+
+The \`gitlab:checks\` / \`gitlab:pipeline\` / \`gitlab:references\` / \`gitlab:affected\` / \`gitlab:pipeline-yaml\` tools are **read-only**: they build from source and never touch the live GitLab instance. They give an agent a *before-it-runs* view of the pipeline — what it does, what it pulls in, and whether it is safe — to complement the *after-it-ran* view it gets from the instance.
 
 | MCP resource | Description |
 |--------------|-------------|

--- a/lexicons/gitlab/src/mcp/context-tools.test.ts
+++ b/lexicons/gitlab/src/mcp/context-tools.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { gitlabContextTools, downstreamJobs, componentPinned } from "./context-tools";
+
+const tools = Object.fromEntries(gitlabContextTools().map((t) => [t.name, t]));
+
+async function call(name: string, params: Record<string, unknown>): Promise<unknown> {
+  return tools[name].handler(params);
+}
+
+describe("downstreamJobs / componentPinned (#327)", () => {
+  test("downstreamJobs follows the needs chain transitively", () => {
+    const yaml = `build:
+  stage: build
+  script:
+    - echo build
+
+test:
+  stage: test
+  needs:
+    - build
+  script:
+    - echo test
+
+deploy:
+  stage: deploy
+  needs:
+    - test
+  script:
+    - echo deploy
+`;
+    expect(downstreamJobs(yaml, "build").sort()).toEqual(["deploy", "test"]);
+    expect(downstreamJobs(yaml, "test")).toEqual(["deploy"]);
+    expect(downstreamJobs(yaml, "deploy")).toEqual([]);
+  });
+
+  test("componentPinned recognises a fixed version", () => {
+    expect(componentPinned("gitlab.com/g/comp@1.2.3")).toBe(true);
+    expect(componentPinned("gitlab.com/g/comp@main")).toBe(false);
+  });
+});
+
+describe("gitlab context tools — end to end (#327/#328)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = join(tmpdir(), `chant-mcp-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "pipeline.infra.ts"),
+      `const M = Symbol.for("chant.declarable");
+export const buildApp = { [M]: true, lexicon: "gitlab", entityType: "GitLab::CI::Job", kind: "resource",
+  props: { stage: "build", image: { name: "node:20" }, script: ["echo build"] } };
+export const testApp = { [M]: true, lexicon: "gitlab", entityType: "GitLab::CI::Job", kind: "resource",
+  props: { stage: "test", script: ["npm test"], needs: ["build-app"] } };
+`,
+    );
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("gitlab:pipeline returns stages and jobs", async () => {
+    const out = (await call("gitlab:pipeline", { path: dir })) as {
+      stages: string[];
+      jobs: Array<{ name: string; stage: string | null; runsAfter: string[] }>;
+    };
+    expect(out.stages).toEqual(expect.arrayContaining(["build", "test"]));
+    const names = out.jobs.map((j) => j.name);
+    expect(names).toEqual(expect.arrayContaining(["build-app", "test-app"]));
+    expect(out.jobs.find((j) => j.name === "test-app")?.runsAfter).toContain("build-app");
+  });
+
+  test("gitlab:references reports the unpinned image", async () => {
+    const out = (await call("gitlab:references", { path: dir })) as Array<{ kind: string; source: string; pinned: boolean | null }>;
+    const img = out.find((r) => r.kind === "image" && r.source === "node:20");
+    expect(img).toBeDefined();
+    expect(img?.pinned).toBe(false);
+  });
+
+  test("gitlab:checks returns the WGL findings (unpinned image trips WGL031)", async () => {
+    const out = (await call("gitlab:checks", { path: dir })) as { findings: Array<{ id: string; severity: string; job: string | null; message: string }> };
+    expect(Array.isArray(out.findings)).toBe(true);
+    expect(out.findings.some((f) => f.id === "WGL031")).toBe(true);
+    for (const f of out.findings) {
+      expect(typeof f.id).toBe("string");
+      expect(typeof f.message).toBe("string");
+    }
+  });
+
+  test("gitlab:affected lists downstream jobs", async () => {
+    const out = (await call("gitlab:affected", { path: dir, job: "build-app" })) as { job: string; wouldRerun: string[] };
+    expect(out.wouldRerun).toContain("test-app");
+  });
+
+  test("gitlab:pipeline-yaml returns the generated YAML for a path", async () => {
+    const out = (await call("gitlab:pipeline-yaml", { path: dir })) as { yaml: string };
+    expect(typeof out.yaml).toBe("string");
+    expect(out.yaml).toContain("stages:");
+  });
+});

--- a/lexicons/gitlab/src/mcp/context-tools.ts
+++ b/lexicons/gitlab/src/mcp/context-tools.ts
@@ -1,0 +1,168 @@
+/**
+ * Read-only MCP tools that expose what `chant build` already computes about a
+ * GitLab pipeline — its stages and jobs, what it pulls in from outside, its
+ * security findings — so an agent can ask about a change *before it runs or
+ * merges* (#327, #328).
+ *
+ * Every tool here builds from source and returns data. None of them touch the
+ * live GitLab instance, read run history, or write anything — that boundary is
+ * what keeps chant a context producer and not a copy of the live tooling.
+ */
+
+import { build, type BuildResult } from "@intentius/chant/build";
+import { runPostSynthChecks, getPrimaryOutput } from "@intentius/chant/lint/post-synth";
+import { discoverPostSynthChecks } from "@intentius/chant/lint/discover";
+import type { McpToolContribution } from "@intentius/chant/mcp/types";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { gitlabSerializer } from "../serializer";
+import {
+  extractStages,
+  extractJobs,
+  extractIncludes,
+  extractImageRefs,
+  isPinnedRef,
+} from "../lint/post-synth/yaml-helpers";
+
+/** Build the project and return the emitted GitLab YAML plus the raw result. */
+async function buildGitlab(path: string): Promise<{ yaml: string; result: BuildResult }> {
+  const result = await build(path, [gitlabSerializer]);
+  const out = result.outputs.get("gitlab");
+  return { yaml: out ? getPrimaryOutput(out) : "", result };
+}
+
+/** Discover the lexicon's post-synth checks without depending on the plugin. */
+function gitlabPostSynthChecks() {
+  const dir = join(dirname(fileURLToPath(import.meta.url)), "..", "lint", "post-synth");
+  return discoverPostSynthChecks(dir, import.meta.url);
+}
+
+/** Is a component address (`host/group/comp@version`) pinned to a fixed version? */
+export function componentPinned(value: string): boolean {
+  const at = value.lastIndexOf("@");
+  return at !== -1 && isPinnedRef(value.slice(at + 1));
+}
+
+/** Jobs that would re-run because they depend (transitively) on `job`. */
+export function downstreamJobs(yaml: string, job: string): string[] {
+  const jobs = extractJobs(yaml);
+  // edge: upstream -> downstream (J depends on each of its needs)
+  const downstreamOf = new Map<string, string[]>();
+  for (const [name, j] of jobs) {
+    for (const dep of j.needs ?? []) {
+      const arr = downstreamOf.get(dep) ?? [];
+      arr.push(name);
+      downstreamOf.set(dep, arr);
+    }
+  }
+  const out = new Set<string>();
+  const queue = [job];
+  while (queue.length) {
+    const cur = queue.shift()!;
+    for (const next of downstreamOf.get(cur) ?? []) {
+      if (!out.has(next)) {
+        out.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  return [...out];
+}
+
+const PATH_INPUT = {
+  type: "object" as const,
+  properties: {
+    path: { type: "string", description: "Path to the chant project directory (default: current directory)" },
+  },
+};
+
+/** The read-only context tools for the GitLab lexicon. */
+export function gitlabContextTools(): McpToolContribution[] {
+  return [
+    {
+      name: "gitlab:checks",
+      description:
+        "Build the pipeline and return its security and correctness findings (the WGL checks) as JSON. Read-only — does not touch the live GitLab instance.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml, result } = await buildGitlab((params.path as string) ?? ".");
+        if (!yaml) return { findings: [], note: "no GitLab pipeline produced from this project" };
+        const scoped = { ...result, outputs: new Map([["gitlab", result.outputs.get("gitlab")!]]) };
+        const diags = runPostSynthChecks(gitlabPostSynthChecks(), scoped);
+        return {
+          findings: diags.map((d) => ({
+            id: d.checkId,
+            severity: d.severity,
+            job: d.entity ?? null,
+            message: d.message,
+          })),
+        };
+      },
+    },
+    {
+      name: "gitlab:pipeline",
+      description:
+        "Build the pipeline and return its stages and jobs as written (name, stage, and what each job runs after) — before anything runs. Read-only.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildGitlab((params.path as string) ?? ".");
+        const jobs = [...extractJobs(yaml).values()].map((j) => ({
+          name: j.name,
+          stage: j.stage ?? null,
+          runsAfter: j.needs ?? [],
+        }));
+        return { stages: extractStages(yaml), jobs };
+      },
+    },
+    {
+      name: "gitlab:references",
+      description:
+        "Build the pipeline and list everything it pulls in from outside (includes, components, images) and whether each is pinned to a fixed version. Read-only.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildGitlab((params.path as string) ?? ".");
+        const includes = extractIncludes(yaml).map((e) => ({
+          kind: e.kind,
+          source: e.value,
+          ref: e.ref ?? null,
+          pinned:
+            e.kind === "project" ? (e.ref ? isPinnedRef(e.ref) : false) : e.kind === "component" ? componentPinned(e.value) : null,
+        }));
+        const images = extractImageRefs(yaml).map((i) => ({
+          kind: "image" as const,
+          source: i.image,
+          ref: null,
+          pinned: i.image.includes("@sha256:"),
+        }));
+        return [...includes, ...images];
+      },
+    },
+    {
+      name: "gitlab:affected",
+      description:
+        "Build the pipeline and, given a job name, list the jobs that would re-run because they depend on it (the needs chain). Read-only.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          path: { type: "string", description: "Path to the chant project directory (default: current directory)" },
+          job: { type: "string", description: "Job name to trace downstream from" },
+        },
+        required: ["job"],
+      },
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildGitlab((params.path as string) ?? ".");
+        const job = params.job as string;
+        return { job, wouldRerun: downstreamJobs(yaml, job) };
+      },
+    },
+    {
+      name: "gitlab:pipeline-yaml",
+      description: "Build the project and return the generated .gitlab-ci.yml as a string. Read-only.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildGitlab((params.path as string) ?? ".");
+        return { yaml };
+      },
+    },
+  ];
+}

--- a/lexicons/gitlab/src/plugin.test.ts
+++ b/lexicons/gitlab/src/plugin.test.ts
@@ -238,6 +238,12 @@ describe("gitlabPlugin", () => {
     const names = tools.map((t) => t.name);
     expect(names).toContain("gitlab:diff");
     expect(names).toContain("migrate");
+    // Read-only context tools (#327/#328)
+    expect(names).toContain("gitlab:checks");
+    expect(names).toContain("gitlab:pipeline");
+    expect(names).toContain("gitlab:references");
+    expect(names).toContain("gitlab:affected");
+    expect(names).toContain("gitlab:pipeline-yaml");
     for (const t of tools) {
       expect(typeof t.handler).toBe("function");
     }

--- a/lexicons/gitlab/src/plugin.ts
+++ b/lexicons/gitlab/src/plugin.ts
@@ -12,6 +12,7 @@ import { createSkillsLoader, createDiffTool, createCatalogResource } from "@inte
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { gitlabSerializer } from "./serializer";
+import { gitlabContextTools } from "./mcp/context-tools";
 import { deprecatedOnlyExceptRule } from "./lint/rules/deprecated-only-except";
 import { missingScriptRule } from "./lint/rules/missing-script";
 import { missingStageRule } from "./lint/rules/missing-stage";
@@ -254,6 +255,9 @@ export const test = new Job({
   mcpTools() {
     return [
       createDiffTool(gitlabSerializer, "Compare current build output against previous output for GitLab CI", "gitlab"),
+      // Read-only context tools: what the pipeline does, what it pulls in, and
+      // its security findings — before anything runs (#327/#328).
+      ...gitlabContextTools(),
       {
         name: "migrate",
         description: "Translate a GitHub Actions workflow YAML into a GitLab CI/CD pipeline. Returns the rendered output plus diagnostic + provenance arrays.",


### PR DESCRIPTION
Advances the context-producer epic #327 and **closes #328**.

Exposes what `chant build` already computes about a pipeline as **read-only MCP tools**, so an agent can ask about a change *before it runs or merges* — the window the live GitLab instance can't see.

| Tool | Answers |
|------|---------|
| `gitlab:checks` (#328) | Is there anything risky here? (the WGL security findings) |
| `gitlab:pipeline` | What does this pipeline do? (stages, jobs, run order) |
| `gitlab:references` | What does it pull in, and is it pinned? |
| `gitlab:affected` | If I change this job, what re-runs? |
| `gitlab:pipeline-yaml` | The generated `.gitlab-ci.yml` |

### Design
- New module `lexicons/gitlab/src/mcp/context-tools.ts`; spread into the plugin's `mcpTools()`. Reuses core `build()` + `runPostSynthChecks` + the existing `extract*` helpers — wiring, not new capability.
- **Read-only boundary:** every handler builds from source only — no live instance, no run history, no writes. `pipeline-yaml` is a *tool* with a path param (not a param-less resource) precisely so it never builds an unintended cwd.

### Tests / docs
- Unit tests for the pure helpers (`downstreamJobs`, `componentPinned`) + an end-to-end test that builds a fixture and exercises every tool (e.g. the unpinned image trips `WGL031` via `gitlab:checks`).
- Plugin test asserts all five tools are registered.
- Docs audited per request: gitlab MCP table updated + a read-only/before-it-runs note; new **"Read-only context tools"** section in core `guide/agent-integration.mdx`.
- `npx vitest run` green for the gitlab lexicon (612); eslint + core `tsc` clean.

Deferred (with reasons, tracked in #327): `gitlab:source`/`gitlab:compare` (per-line provenance only exists via the migration path), a standalone `gitlab:owns` (build-time pipeline ownership adds little over `gitlab:pipeline`; the resource-level ownership marker is a separate, live concern), and the parallel `github:*` set (follow-on).