### PR TITLE
feat(gitlab): gitlab:compare migration safety view (#327)

### DIFF
--- a/docs/src/content/docs/guide/agent-integration.mdx
+++ b/docs/src/content/docs/guide/agent-integration.mdx
@@ -86,6 +86,7 @@ The GitLab lexicon ships these:
 | `gitlab:pipeline-yaml` | The generated `.gitlab-ci.yml` |
 | `gitlab:source` | Where did this job come from in my TypeScript? (file + composite) |
 | `gitlab:owns` | Is this job declared by chant in this project? |
+| `gitlab:compare` | If I migrate this GitHub workflow to GitLab, which safety properties survive? |
 
 The GitHub lexicon ships the parallel set for Actions workflows:
 

--- a/lexicons/gitlab/docs/src/content/docs/skills.mdx
+++ b/lexicons/gitlab/docs/src/content/docs/skills.mdx
@@ -61,8 +61,11 @@ The lexicon also provides MCP (Model Context Protocol) tools and resources that 
 | `gitlab:pipeline-yaml` | Build and return the generated `.gitlab-ci.yml` |
 | `gitlab:source` | Given a job, where it came from in the TypeScript — the declaring file and the composite that expanded it, if any (entity-level, not a YAML-line source map) |
 | `gitlab:owns` | Given a job, whether it is declared (owned) by chant in this project. Pipeline jobs are not taggable cloud resources, so ownership here means "declared here" — live ownership markers apply to cloud lexicons |
+| `gitlab:compare` | Given a GitHub Actions workflow file, migrate it to GitLab CI and report which security properties survive (translated/approximated/needs-review/lost) — the migration safety view |
 
-The `gitlab:checks` / `gitlab:pipeline` / `gitlab:references` / `gitlab:affected` / `gitlab:pipeline-yaml` / `gitlab:source` / `gitlab:owns` tools are **read-only**: they build from source and never touch the live GitLab instance. They give an agent a *before-it-runs* view of the pipeline — what it does, what it pulls in, whether it is safe, and where it came from — to complement the *after-it-ran* view it gets from the instance.
+The `gitlab:checks` / `gitlab:pipeline` / `gitlab:references` / `gitlab:affected` / `gitlab:pipeline-yaml` / `gitlab:source` / `gitlab:owns` / `gitlab:compare` tools are **read-only**: they build (or migrate) from source and never touch the live GitLab instance. They give an agent a *before-it-runs* view of the pipeline — what it does, what it pulls in, whether it is safe, where it came from, and what survives a migration — to complement the *after-it-ran* view it gets from the instance.
+
+> **Why no `github:compare`?** The GitHub → GitLab migration lives in the GitLab lexicon (the GitHub lexicon does not depend on GitLab). A `github:compare` would invert that dependency, so the migration safety view is exposed once, here, as `gitlab:compare`.
 
 | MCP resource | Description |
 |--------------|-------------|

--- a/lexicons/gitlab/src/codegen/docs.ts
+++ b/lexicons/gitlab/src/codegen/docs.ts
@@ -916,8 +916,11 @@ The lexicon also provides MCP (Model Context Protocol) tools and resources that 
 | \`gitlab:pipeline-yaml\` | Build and return the generated \`.gitlab-ci.yml\` |
 | \`gitlab:source\` | Given a job, where it came from in the TypeScript — the declaring file and the composite that expanded it, if any (entity-level, not a YAML-line source map) |
 | \`gitlab:owns\` | Given a job, whether it is declared (owned) by chant in this project. Pipeline jobs are not taggable cloud resources, so ownership here means "declared here" — live ownership markers apply to cloud lexicons |
+| \`gitlab:compare\` | Given a GitHub Actions workflow file, migrate it to GitLab CI and report which security properties survive (translated/approximated/needs-review/lost) — the migration safety view |
 
-The \`gitlab:checks\` / \`gitlab:pipeline\` / \`gitlab:references\` / \`gitlab:affected\` / \`gitlab:pipeline-yaml\` / \`gitlab:source\` / \`gitlab:owns\` tools are **read-only**: they build from source and never touch the live GitLab instance. They give an agent a *before-it-runs* view of the pipeline — what it does, what it pulls in, whether it is safe, and where it came from — to complement the *after-it-ran* view it gets from the instance.
+The \`gitlab:checks\` / \`gitlab:pipeline\` / \`gitlab:references\` / \`gitlab:affected\` / \`gitlab:pipeline-yaml\` / \`gitlab:source\` / \`gitlab:owns\` / \`gitlab:compare\` tools are **read-only**: they build (or migrate) from source and never touch the live GitLab instance. They give an agent a *before-it-runs* view of the pipeline — what it does, what it pulls in, whether it is safe, where it came from, and what survives a migration — to complement the *after-it-ran* view it gets from the instance.
+
+> **Why no \`github:compare\`?** The GitHub → GitLab migration lives in the GitLab lexicon (the GitHub lexicon does not depend on GitLab). A \`github:compare\` would invert that dependency, so the migration safety view is exposed once, here, as \`gitlab:compare\`.
 
 | MCP resource | Description |
 |--------------|-------------|

--- a/lexicons/gitlab/src/mcp/context-tools.test.ts
+++ b/lexicons/gitlab/src/mcp/context-tools.test.ts
@@ -123,3 +123,56 @@ export const testApp = { [M]: true, lexicon: "gitlab", entityType: "GitLab::CI::
     expect(foreign.owned).toBe(false);
   });
 });
+
+describe("gitlab:compare — migration safety view (#327)", () => {
+  let dir: string;
+  let wf: string;
+  beforeEach(async () => {
+    dir = join(tmpdir(), `chant-mcp-cmp-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(dir, { recursive: true });
+    wf = join(dir, "ci.yml");
+    await writeFile(
+      wf,
+      `name: CI
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@${"a".repeat(40)}
+      - run: npm ci
+`,
+    );
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("reports the SHA pin as lost across the migration edge", async () => {
+    const out = (await call("gitlab:compare", { file: wf })) as {
+      found: boolean;
+      properties: Array<{ property: string; fate: string }>;
+      summary: Record<string, number>;
+    };
+    expect(out.found).toBe(true);
+    const pin = out.properties.find((p) => p.property === "Pinned action SHA");
+    expect(pin?.fate).toBe("lost");
+    expect(out.summary.lost).toBeGreaterThanOrEqual(1);
+  });
+
+  test("not-found for a missing file", async () => {
+    const out = (await call("gitlab:compare", { file: join(dir, "nope.yml") })) as { found: boolean };
+    expect(out.found).toBe(false);
+  });
+
+  test("not-found for a non-workflow file", async () => {
+    const notWf = join(dir, "plain.yml");
+    await writeFile(notWf, "hello: world\n");
+    const out = (await call("gitlab:compare", { file: notWf })) as { found: boolean };
+    expect(out.found).toBe(false);
+  });
+});

--- a/lexicons/gitlab/src/mcp/context-tools.ts
+++ b/lexicons/gitlab/src/mcp/context-tools.ts
@@ -14,9 +14,11 @@ import { runPostSynthChecks, getPrimaryOutput } from "@intentius/chant/lint/post
 import { discoverPostSynthChecks } from "@intentius/chant/lint/discover";
 import { getProvenance } from "@intentius/chant/provenance";
 import type { McpToolContribution } from "@intentius/chant/mcp/types";
-import { dirname, join, relative, isAbsolute } from "path";
+import { dirname, join, relative, isAbsolute, resolve } from "path";
+import { readFile } from "fs/promises";
 import { fileURLToPath } from "url";
 import { gitlabSerializer } from "../serializer";
+import { transform, detectGitHubWorkflow } from "../migrate/from-github";
 import {
   extractStages,
   extractJobs,
@@ -237,6 +239,43 @@ export function gitlabContextTools(): McpToolContribution[] {
           basis: "declared-in-source",
           note: "GitLab CI jobs are not taggable cloud resources; ownership here means the job is declared by chant in this project. Live ownership markers apply to cloud lexicons (aws/azure/k8s).",
         };
+      },
+    },
+    {
+      name: "gitlab:compare",
+      description:
+        "Given a GitHub Actions workflow file, migrate it to GitLab CI and report which security properties survive the move and which weaken or are lost (the migration safety view). Returns a per-property fate (translated/approximated/needs-review/lost). Read-only — builds and analyzes, never writes.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          file: { type: "string", description: "Path to a .github/workflows/*.yml workflow file to migrate and compare" },
+        },
+        required: ["file"],
+      },
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const file = resolve((params.file as string) ?? "");
+        let content: string;
+        try {
+          content = await readFile(file, "utf8");
+        } catch {
+          return { file: params.file ?? null, found: false, note: "could not read the workflow file" };
+        }
+        if (!detectGitHubWorkflow(content)) {
+          return { file: params.file ?? null, found: false, note: "file does not look like a GitHub Actions workflow" };
+        }
+        const migration = await transform(content, { security: true, sourceFile: file });
+        const properties = migration.provenance
+          .filter((r) => r.security)
+          .map((r) => ({
+            property: r.security!.property,
+            fate: r.security!.fate,
+            severity: r.security!.severity,
+            reestablish: r.security!.reestablish ?? null,
+            note: r.note ?? null,
+          }));
+        const summary = { translated: 0, approximated: 0, "needs-review": 0, lost: 0 } as Record<string, number>;
+        for (const p of properties) summary[p.fate] = (summary[p.fate] ?? 0) + 1;
+        return { found: true, properties, summary };
       },
     },
   ];

--- a/lexicons/gitlab/src/plugin.test.ts
+++ b/lexicons/gitlab/src/plugin.test.ts
@@ -246,6 +246,7 @@ describe("gitlabPlugin", () => {
     expect(names).toContain("gitlab:pipeline-yaml");
     expect(names).toContain("gitlab:source");
     expect(names).toContain("gitlab:owns");
+    expect(names).toContain("gitlab:compare");
     for (const t of tools) {
       expect(typeof t.handler).toBe("function");
     }


### PR DESCRIPTION
Part of #327. Exposes the GitHub → GitLab migration **security-fate** analysis over MCP.

## Tool

`gitlab:compare` — given a `.github/workflows/*.yml`, migrate it to GitLab CI and report each security property's fate across the edge:

```json
{
  "found": true,
  "properties": [
    { "property": "Pinned action SHA", "fate": "lost", "severity": "warning", "reestablish": "#297", "note": "..." },
    { "property": "Least-privilege permissions", "fate": "needs-review", "severity": "warning", "reestablish": "#298" }
  ],
  "summary": { "translated": 0, "approximated": 0, "needs-review": 1, "lost": 1 }
}
```

Wraps the existing `transform({ security: true })` + the #306 security-fate model — no new analysis engine.

## One tool, not two (deliberate)

The issue listed `gitlab:compare` + `github:compare`. The GitHub → GitLab migration code lives in the **GitLab** lexicon, and the GitHub lexicon does not depend on GitLab. A `github:compare` would invert that dependency (or force a lazy optional cycle), so the migration safety view is exposed once, here. Documented in the lexicon page with the rationale.

## Tests
- SHA-pinned action → `lost`; missing file → not-found; non-workflow file → not-found
- full suite green (6024)

## Docs
- core `agent-integration.mdx` gitlab table + gitlab lexicon MCP table (regenerated)

Stacked on #334 (merged); rebased onto main.