### PR TITLE
feat(github): read-only context MCP tools (#327)

### DIFF
--- a/docs/src/content/docs/guide/agent-integration.mdx
+++ b/docs/src/content/docs/guide/agent-integration.mdx
@@ -75,7 +75,7 @@ Lexicon plugins can contribute additional tools and resources.
 
 Some lexicons add **read-only context tools** that build from your source and return what chant already computes — without touching any live system. They give an agent a *before-it-runs* view of your infrastructure: what a change does, what it pulls in, and whether it is safe, **before it runs or merges**. This is the window live tooling can't see.
 
-The GitLab lexicon ships the first set:
+The GitLab lexicon ships these:
 
 | MCP tool | Answers |
 |----------|---------|
@@ -84,6 +84,16 @@ The GitLab lexicon ships the first set:
 | `gitlab:references` | What does it pull in from outside, and is it pinned? |
 | `gitlab:affected` | If I change this job, what re-runs? |
 | `gitlab:pipeline-yaml` | The generated `.gitlab-ci.yml` |
+
+The GitHub lexicon ships the parallel set for Actions workflows:
+
+| MCP tool | Answers |
+|----------|---------|
+| `github:checks` | Is there anything risky in this workflow? (returns the security findings) |
+| `github:workflow` | What does this workflow do? (triggers, jobs, run order) |
+| `github:references` | What actions/images does it pull in, and are they pinned to a commit SHA? |
+| `github:affected` | If I change this job, what re-runs? |
+| `github:workflow-yaml` | The generated workflow YAML |
 
 Every one of these reads the build only — no live instance, no run history, no writes. That boundary is deliberate: chant is a context *producer*, complementary to (not a copy of) the live tooling an agent already uses.
 

--- a/lexicons/github/docs/src/content/docs/skills.mdx
+++ b/lexicons/github/docs/src/content/docs/skills.mdx
@@ -53,6 +53,13 @@ The lexicon provides MCP (Model Context Protocol) tools and resources that AI ag
 | MCP tool | Description |
 |----------|-------------|
 | `diff` | Compare current build output against previous output |
+| `github:checks` | Build the workflow and return its security findings (the GHA checks) |
+| `github:workflow` | Triggers and jobs as written — name, run order, step count |
+| `github:references` | Actions and images pulled in, and whether each is pinned to a commit SHA |
+| `github:affected` | Given a job, the jobs that would re-run because they depend on it |
+| `github:workflow-yaml` | The generated workflow YAML |
+
+The `github:*` tools are **read-only context tools** (#327): each builds from your source and returns what chant already computes — before the workflow runs or merges. None touch the live GitHub instance, run history, or write anything.
 
 | MCP resource | Description |
 |--------------|-------------|

--- a/lexicons/github/src/codegen/docs.ts
+++ b/lexicons/github/src/codegen/docs.ts
@@ -1385,6 +1385,13 @@ The lexicon provides MCP (Model Context Protocol) tools and resources that AI ag
 | MCP tool | Description |
 |----------|-------------|
 | \`diff\` | Compare current build output against previous output |
+| \`github:checks\` | Build the workflow and return its security findings (the GHA checks) |
+| \`github:workflow\` | Triggers and jobs as written — name, run order, step count |
+| \`github:references\` | Actions and images pulled in, and whether each is pinned to a commit SHA |
+| \`github:affected\` | Given a job, the jobs that would re-run because they depend on it |
+| \`github:workflow-yaml\` | The generated workflow YAML |
+
+The \`github:*\` tools are **read-only context tools** (#327): each builds from your source and returns what chant already computes — before the workflow runs or merges. None touch the live GitHub instance, run history, or write anything.
 
 | MCP resource | Description |
 |--------------|-------------|

--- a/lexicons/github/src/mcp/context-tools.test.ts
+++ b/lexicons/github/src/mcp/context-tools.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { githubContextTools, downstreamJobs, actionPinned } from "./context-tools";
+
+const tools = Object.fromEntries(githubContextTools().map((t) => [t.name, t]));
+
+async function call(name: string, params: Record<string, unknown>): Promise<unknown> {
+  return tools[name].handler(params);
+}
+
+describe("downstreamJobs / actionPinned (#327)", () => {
+  test("downstreamJobs follows the needs chain transitively", () => {
+    const yaml = `jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+  test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - run: echo test
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - run: echo deploy
+`;
+    expect(downstreamJobs(yaml, "build").sort()).toEqual(["deploy", "test"]);
+    expect(downstreamJobs(yaml, "test")).toEqual(["deploy"]);
+    expect(downstreamJobs(yaml, "deploy")).toEqual([]);
+  });
+
+  test("actionPinned only accepts a full commit SHA", () => {
+    expect(actionPinned("actions/checkout@" + "a".repeat(40))).toBe(true);
+    expect(actionPinned("actions/checkout@v4")).toBe(false);
+    expect(actionPinned("actions/checkout@main")).toBe(false);
+  });
+});
+
+describe("github context tools — end to end (#327)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = join(tmpdir(), `chant-mcp-gh-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "workflow.github.ts"),
+      `const M = Symbol.for("chant.declarable");
+export const ci = { [M]: true, lexicon: "github", entityType: "GitHub::Actions::Workflow", kind: "resource",
+  props: {
+    name: "CI",
+    on: { push: { branches: ["main"] } },
+    permissions: { contents: "read" },
+    jobs: {
+      build: { runsOn: "ubuntu-latest", steps: [ { uses: "peter-evans/create-pull-request@v6" }, { run: "npm ci" } ] },
+      test: { runsOn: "ubuntu-latest", needs: ["build"], steps: [ { run: "npm test" } ] },
+    },
+  } };
+`,
+    );
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("github:workflow returns triggers and jobs", async () => {
+    const out = (await call("github:workflow", { path: dir })) as {
+      workflow: string | null;
+      triggers: string[];
+      jobs: Array<{ name: string; runsAfter: string[]; steps: number }>;
+    };
+    expect(out.workflow).toBe("CI");
+    expect(out.triggers).toContain("push");
+    const names = out.jobs.map((j) => j.name);
+    expect(names).toEqual(expect.arrayContaining(["build", "test"]));
+    expect(out.jobs.find((j) => j.name === "test")?.runsAfter).toContain("build");
+  });
+
+  test("github:references reports the unpinned third-party action", async () => {
+    const out = (await call("github:references", { path: dir })) as Array<{ kind: string; source: string; pinned: boolean }>;
+    const action = out.find((r) => r.kind === "action" && r.source === "peter-evans/create-pull-request@v6");
+    expect(action).toBeDefined();
+    expect(action?.pinned).toBe(false);
+  });
+
+  test("github:checks returns the GHA findings (unpinned action trips GHA029)", async () => {
+    const out = (await call("github:checks", { path: dir })) as { findings: Array<{ id: string; severity: string; job: string | null; message: string }> };
+    expect(Array.isArray(out.findings)).toBe(true);
+    expect(out.findings.some((f) => f.id === "GHA029")).toBe(true);
+    for (const f of out.findings) {
+      expect(typeof f.id).toBe("string");
+      expect(typeof f.message).toBe("string");
+    }
+  });
+
+  test("github:affected lists downstream jobs", async () => {
+    const out = (await call("github:affected", { path: dir, job: "build" })) as { job: string; wouldRerun: string[] };
+    expect(out.wouldRerun).toContain("test");
+  });
+
+  test("github:workflow-yaml returns the generated YAML for a path", async () => {
+    const out = (await call("github:workflow-yaml", { path: dir })) as { yaml: string };
+    expect(typeof out.yaml).toBe("string");
+    expect(out.yaml).toContain("jobs:");
+  });
+});

--- a/lexicons/github/src/mcp/context-tools.ts
+++ b/lexicons/github/src/mcp/context-tools.ts
@@ -1,0 +1,172 @@
+/**
+ * Read-only MCP tools that expose what `chant build` already computes about a
+ * GitHub Actions workflow — its jobs and run order, what it pulls in from
+ * outside (actions, images), and its security findings — so an agent can ask
+ * about a change *before it runs or merges* (#327).
+ *
+ * The GitHub counterpart to the GitLab context tools. Every tool builds from
+ * source and returns data. None of them touch the live GitHub instance, read
+ * run history, or write anything — that boundary is what keeps chant a context
+ * producer and not a copy of the live tooling.
+ */
+
+import { build, type BuildResult } from "@intentius/chant/build";
+import { runPostSynthChecks, getPrimaryOutput } from "@intentius/chant/lint/post-synth";
+import { discoverPostSynthChecks } from "@intentius/chant/lint/discover";
+import type { McpToolContribution } from "@intentius/chant/mcp/types";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { githubSerializer } from "../serializer";
+import {
+  extractJobs,
+  extractActionRefs,
+  extractImageRefs,
+  extractTriggers,
+  extractWorkflowName,
+} from "../lint/post-synth/yaml-helpers";
+
+/** Build the project and return the emitted GitHub workflow YAML plus the raw result. */
+async function buildGithub(path: string): Promise<{ yaml: string; result: BuildResult }> {
+  const result = await build(path, [githubSerializer]);
+  const out = result.outputs.get("github");
+  return { yaml: out ? getPrimaryOutput(out) : "", result };
+}
+
+/** Discover the lexicon's post-synth checks without depending on the plugin. */
+function githubPostSynthChecks() {
+  const dir = join(dirname(fileURLToPath(import.meta.url)), "..", "lint", "post-synth");
+  return discoverPostSynthChecks(dir, import.meta.url);
+}
+
+/** Is a `uses:` ref pinned to a full commit SHA (the only immutable form)? */
+export function actionPinned(ref: string): boolean {
+  const at = ref.lastIndexOf("@");
+  return at !== -1 && /^[0-9a-f]{40}$/.test(ref.slice(at + 1));
+}
+
+/** Jobs that would re-run because they depend (transitively) on `job`. */
+export function downstreamJobs(yaml: string, job: string): string[] {
+  const jobs = extractJobs(yaml);
+  // edge: upstream -> downstream (J depends on each of its needs)
+  const downstreamOf = new Map<string, string[]>();
+  for (const [name, j] of jobs) {
+    for (const dep of j.needs ?? []) {
+      const arr = downstreamOf.get(dep) ?? [];
+      arr.push(name);
+      downstreamOf.set(dep, arr);
+    }
+  }
+  const out = new Set<string>();
+  const queue = [job];
+  while (queue.length) {
+    const cur = queue.shift()!;
+    for (const next of downstreamOf.get(cur) ?? []) {
+      if (!out.has(next)) {
+        out.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  return [...out];
+}
+
+const PATH_INPUT = {
+  type: "object" as const,
+  properties: {
+    path: { type: "string", description: "Path to the chant project directory (default: current directory)" },
+  },
+};
+
+/** The read-only context tools for the GitHub lexicon. */
+export function githubContextTools(): McpToolContribution[] {
+  return [
+    {
+      name: "github:checks",
+      description:
+        "Build the workflow and return its security and correctness findings (the GHA checks) as JSON. Read-only — does not touch the live GitHub instance.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml, result } = await buildGithub((params.path as string) ?? ".");
+        if (!yaml) return { findings: [], note: "no GitHub workflow produced from this project" };
+        const scoped = { ...result, outputs: new Map([["github", result.outputs.get("github")!]]) };
+        const diags = runPostSynthChecks(githubPostSynthChecks(), scoped);
+        return {
+          findings: diags.map((d) => ({
+            id: d.checkId,
+            severity: d.severity,
+            job: d.entity ?? null,
+            message: d.message,
+          })),
+        };
+      },
+    },
+    {
+      name: "github:workflow",
+      description:
+        "Build the workflow and return its triggers and jobs as written (name, what each job runs after, step count) — before anything runs. Read-only.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildGithub((params.path as string) ?? ".");
+        const jobs = [...extractJobs(yaml).values()].map((j) => ({
+          name: j.name,
+          runsAfter: j.needs ?? [],
+          steps: j.steps?.length ?? 0,
+        }));
+        return {
+          workflow: extractWorkflowName(yaml) ?? null,
+          triggers: Object.keys(extractTriggers(yaml)),
+          jobs,
+        };
+      },
+    },
+    {
+      name: "github:references",
+      description:
+        "Build the workflow and list everything it pulls in from outside (actions via uses:, container/service images) and whether each is pinned to an immutable commit SHA. Read-only.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildGithub((params.path as string) ?? ".");
+        const actions = extractActionRefs(yaml).map((a) => ({
+          kind: a.level === "job" ? ("reusable-workflow" as const) : ("action" as const),
+          job: a.job,
+          source: a.ref,
+          pinned: actionPinned(a.ref),
+        }));
+        const images = extractImageRefs(yaml).map((i) => ({
+          kind: "image" as const,
+          job: i.job,
+          source: i.image,
+          pinned: i.image.includes("@sha256:"),
+        }));
+        return [...actions, ...images];
+      },
+    },
+    {
+      name: "github:affected",
+      description:
+        "Build the workflow and, given a job name, list the jobs that would re-run because they depend on it (the needs chain). Read-only.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          path: { type: "string", description: "Path to the chant project directory (default: current directory)" },
+          job: { type: "string", description: "Job name to trace downstream from" },
+        },
+        required: ["job"],
+      },
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildGithub((params.path as string) ?? ".");
+        const job = params.job as string;
+        return { job, wouldRerun: downstreamJobs(yaml, job) };
+      },
+    },
+    {
+      name: "github:workflow-yaml",
+      description: "Build the project and return the generated GitHub Actions workflow YAML as a string. Read-only.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildGithub((params.path as string) ?? ".");
+        return { yaml };
+      },
+    },
+  ];
+}

--- a/lexicons/github/src/plugin.test.ts
+++ b/lexicons/github/src/plugin.test.ts
@@ -125,8 +125,17 @@ describe("githubPlugin", () => {
 
   test("provides MCP tools", () => {
     const tools = githubPlugin.mcpTools!();
-    expect(tools.length).toBe(1);
-    expect(tools[0].name).toBe("github:diff");
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("github:diff");
+    // Read-only context tools (#327)
+    expect(names).toContain("github:checks");
+    expect(names).toContain("github:workflow");
+    expect(names).toContain("github:references");
+    expect(names).toContain("github:affected");
+    expect(names).toContain("github:workflow-yaml");
+    for (const t of tools) {
+      expect(typeof t.handler).toBe("function");
+    }
   });
 
   test("provides MCP resources", () => {

--- a/lexicons/github/src/plugin.ts
+++ b/lexicons/github/src/plugin.ts
@@ -29,6 +29,7 @@ import { githubCompletions } from "./lsp/completions";
 import { githubHover } from "./lsp/hover";
 import { GitHubActionsParser } from "./import/parser";
 import { GitHubActionsGenerator } from "./import/generator";
+import { githubContextTools } from "./mcp/context-tools";
 
 export const githubPlugin: LexiconPlugin = {
   name: "github",
@@ -224,7 +225,10 @@ export const build = new Job({
   },
 
   mcpTools() {
-    return [createDiffTool(githubSerializer, "Compare current build output against previous output for GitHub Actions", "github")];
+    return [
+      createDiffTool(githubSerializer, "Compare current build output against previous output for GitHub Actions", "github"),
+      ...githubContextTools(),
+    ];
   },
 
   mcpResources() {


### PR DESCRIPTION
Part of #327. Builds the GitHub half of the read-only pipeline context tools — the parallel set to the GitLab tools shipped in #331.

## Tools

| Tool | Answers |
|---|---|
| `github:checks` | security/correctness findings (the GHA checks) |
| `github:workflow` | triggers, jobs, run order (step counts + needs) |
| `github:references` | actions (`uses:`) and images pulled in, and whether pinned to a commit SHA |
| `github:affected` | given a job, what re-runs (the needs chain) |
| `github:workflow-yaml` | the generated workflow YAML |

All build-only — no live GitHub instance, no run history, no writes. Same boundary discipline as the GitLab set.

## Reuse

Nearly all wiring: reuses the existing GHA post-synth checks and `yaml-helpers` (`extractJobs`, `extractActionRefs`, `extractImageRefs`, `extractTriggers`, `buildNeedsGraph`). `actionPinned` recognizes the only immutable form — a full 40-char commit SHA.

## Tests

- unit: `downstreamJobs` (transitive needs), `actionPinned` (SHA vs tag/branch)
- e2e: builds a fixture workflow and asserts each tool — `github:workflow` jobs/triggers, `github:references` pinned:false on a third-party action, `github:checks` trips GHA029, `github:affected` downstream, `github:workflow-yaml`
- github lexicon suite green (453), core tsc clean

## Docs

- core `agent-integration.mdx` — GitHub table alongside GitLab
- github lexicon MCP table (regenerated `skills.mdx`)