### PR TITLE
feat(gitlab): gitlab:source + gitlab:owns with build provenance (#327)

### DIFF
--- a/docs/src/content/docs/guide/agent-integration.mdx
+++ b/docs/src/content/docs/guide/agent-integration.mdx
@@ -84,6 +84,8 @@ The GitLab lexicon ships these:
 | `gitlab:references` | What does it pull in from outside, and is it pinned? |
 | `gitlab:affected` | If I change this job, what re-runs? |
 | `gitlab:pipeline-yaml` | The generated `.gitlab-ci.yml` |
+| `gitlab:source` | Where did this job come from in my TypeScript? (file + composite) |
+| `gitlab:owns` | Is this job declared by chant in this project? |
 
 The GitHub lexicon ships the parallel set for Actions workflows:
 

--- a/lexicons/gitlab/docs/src/content/docs/skills.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/skills.mdx
@@ -59,8 +59,10 @@ The lexicon also provides MCP (Model Context Protocol) tools and resources that 
 | `gitlab:references` | Build and list what the pipeline pulls in (includes, components, images) and whether each is pinned |
 | `gitlab:affected` | Given a job, list the jobs that would re-run because they depend on it |
 | `gitlab:pipeline-yaml` | Build and return the generated `.gitlab-ci.yml` |
+| `gitlab:source` | Given a job, where it came from in the TypeScript — the declaring file and the composite that expanded it, if any (entity-level, not a YAML-line source map) |
+| `gitlab:owns` | Given a job, whether it is declared (owned) by chant in this project. Pipeline jobs are not taggable cloud resources, so ownership here means "declared here" — live ownership markers apply to cloud lexicons |
 
-The `gitlab:checks` / `gitlab:pipeline` / `gitlab:references` / `gitlab:affected` / `gitlab:pipeline-yaml` tools are **read-only**: they build from source and never touch the live GitLab instance. They give an agent a *before-it-runs* view of the pipeline — what it does, what it pulls in, and whether it is safe — to complement the *after-it-ran* view it gets from the instance.
+The `gitlab:checks` / `gitlab:pipeline` / `gitlab:references` / `gitlab:affected` / `gitlab:pipeline-yaml` / `gitlab:source` / `gitlab:owns` tools are **read-only**: they build from source and never touch the live GitLab instance. They give an agent a *before-it-runs* view of the pipeline — what it does, what it pulls in, whether it is safe, and where it came from — to complement the *after-it-ran* view it gets from the instance.
 
 | MCP resource | Description |
 |--------------|-------------|

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -914,8 +914,10 @@ The lexicon also provides MCP (Model Context Protocol) tools and resources that 
 | \`gitlab:references\` | Build and list what the pipeline pulls in (includes, components, images) and whether each is pinned |
 | \`gitlab:affected\` | Given a job, list the jobs that would re-run because they depend on it |
 | \`gitlab:pipeline-yaml\` | Build and return the generated \`.gitlab-ci.yml\` |
+| \`gitlab:source\` | Given a job, where it came from in the TypeScript — the declaring file and the composite that expanded it, if any (entity-level, not a YAML-line source map) |
+| \`gitlab:owns\` | Given a job, whether it is declared (owned) by chant in this project. Pipeline jobs are not taggable cloud resources, so ownership here means "declared here" — live ownership markers apply to cloud lexicons |
 
-The \`gitlab:checks\` / \`gitlab:pipeline\` / \`gitlab:references\` / \`gitlab:affected\` / \`gitlab:pipeline-yaml\` tools are **read-only**: they build from source and never touch the live GitLab instance. They give an agent a *before-it-runs* view of the pipeline — what it does, what it pulls in, and whether it is safe — to complement the *after-it-ran* view it gets from the instance.
+The \`gitlab:checks\` / \`gitlab:pipeline\` / \`gitlab:references\` / \`gitlab:affected\` / \`gitlab:pipeline-yaml\` / \`gitlab:source\` / \`gitlab:owns\` tools are **read-only**: they build from source and never touch the live GitLab instance. They give an agent a *before-it-runs* view of the pipeline — what it does, what it pulls in, whether it is safe, and where it came from — to complement the *after-it-ran* view it gets from the instance.
 
 | MCP resource | Description |
 |--------------|-------------|

--- a/lexicons/gitlab/src/mcp/context-tools.test.ts
+++ b/lexicons/gitlab/src/mcp/context-tools.test.ts
@@ -99,4 +99,27 @@ export const testApp = { [M]: true, lexicon: "gitlab", entityType: "GitLab::CI::
     expect(typeof out.yaml).toBe("string");
     expect(out.yaml).toContain("stages:");
   });
+
+  test("gitlab:source traces a job back to its declaring file", async () => {
+    const out = (await call("gitlab:source", { path: dir, job: "build-app" })) as {
+      job: string; found: boolean; entity: string; from: string | null; via: string | null;
+    };
+    expect(out.found).toBe(true);
+    expect(out.entity).toBe("buildApp");
+    expect(out.from).toMatch(/pipeline\.infra\.ts$/);
+    expect(out.via).toBeNull(); // plain declarable, not from a composite
+  });
+
+  test("gitlab:source reports not-found for an unknown job", async () => {
+    const out = (await call("gitlab:source", { path: dir, job: "nope" })) as { job: string; found: boolean };
+    expect(out.found).toBe(false);
+  });
+
+  test("gitlab:owns reports a declared job as owned, an unknown one as not", async () => {
+    const owned = (await call("gitlab:owns", { path: dir, job: "test-app" })) as { owned: boolean; basis: string };
+    expect(owned.owned).toBe(true);
+    expect(owned.basis).toBe("declared-in-source");
+    const foreign = (await call("gitlab:owns", { path: dir, job: "not-here" })) as { owned: boolean };
+    expect(foreign.owned).toBe(false);
+  });
 });

--- a/lexicons/gitlab/src/mcp/context-tools.ts
+++ b/lexicons/gitlab/src/mcp/context-tools.ts
@@ -12,8 +12,9 @@
 import { build, type BuildResult } from "@intentius/chant/build";
 import { runPostSynthChecks, getPrimaryOutput } from "@intentius/chant/lint/post-synth";
 import { discoverPostSynthChecks } from "@intentius/chant/lint/discover";
+import { getProvenance } from "@intentius/chant/provenance";
 import type { McpToolContribution } from "@intentius/chant/mcp/types";
-import { dirname, join } from "path";
+import { dirname, join, relative, isAbsolute } from "path";
 import { fileURLToPath } from "url";
 import { gitlabSerializer } from "../serializer";
 import {
@@ -41,6 +42,27 @@ function gitlabPostSynthChecks() {
 export function componentPinned(value: string): boolean {
   const at = value.lastIndexOf("@");
   return at !== -1 && isPinnedRef(value.slice(at + 1));
+}
+
+/** The YAML job name a build entity serializes to (camelCase → kebab-case). */
+export function jobNameOf(entityName: string): string {
+  return entityName.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+/** Find the build entity whose serialized job name matches `job`. */
+function entityForJob(result: BuildResult, job: string): { name: string; entity: object } | undefined {
+  for (const [name, entity] of result.entities) {
+    if (name === job || jobNameOf(name) === job) return { name, entity };
+  }
+  return undefined;
+}
+
+/** Render a source-file path relative to the project root, when possible. */
+function relSource(root: string, file: string | undefined): string | undefined {
+  if (!file) return undefined;
+  if (!isAbsolute(file)) return file;
+  const rel = relative(root, file);
+  return rel.startsWith("..") ? file : rel;
 }
 
 /** Jobs that would re-run because they depend (transitively) on `job`. */
@@ -162,6 +184,59 @@ export function gitlabContextTools(): McpToolContribution[] {
       async handler(params: Record<string, unknown>): Promise<unknown> {
         const { yaml } = await buildGitlab((params.path as string) ?? ".");
         return { yaml };
+      },
+    },
+    {
+      name: "gitlab:source",
+      description:
+        "Build the project and, given a job name, say where it came from in the TypeScript source — the file that declared it and the composite that expanded it, if any. Entity-level provenance (file + composite), not a YAML-line source map. Read-only.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          path: { type: "string", description: "Path to the chant project directory (default: current directory)" },
+          job: { type: "string", description: "Job name (as it appears in the generated YAML) to trace back to source" },
+        },
+        required: ["job"],
+      },
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const root = (params.path as string) ?? ".";
+        const { result } = await buildGitlab(root);
+        const job = params.job as string;
+        const found = entityForJob(result, job);
+        if (!found) return { job, found: false, note: "no build entity serializes to that job name" };
+        const prov = getProvenance(found.entity);
+        return {
+          job,
+          found: true,
+          entity: found.name,
+          from: relSource(root, prov?.sourceFile) ?? null,
+          via: prov?.composite ?? null,
+        };
+      },
+    },
+    {
+      name: "gitlab:owns",
+      description:
+        "Build the project and report whether a job is declared (owned) by chant in this project's source. For pipeline config, ownership means \"declared here\" — GitLab CI jobs are not taggable cloud resources, so there is no live ownership marker as there is for cloud lexicons. Read-only.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          path: { type: "string", description: "Path to the chant project directory (default: current directory)" },
+          job: { type: "string", description: "Job name (as it appears in the generated YAML) to check" },
+        },
+        required: ["job"],
+      },
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const root = (params.path as string) ?? ".";
+        const { result } = await buildGitlab(root);
+        const job = params.job as string;
+        const found = entityForJob(result, job);
+        return {
+          job,
+          owned: Boolean(found),
+          basis: "declared-in-source",
+          note: "GitLab CI jobs are not taggable cloud resources; ownership here means the job is declared by chant in this project. Live ownership markers apply to cloud lexicons (aws/azure/k8s).",
+        };
       },
     },
   ];

--- a/lexicons/gitlab/src/plugin.test.ts
+++ b/lexicons/gitlab/src/plugin.test.ts
@@ -244,6 +244,8 @@ describe("gitlabPlugin", () => {
     expect(names).toContain("gitlab:references");
     expect(names).toContain("gitlab:affected");
     expect(names).toContain("gitlab:pipeline-yaml");
+    expect(names).toContain("gitlab:source");
+    expect(names).toContain("gitlab:owns");
     for (const t of tools) {
       expect(typeof t.handler).toBe("function");
     }

--- a/packages/core/src/composite.ts
+++ b/packages/core/src/composite.ts
@@ -1,4 +1,5 @@
 import { isDeclarable, type Declarable } from "./declarable";
+import { setProvenance } from "./provenance";
 
 /**
  * Marker symbol for Composite type identification.
@@ -128,15 +129,20 @@ export function expandComposite(
   const result = new Map<string, Declarable>();
   const shared = (instance as unknown as Record<symbol, unknown>)[SHARED_PROPS] as Record<string, unknown> | undefined;
 
+  const compositeName = instance._definition?.compositeName;
+
   for (const [memberName, member] of Object.entries(instance.members)) {
     const fullName = `${prefix}${memberName[0].toUpperCase()}${memberName.slice(1)}`;
 
     if (isCompositeInstance(member)) {
       const nested = expandComposite(fullName, member);
       for (const [nestedName, nestedEntity] of nested) {
+        // Inner composite already stamped; `??=` keeps the most-specific one.
+        if (compositeName) setProvenance(nestedEntity, { composite: compositeName });
         result.set(nestedName, nestedEntity);
       }
     } else {
+      if (compositeName) setProvenance(member as Declarable, { composite: compositeName });
       result.set(fullName, member as Declarable);
     }
   }

--- a/packages/core/src/discovery/collect.ts
+++ b/packages/core/src/discovery/collect.ts
@@ -2,6 +2,7 @@ import { isDeclarable, type Declarable } from "../declarable";
 import { isCompositeInstance, expandComposite } from "../composite";
 import { isLexiconOutput } from "../lexicon-output";
 import { DiscoveryError } from "../errors";
+import { setProvenance } from "../provenance";
 
 /**
  * Collects all declarable entities from imported modules.
@@ -32,6 +33,7 @@ export function collectEntities(
             );
           }
         } else {
+          setProvenance(value, { sourceFile: file });
           entities.set(name, value);
         }
       } else if (Array.isArray(value)) {
@@ -43,6 +45,7 @@ export function collectEntities(
             if (entities.has(indexedName) && entities.get(indexedName) !== item) {
               throw new DiscoveryError(file, `Duplicate entity name "${indexedName}"`, "resolution");
             }
+            setProvenance(item, { sourceFile: file });
             entities.set(indexedName, item);
           } else if (isCompositeInstance(item)) {
             const indexedName = `${name}_${i}`;
@@ -55,6 +58,7 @@ export function collectEntities(
                   "resolution",
                 );
               }
+              setProvenance(entity, { sourceFile: file });
               entities.set(expandedName, entity);
             }
           }
@@ -69,6 +73,7 @@ export function collectEntities(
               "resolution",
             );
           }
+          setProvenance(entity, { sourceFile: file });
           entities.set(expandedName, entity);
         }
       } else if (isLexiconOutput(value)) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@
 
 export * from "./declarable";
 export * from "./composite";
+export * from "./provenance";
 export * from "./intrinsic";
 export * from "./types";
 export * from "./errors";

--- a/packages/core/src/provenance.test.ts
+++ b/packages/core/src/provenance.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+import { setProvenance, getProvenance } from "./provenance";
+import { Composite, expandComposite } from "./composite";
+import { collectEntities } from "./discovery/collect";
+import { DECLARABLE_MARKER, type Declarable } from "./declarable";
+
+const decl = (entityType: string): Declarable =>
+  ({ [DECLARABLE_MARKER]: true, lexicon: "test", entityType, kind: "resource", props: {} }) as unknown as Declarable;
+
+const Pair = Composite<{ n: string }>((props) => ({
+  first: decl(`Test::First:${props.n}`),
+  second: decl(`Test::Second:${props.n}`),
+}), "Pair");
+
+describe("provenance side channel", () => {
+  test("set then get returns the stamped fields", () => {
+    const e = decl("Test::Thing");
+    setProvenance(e, { sourceFile: "/proj/src/a.ts" });
+    setProvenance(e, { composite: "MyComposite" });
+    expect(getProvenance(e)).toEqual({ sourceFile: "/proj/src/a.ts", composite: "MyComposite" });
+  });
+
+  test("first writer wins (??= merge keeps the most specific)", () => {
+    const e = decl("Test::Thing");
+    setProvenance(e, { composite: "Inner" });
+    setProvenance(e, { composite: "Outer" });
+    expect(getProvenance(e)?.composite).toBe("Inner");
+  });
+
+  test("provenance is non-enumerable — invisible to spreads and JSON", () => {
+    const e = decl("Test::Thing");
+    setProvenance(e, { sourceFile: "/x.ts" });
+    expect(Object.keys(e)).not.toContain(Symbol.for("chant.provenance").toString());
+    expect(JSON.stringify(e)).not.toContain("provenance");
+  });
+
+  test("getProvenance is undefined when nothing was stamped", () => {
+    expect(getProvenance(decl("Test::Thing"))).toBeUndefined();
+  });
+});
+
+describe("composite expansion stamps composite provenance", () => {
+  test("expandComposite stamps each member with the composite name", () => {
+    const expanded = expandComposite("p", Pair({ n: "x" }));
+    for (const [, entity] of expanded) {
+      expect(getProvenance(entity)?.composite).toBe("Pair");
+    }
+  });
+
+  test("nested composites keep the innermost composite name", () => {
+    // expandComposite recurses on CompositeInstance members at runtime; the
+    // CompositeMembers type only models Declarable leaves, so cast the nested
+    // composite to satisfy the factory's static type.
+    const Wrapper = Composite<{ n: string }>((props) => ({
+      inner: Pair({ n: props.n }) as unknown as Declarable,
+    }), "Wrapper");
+    const expanded = expandComposite("w", Wrapper({ n: "y" }));
+    // Pair's members are the leaves; the inner (Pair) name must win over Wrapper.
+    for (const [, entity] of expanded) {
+      expect(getProvenance(entity)?.composite).toBe("Pair");
+    }
+  });
+});
+
+describe("collectEntities stamps the source file", () => {
+  test("direct exports get their declaring file", () => {
+    const a = decl("Test::A");
+    const entities = collectEntities([{ file: "/proj/src/infra.ts", exports: { a } }]);
+    expect(getProvenance(entities.get("a")!)?.sourceFile).toBe("/proj/src/infra.ts");
+  });
+
+  test("composite-expanded entities get both file and composite", () => {
+    const entities = collectEntities([{ file: "/proj/src/pipe.ts", exports: { p: Pair({ n: "z" }) } }]);
+    const member = entities.get("pFirst")!;
+    const prov = getProvenance(member);
+    expect(prov?.sourceFile).toBe("/proj/src/pipe.ts");
+    expect(prov?.composite).toBe("Pair");
+  });
+});

--- a/packages/core/src/provenance.ts
+++ b/packages/core/src/provenance.ts
@@ -1,0 +1,46 @@
+/**
+ * Build provenance: where a declared entity came from in the TypeScript source.
+ *
+ * Stamped during discovery as a non-enumerable, symbol-keyed side channel on the
+ * entity object, so it never serializes into the emitted YAML/JSON — it is build
+ * metadata, not declared configuration. Read it back with {@link getProvenance}.
+ *
+ * This is entity-level provenance (which file declared it, and which composite
+ * expanded it), not a YAML-line source map. It answers "where did this resource
+ * come from?", which is the question an agent asks before changing it.
+ */
+
+const PROVENANCE = Symbol.for("chant.provenance");
+
+export interface EntityProvenance {
+  /** Absolute path of the source file that declared (or exported) the entity. */
+  sourceFile?: string;
+  /** The composite that expanded this entity, when it came from one. */
+  composite?: string;
+}
+
+/**
+ * Merge provenance onto an entity. Non-enumerable so it is invisible to
+ * serializers and spreads. Existing fields win (`??=`), so the first/most
+ * specific writer — the innermost composite, the declaring file — is kept.
+ */
+export function setProvenance(entity: object, prov: EntityProvenance): void {
+  if (!Object.isExtensible(entity)) return;
+  const existing = (entity as Record<symbol, unknown>)[PROVENANCE] as EntityProvenance | undefined;
+  if (existing) {
+    existing.sourceFile ??= prov.sourceFile;
+    existing.composite ??= prov.composite;
+    return;
+  }
+  Object.defineProperty(entity, PROVENANCE, {
+    value: { ...prov },
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  });
+}
+
+/** Read an entity's build provenance, if any was stamped. */
+export function getProvenance(entity: object): EntityProvenance | undefined {
+  return (entity as Record<symbol, unknown>)[PROVENANCE] as EntityProvenance | undefined;
+}


### PR DESCRIPTION
Part of #327. Adds the last two GitLab context tools. Both required a small, isolated core feature: **entity-level build provenance**.

## Core: provenance side channel

`packages/core/src/provenance.ts` — a non-enumerable, symbol-keyed record stamped on entities during discovery:
- `collectEntities` stamps the **declaring file**
- `expandComposite` stamps the **composite name** (most-specific wins for nested composites)

Non-enumerable + symbol-keyed, so it never serializes into the emitted YAML/JSON — it is build metadata, not declared config. Read back with `getProvenance(entity)`.

This is **entity-level** provenance (which file/composite produced a resource), not a YAML-line source map — the honest scope, stated plainly in the tool description and docs.

## Tools

| Tool | Answers |
|---|---|
| `gitlab:source` | Given a job, the file that declared it and the composite that expanded it (`{ from, via }`) |
| `gitlab:owns` | Whether a job is declared (owned) by chant in this project |

**On `gitlab:owns` honesty:** GitLab CI jobs are not taggable cloud resources, so there is no live ownership marker as there is for aws/azure/k8s. Ownership here means *declared in this project's source* (`basis: "declared-in-source"`), and the tool says so in its output `note`. This is the build-side form of the ownership check; the live-marker form belongs to cloud lexicons.

## Tests
- core: provenance set/get, non-enumerability, first-writer-wins, composite + file stamping through `collectEntities`
- gitlab: `gitlab:source` traces to file (via:null for plain declarables), not-found path; `gitlab:owns` owned vs not
- full suite green (6021), core tsc clean

## Docs
- core `agent-integration.mdx` gitlab table
- gitlab lexicon MCP table (regenerated `skills.mdx`)