### PR TITLE
feat(gitlab): chant plan as GitLab MR plan widget (#329)

### DIFF
--- a/docs/src/content/docs/cli/lifecycle.mdx
+++ b/docs/src/content/docs/cli/lifecycle.mdx
@@ -9,7 +9,7 @@ description: Capture, diff, and plan against deployed infrastructure — the obs
 chant lifecycle snapshot <env> [lexicon] [--src <dir>]
 chant lifecycle show <env>
 chant lifecycle diff <env> [--live] [--src <dir>]
-chant lifecycle plan <env> [--json] [--owned] [--src <dir>]
+chant lifecycle plan <env> [lexicon] [--json] [--owned] [--report gitlab-mr] [--src <dir>]
 chant lifecycle affected --base <ref> [--head <ref>] [--include-dependents] [--json]
 chant lifecycle log [env]
 ```
@@ -118,6 +118,19 @@ The six `diff --live` categories and the five `plan` actions describe the same s
 | **disappeared** | **create** if still declared, else **noop** | A snapshot-history signal; the plan reads live + source, not snapshot age |
 
 The "when declared" qualifiers are where the axes diverge: an undeclared resource that also **drifted** or is **unchanged** is still an **orphan** to the plan — the snapshot history doesn't change that it's live-but-undeclared, so ownership decides between `adopt` and `delete`.
+
+#### Reporting to a GitLab merge request
+
+`--report gitlab-mr` emits the plan as the JSON GitLab reads for its merge-request plan widget:
+
+```bash
+chant lifecycle plan prod --report gitlab-mr > tfplan.json
+# {"create":3,"update":1,"delete":0}
+```
+
+Declare the file as `artifacts:reports:terraform` and GitLab renders "3 to add, 1 to change, 0 to delete" on the MR. The widget format is generic — any tool that emits this JSON gets it — so the plan maps onto it directly. Only the mutating actions count: `adopt` and `noop` are excluded, since the widget has no column for live-but-undeclared or no-change.
+
+The widget label always reads "Terraform" — that is GitLab's fixed string, not a claim chant makes. The GitLab lexicon ships an [`MrPlanReport`](/chant/lexicons/gitlab/examples/#merge-request-plan-widget) composite that wires the job for you.
 
 ### Resources vs artifacts
 

--- a/lexicons/gitlab/docs/src/content/docs/examples.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/examples.mdx
@@ -194,6 +194,29 @@ export const test = new Job({
 });
 ```
 
+## Merge-request plan widget
+
+The `MrPlanReport` composite turns `chant lifecycle plan` into the GitLab merge-request plan widget — the "N to add, M to change, K to delete" summary GitLab renders from an `artifacts:reports:terraform` artifact:
+
+```typescript
+import { MrPlanReport } from "@intentius/chant-lexicon-gitlab";
+
+export const plan = MrPlanReport({
+  environment: "prod",
+  // credential setup — the plan queries the live system to classify drift
+  before: ["aws sts get-caller-identity"],
+});
+```
+
+The job runs `chant lifecycle plan prod --report gitlab-mr`, writes the count JSON to `tfplan.json`, and declares it as `artifacts:reports:terraform`. On the merge request, GitLab shows the plan summary inline.
+
+Caveats worth knowing:
+
+- The widget label always reads **"Terraform"** — that is GitLab's fixed string for this report type, not a claim chant makes.
+- It is **counts only** (create/update/delete). `adopt` and `noop` are excluded, since the widget has no column for live-but-undeclared or no-change. There is no per-resource breakdown — run `chant lifecycle plan` in the job log for that.
+- It is a **GitLab-only** surface. The same plan JSON is portable, but the widget is GitLab's.
+- The plan reads the live system, so the job needs cloud credentials — wire them via `before` or CI variables.
+
 ## AWS ALB Deployment
 
 A cross-lexicon example showing how to deploy AWS CloudFormation stacks from GitLab CI. Three separate pipelines mirror the separate-project AWS ALB pattern:

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -789,6 +789,29 @@ The \`DockerBuild\` composite expands to a job with Docker-in-Docker service, re
 
 {{file:review-app/src/pipeline.ts}}
 
+## Merge-request plan widget
+
+The \`MrPlanReport\` composite turns \`chant lifecycle plan\` into the GitLab merge-request plan widget — the "N to add, M to change, K to delete" summary GitLab renders from an \`artifacts:reports:terraform\` artifact:
+
+\`\`\`typescript
+import { MrPlanReport } from "@intentius/chant-lexicon-gitlab";
+
+export const plan = MrPlanReport({
+  environment: "prod",
+  // credential setup — the plan queries the live system to classify drift
+  before: ["aws sts get-caller-identity"],
+});
+\`\`\`
+
+The job runs \`chant lifecycle plan prod --report gitlab-mr\`, writes the count JSON to \`tfplan.json\`, and declares it as \`artifacts:reports:terraform\`. On the merge request, GitLab shows the plan summary inline.
+
+Caveats worth knowing:
+
+- The widget label always reads **"Terraform"** — that is GitLab's fixed string for this report type, not a claim chant makes.
+- It is **counts only** (create/update/delete). \`adopt\` and \`noop\` are excluded, since the widget has no column for live-but-undeclared or no-change. There is no per-resource breakdown — run \`chant lifecycle plan\` in the job log for that.
+- It is a **GitLab-only** surface. The same plan JSON is portable, but the widget is GitLab's.
+- The plan reads the live system, so the job needs cloud credentials — wire them via \`before\` or CI variables.
+
 ## AWS ALB Deployment
 
 A cross-lexicon example showing how to deploy AWS CloudFormation stacks from GitLab CI. Three separate pipelines mirror the separate-project AWS ALB pattern:

--- a/lexicons/gitlab/src/composites/composites.test.ts
+++ b/lexicons/gitlab/src/composites/composites.test.ts
@@ -4,6 +4,7 @@ import { DockerBuild } from "./docker-build";
 import { NodePipeline, BunPipeline, PnpmPipeline } from "./node-pipeline";
 import { PythonPipeline } from "./python-pipeline";
 import { ReviewApp } from "./review-app";
+import { MrPlanReport } from "./mr-plan-report";
 
 // ---------------------------------------------------------------------------
 // DockerBuild
@@ -701,5 +702,62 @@ describe("ReviewApp", () => {
     });
     const props = (instance.stop as any).props;
     expect(props.allow_failure).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MrPlanReport (#329)
+// ---------------------------------------------------------------------------
+describe("MrPlanReport", () => {
+  test("returns a single plan member", () => {
+    const instance = MrPlanReport({ environment: "prod" });
+    expect(instance.plan).toBeDefined();
+    expect(Object.keys(instance.members)).toEqual(["plan"]);
+    expect(isCompositeInstance(instance)).toBe(true);
+  });
+
+  test("declares the terraform report artifact", () => {
+    const props = (MrPlanReport({ environment: "prod" }).plan as any).props;
+    const artifacts = (props.artifacts as any).props;
+    expect(artifacts.reports.terraform).toBe("tfplan.json");
+  });
+
+  test("runs the plan with --report gitlab-mr and redirects to the report file", () => {
+    const props = (MrPlanReport({ environment: "prod" }).plan as any).props;
+    expect(props.script).toContain("npx chant build");
+    expect(props.script.some((s: string) => s.includes("lifecycle plan prod --report gitlab-mr > tfplan.json"))).toBe(true);
+  });
+
+  test("default stage is plan", () => {
+    const props = (MrPlanReport({ environment: "prod" }).plan as any).props;
+    expect(props.stage).toBe("plan");
+  });
+
+  test("lexicon, owned, and custom report file flow into the command", () => {
+    const props = (MrPlanReport({
+      environment: "staging",
+      lexicon: "gitlab",
+      ownedOnly: true,
+      reportFile: "plan.json",
+    }).plan as any).props;
+    const cmd = props.script.find((s: string) => s.includes("lifecycle plan"));
+    expect(cmd).toContain("lifecycle plan staging gitlab --owned --report gitlab-mr > plan.json");
+    expect((props.artifacts as any).props.reports.terraform).toBe("plan.json");
+  });
+
+  test("before commands become before_script (credential setup)", () => {
+    const props = (MrPlanReport({
+      environment: "prod",
+      before: ["gcloud auth ..."],
+    }).plan as any).props;
+    expect(props.before_script).toEqual(["gcloud auth ..."]);
+  });
+
+  test("per-member defaults override the plan job", () => {
+    const props = (MrPlanReport({
+      environment: "prod",
+      defaults: { plan: { tags: ["plan-runner"] } },
+    }).plan as any).props;
+    expect(props.tags).toEqual(["plan-runner"]);
   });
 });

--- a/lexicons/gitlab/src/composites/index.ts
+++ b/lexicons/gitlab/src/composites/index.ts
@@ -6,3 +6,5 @@ export { PythonPipeline } from "./python-pipeline";
 export type { PythonPipelineProps } from "./python-pipeline";
 export { ReviewApp } from "./review-app";
 export type { ReviewAppProps } from "./review-app";
+export { MrPlanReport } from "./mr-plan-report";
+export type { MrPlanReportProps } from "./mr-plan-report";

--- a/lexicons/gitlab/src/composites/mr-plan-report.ts
+++ b/lexicons/gitlab/src/composites/mr-plan-report.ts
@@ -1,0 +1,82 @@
+import { Composite, mergeDefaults } from "@intentius/chant";
+import { Job, Image, Artifacts } from "../generated";
+
+export interface MrPlanReportProps {
+  /**
+   * Lifecycle environment to plan against — the `<environment>` argument of
+   * `chant lifecycle plan`.
+   */
+  environment: string;
+  /** Restrict the plan to one lexicon (the optional `[lexicon]` argument). */
+  lexicon?: string;
+  /** Stage for the plan job. Default: `"plan"` */
+  stage?: string;
+  /** Image to run chant in. Default: `"node:22-alpine"` */
+  image?: string;
+  /** Plan against chant-owned resources only (passes `--owned`). */
+  ownedOnly?: boolean;
+  /** Artifact filename the report is written to. Default: `"tfplan.json"` */
+  reportFile?: string;
+  /**
+   * Commands to run before the plan — typically cloud-credential setup, since
+   * the plan queries the live system to classify create/update/delete.
+   */
+  before?: string[];
+  /** Per-member defaults for customizing the generated job. */
+  defaults?: {
+    plan?: Partial<ConstructorParameters<typeof Job>[0]>;
+  };
+}
+
+/**
+ * A CI job that publishes `chant lifecycle plan` as the GitLab merge-request
+ * plan widget.
+ *
+ * The job runs the plan with `--report gitlab-mr`, writes the count JSON to a
+ * file, and declares it as `artifacts:reports:terraform`. GitLab then renders
+ * "N to add, M to change, K to delete" on the MR — the same widget Terraform
+ * uses. The label reads "Terraform" regardless of producer; that is GitLab's
+ * fixed string. Counts are create/update/delete only — `adopt` and `noop` do
+ * not appear.
+ *
+ * The plan reads the live system to classify drift, so wire cloud credentials
+ * via `before` or CI variables.
+ */
+export const MrPlanReport = Composite<MrPlanReportProps>((props) => {
+  const {
+    environment,
+    lexicon,
+    stage = "plan",
+    image = "node:22-alpine",
+    ownedOnly = false,
+    reportFile = "tfplan.json",
+    before,
+    defaults: defs,
+  } = props;
+
+  const planArgs = [
+    "lifecycle",
+    "plan",
+    environment,
+    ...(lexicon ? [lexicon] : []),
+    ...(ownedOnly ? ["--owned"] : []),
+    "--report",
+    "gitlab-mr",
+  ].join(" ");
+
+  const plan = new Job(mergeDefaults({
+    stage,
+    image: new Image({ name: image }),
+    ...(before ? { before_script: before } : {}),
+    script: [
+      "npx chant build",
+      `npx chant ${planArgs} > ${reportFile}`,
+    ],
+    artifacts: new Artifacts({
+      reports: { terraform: reportFile },
+      when: "always",
+    }),
+  }, defs?.plan));
+
+  return { plan };
+}, "MrPlanReport");

--- a/lexicons/gitlab/src/index.ts
+++ b/lexicons/gitlab/src/index.ts
@@ -15,8 +15,8 @@ export { CI } from "./variables";
 export * from "./generated/index";
 
 // Composites
-export { DockerBuild, NodePipeline, BunPipeline, PnpmPipeline, PythonPipeline, ReviewApp } from "./composites/index";
-export type { DockerBuildProps, NodePipelineProps, PythonPipelineProps, ReviewAppProps } from "./composites/index";
+export { DockerBuild, NodePipeline, BunPipeline, PnpmPipeline, PythonPipeline, ReviewApp, MrPlanReport } from "./composites/index";
+export type { DockerBuildProps, NodePipelineProps, PythonPipelineProps, ReviewAppProps, MrPlanReportProps } from "./composites/index";
 
 // Spec utilities (for tooling)
 export { fetchCISchema, fetchSchemas, GITLAB_SCHEMA_VERSION } from "./codegen/fetch";

--- a/lexicons/gitlab/src/skills/chant-gitlab-patterns.md
+++ b/lexicons/gitlab/src/skills/chant-gitlab-patterns.md
@@ -197,6 +197,21 @@ export const app = NodePipeline({
 });
 ```
 
+### Publish the plan to the merge request
+
+`MrPlanReport` turns `chant lifecycle plan` into the MR plan widget (the `terraform` artifact type above). It runs the plan with `--report gitlab-mr`, writes the `{create,update,delete}` counts to `tfplan.json`, and declares it as `artifacts:reports:terraform`:
+
+```typescript
+import { MrPlanReport } from "@intentius/chant-lexicon-gitlab";
+
+export const plan = MrPlanReport({
+  environment: "prod",
+  before: ["aws sts get-caller-identity"], // credential setup — the plan reads live state
+});
+```
+
+The widget label always reads "Terraform" (GitLab's fixed string). Counts only — `adopt`/`noop` are excluded; run the plan in the job log for the per-resource breakdown.
+
 ## Rules and Conditional Execution
 
 ### Branch-Based Rules

--- a/packages/core/src/cli/handlers/lifecycle.ts
+++ b/packages/core/src/cli/handlers/lifecycle.ts
@@ -4,7 +4,7 @@ import { takeSnapshot } from "../../lifecycle/snapshot";
 import { readSnapshot, readEnvironmentSnapshots, listSnapshots, fetchLifecycle, StaleLifecycleBranchError } from "../../lifecycle/git";
 import { computeBuildDigest, diffDigests } from "../../lifecycle/digest";
 import { diffLive, diffLiveArtifacts, type LiveDiffResult, type LiveArtifactDiffResult } from "../../lifecycle/live-diff";
-import { buildChangeSet, renderChangeSet, type ChangeSet } from "../../lifecycle/change-set";
+import { buildChangeSet, renderChangeSet, gitlabMrReport, type ChangeSet } from "../../lifecycle/change-set";
 import { affectedStacks } from "../../lifecycle/affected";
 import { loadChantConfig } from "../../config";
 import { formatError, formatWarning, formatSuccess, formatBold } from "../format";
@@ -519,6 +519,14 @@ export async function runLifecyclePlan(ctx: CommandContext): Promise<number> {
   }
 
   merged.entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  // `--report gitlab-mr` emits the GitLab MR plan-widget artifact instead of the
+  // human render. Write it to a file (`tfplan.json`) in CI and declare it as
+  // `artifacts:reports:terraform` to light up the merge-request widget.
+  if (args.reportFile === "gitlab-mr") {
+    console.log(JSON.stringify(gitlabMrReport(merged)));
+    return 0;
+  }
 
   if (args.json) {
     console.log(JSON.stringify(merged, null, 2));

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -227,6 +227,8 @@ Options:
   --json                Emit the structured run result as JSON (run command)
   --report              Print deployment report instead of running (run command)
                         OR with a path arg: SARIF report destination (migrate)
+                        OR '--report gitlab-mr': emit the GitLab MR plan-widget
+                        JSON (lifecycle plan)
   --from <name>         Source lexicon for migrate (default: github)
   --to <name>           Target lexicon for migrate (default: gitlab)
   --emit <fmt>          Migration output format: yaml (default) or ts

--- a/packages/core/src/lifecycle/change-set.test.ts
+++ b/packages/core/src/lifecycle/change-set.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { buildChangeSet, renderChangeSet, summarize } from "./change-set";
+import { buildChangeSet, renderChangeSet, summarize, gitlabMrReport } from "./change-set";
 import type { ResourceMetadata } from "../lexicon";
 
 const meta = (over: Partial<ResourceMetadata> = {}): ResourceMetadata => ({
@@ -147,5 +147,43 @@ describe("summarize / renderChangeSet", () => {
     expect(out).toContain("create-me");
     expect(out).toContain("ADOPT:");
     expect(out).toContain("orphan");
+  });
+});
+
+describe("gitlabMrReport (#329)", () => {
+  test("counts only create/update/delete; adopt and noop are excluded", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(["new-bucket", "drifted-queue", "stable-topic"]),
+      observedNow: {
+        "drifted-queue": meta({ status: "ACTIVE" }), // declared+live+drift → update
+        "stable-topic": meta({ status: "OK" }), // declared+live, no drift → noop
+        "owned-orphan": meta({ ownership: "owned" }), // owned orphan → delete
+        "foreign-orphan": meta({ ownership: "foreign" }), // foreign orphan → adopt
+        // new-bucket: declared, not live → create
+      },
+      observedThen: {
+        "drifted-queue": meta({ status: "CREATING" }),
+        "stable-topic": meta({ status: "OK" }),
+      },
+    });
+    expect(gitlabMrReport(cs)).toEqual({ create: 1, update: 1, delete: 1 });
+  });
+
+  test("empty plan reports all zeros", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(),
+      observedNow: {},
+      observedThen: undefined,
+    });
+    expect(gitlabMrReport(cs)).toEqual({ create: 0, update: 0, delete: 0 });
+  });
+
+  test("adopt-only plan reports zeros — the widget never shows undeclared resources", () => {
+    const cs = buildChangeSet("prod", {
+      declared: new Set(),
+      observedNow: { orphan: meta() }, // unknown ownership → adopt
+      observedThen: undefined,
+    });
+    expect(gitlabMrReport(cs)).toEqual({ create: 0, update: 0, delete: 0 });
   });
 });

--- a/packages/core/src/lifecycle/change-set.ts
+++ b/packages/core/src/lifecycle/change-set.ts
@@ -142,6 +142,30 @@ export function summarize(cs: ChangeSet): Record<ChangeAction, number> {
   return counts;
 }
 
+/**
+ * GitLab MR plan widget report.
+ *
+ * GitLab renders an `artifacts:reports:terraform` artifact in the merge-request
+ * UI as "N to add, M to change, K to delete". The format is generic — any tool
+ * that emits this JSON gets the widget — and the chant plan maps onto it
+ * directly. Only the mutating actions count: `adopt` and `noop` are excluded,
+ * since the widget has no column for "live but undeclared" or "no change".
+ *
+ * The widget label reads "Terraform" regardless of producer; that is GitLab's
+ * fixed string, not a claim chant makes.
+ */
+export interface GitlabMrReport {
+  create: number;
+  update: number;
+  delete: number;
+}
+
+/** Project a change set onto the GitLab MR plan widget shape. Pure. */
+export function gitlabMrReport(cs: ChangeSet): GitlabMrReport {
+  const counts = summarize(cs);
+  return { create: counts.create, update: counts.update, delete: counts.delete };
+}
+
 /** Human-readable render of a change set. Pure — returns a string. */
 export function renderChangeSet(cs: ChangeSet): string {
   const counts = summarize(cs);


### PR DESCRIPTION
Closes #329. Third and final PR of the Orbit context-producer epic (#327); follows #331 (read-only context tools).

## What

`chant lifecycle plan <env> --report gitlab-mr` emits the JSON GitLab reads for its merge-request **plan widget** — the "N to add, M to change, K to delete" summary. Declared as `artifacts:reports:terraform`, GitLab renders it inline on the MR.

The widget format is generic (any tool that emits this JSON gets it), so the chant change set maps onto it directly:

```bash
chant lifecycle plan prod --report gitlab-mr > tfplan.json
# {"create":3,"update":1,"delete":0}
```

## How

- **core** — `gitlabMrReport(changeSet)` pure formatter in `lifecycle/change-set.ts` (counts create/update/delete; `adopt`/`noop` excluded — the widget has no column for live-but-undeclared or no-change). Wired behind `--report gitlab-mr` in the plan handler; `--help` updated.
- **gitlab** — `MrPlanReport` composite emits the report job (runs the plan, writes `tfplan.json`, declares `artifacts:reports:terraform`). `before` hook for credential setup, since the plan reads the live system.
- **docs** — CLI lifecycle page + gitlab examples page.

## Caveats (documented)

- The widget label always reads **"Terraform"** — GitLab's fixed string, not a claim chant makes.
- **Counts only**; no per-resource breakdown (use the plan job log).
- **GitLab-only** surface (the JSON is portable, the widget is GitLab's).
- The plan queries live state, so the job needs cloud credentials.

## Tests

- `gitlabMrReport`: action mapping, adopt/noop exclusion, empty + adopt-only plans → zeros.
- `MrPlanReport`: report artifact, command assembly (lexicon/owned/report-file), `before` → `before_script`, per-member defaults.
- Full suite green (5998 passed).