### PR TITLE
test(gitlab): runtime E2E — run a chant pipeline in Docker (#327)

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,6 +54,10 @@ smoke-build-examples:
 smoke-npm-registry:
     ./test/smoke.sh npm-registry
 
+# Run a chant-generated GitLab pipeline in Docker (gitlab-ci-local; on-demand, needs Docker)
+gitlab-runtime-e2e:
+    bash test/gitlab-runtime-e2e.sh
+
 # Run all smoke tests
 smoke: smoke-workspace smoke-npm
 

--- a/test/gitlab-runtime-e2e.sh
+++ b/test/gitlab-runtime-e2e.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GitLab runtime E2E: build a chant pipeline and ACTUALLY RUN it in Docker.
+#
+# Unlike the post-synth checks (which prove the YAML is well-formed) and the
+# smoke tests (which prove the package installs), this proves GitLab CI accepts
+# and executes chant's generated `.gitlab-ci.yml` — image pull, scripts,
+# artifacts passed between jobs, and `needs:` ordering — using `gitlab-ci-local`
+# (a maintained local pipeline runner). `gitlab-runner exec` is intentionally
+# NOT used: it was removed in gitlab-runner 16.0.
+#
+# On-demand only — NOT part of the gating CI. It needs Docker + network and is
+# inherently slower/flakier than unit tests. Run it yourself:
+#
+#   just gitlab-runtime-e2e        (or)   bash test/gitlab-runtime-e2e.sh
+#
+# Exit codes: 0 pass or cleanly skipped (no Docker); non-zero on real failure.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE="$ROOT/test/gitlab-runtime-e2e"
+
+skip() { echo "SKIP: $1"; exit 0; }
+
+# ── Preconditions ────────────────────────────────────────────────────────────
+command -v docker >/dev/null 2>&1 || skip "docker not installed"
+docker info >/dev/null 2>&1 || skip "docker daemon not reachable"
+
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# ── 1. Build the fixture pipeline → .gitlab-ci.yml ───────────────────────────
+echo "=== Building fixture pipeline ==="
+npx tsx "$FIXTURE/build.ts" "$WORK"
+echo "--- generated .gitlab-ci.yml ---"
+cat "$WORK/.gitlab-ci.yml"
+echo "--------------------------------"
+
+# ── 2. Run the pipeline in Docker via gitlab-ci-local ────────────────────────
+echo "=== Running pipeline (gitlab-ci-local) ==="
+cd "$WORK"
+LOG="$WORK/run.log"
+if ! npx --yes gitlab-ci-local@4 --no-color 2>&1 | tee "$LOG"; then
+  echo "FAIL: gitlab-ci-local reported a job failure"
+  exit 1
+fi
+
+# ── 3. Assert both jobs ran and the artifact crossed the needs edge ──────────
+# gitlab-ci-local prints a per-job summary; a passing run shows each job's
+# script finishing. The `verify` job greps the artifact written by `build`, so
+# its success alone proves the artifact was passed across the `needs:` edge.
+if ! grep -Eq "verify.*finished|finished.*verify|verify.*pass" "$LOG"; then
+  # Fall back to the explicit script echo to be runner-version tolerant.
+  grep -q "built by chant" "$LOG" || { echo "FAIL: could not confirm the verify job ran"; exit 1; }
+fi
+
+echo "PASS: chant-generated pipeline built and executed in Docker"

--- a/test/gitlab-runtime-e2e/README.md
+++ b/test/gitlab-runtime-e2e/README.md
@@ -1,0 +1,24 @@
+# GitLab runtime E2E
+
+Proves GitLab CI actually **accepts and executes** chant's generated
+`.gitlab-ci.yml` — not just that the YAML is well-formed (the post-synth WGL
+checks already cover that) or that the package installs (the smoke tests cover
+that).
+
+`src/pipeline.infra.ts` is a minimal, dependency-free pipeline (alpine image, a
+script, an artifact, a `needs:` edge). `build.ts` builds it to a real
+`.gitlab-ci.yml`; `../gitlab-runtime-e2e.sh` then runs that pipeline in Docker
+with [`gitlab-ci-local`](https://github.com/firecow/gitlab-ci-local) and asserts
+both jobs run and the artifact crosses the `needs:` edge.
+
+`gitlab-runner exec` is deliberately not used — it was removed in
+gitlab-runner 16.0. `gitlab-ci-local` is the maintained local runner.
+
+## Run
+
+```bash
+just gitlab-runtime-e2e        # or: bash test/gitlab-runtime-e2e.sh
+```
+
+On-demand only. It needs Docker + network, so it is **not** part of the gating
+CI; it cleanly skips (exit 0) when Docker is unavailable.

--- a/test/gitlab-runtime-e2e/build.ts
+++ b/test/gitlab-runtime-e2e/build.ts
@@ -1,0 +1,39 @@
+/**
+ * Build the runtime-E2E fixture pipeline (./src) and write the generated
+ * .gitlab-ci.yml into the output directory passed as argv[2].
+ *
+ * Kept out of ./src so discovery doesn't import this driver. Run by
+ * test/gitlab-runtime-e2e.sh before handing the YAML to gitlab-ci-local.
+ */
+
+import { build } from "@intentius/chant/build";
+import { getPrimaryOutput } from "@intentius/chant/lint/post-synth";
+import { gitlabSerializer } from "@intentius/chant-lexicon-gitlab/serializer";
+import { writeFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = process.argv[2];
+if (!outDir) {
+  console.error("usage: tsx build.ts <output-dir>");
+  process.exit(2);
+}
+
+const result = await build(join(here, "src"), [gitlabSerializer]);
+if (result.errors.length > 0) {
+  console.error("build failed:");
+  for (const e of result.errors) console.error("  " + (e.message ?? String(e)));
+  process.exit(1);
+}
+
+const out = result.outputs.get("gitlab");
+const yaml = out ? getPrimaryOutput(out) : "";
+if (!yaml) {
+  console.error("no GitLab YAML produced");
+  process.exit(1);
+}
+
+const dest = join(outDir, ".gitlab-ci.yml");
+writeFileSync(dest, yaml);
+console.log(`wrote ${dest}`);

--- a/test/gitlab-runtime-e2e/src/pipeline.infra.ts
+++ b/test/gitlab-runtime-e2e/src/pipeline.infra.ts
@@ -1,0 +1,26 @@
+/**
+ * Self-contained GitLab pipeline used by the runtime E2E (test/gitlab-runtime-e2e.sh).
+ *
+ * Deliberately minimal and dependency-free (alpine, no network beyond the base
+ * image) so `gitlab-ci-local` can actually execute it in Docker. It exercises
+ * the parts a runtime check should prove work end to end: an image pull, a
+ * script, an artifact passed between jobs, and `needs:` ordering across stages.
+ */
+
+import { Job, Image, Artifacts } from "@intentius/chant-lexicon-gitlab";
+
+const alpine = new Image({ name: "alpine:3.20" });
+
+export const build = new Job({
+  stage: "build",
+  image: alpine,
+  script: ['echo "built by chant" > out.txt'],
+  artifacts: new Artifacts({ paths: ["out.txt"], expire_in: "1 hour" }),
+});
+
+export const verify = new Job({
+  stage: "test",
+  image: alpine,
+  needs: ["build"],
+  script: ["cat out.txt", 'grep -q "built by chant" out.txt'],
+});


### PR DESCRIPTION
Part of #327. The "full runtime E2E" — proves GitLab CI actually **accepts and executes** chant's generated `.gitlab-ci.yml`, beyond the static post-synth WGL checks (well-formed) and smoke tests (installs).

## What it does

`test/gitlab-runtime-e2e/src/pipeline.infra.ts` is a minimal, dependency-free pipeline (alpine image, a script, an artifact, a `needs:` edge). `build.ts` builds it to a real `.gitlab-ci.yml`; `test/gitlab-runtime-e2e.sh` runs that pipeline in Docker with [`gitlab-ci-local`](https://github.com/firecow/gitlab-ci-local) and asserts both jobs run and the artifact crosses the `needs:` edge.

Verified locally:
```
build  $ echo "built by chant" > out.txt
build  finished — exported artifacts
verify $ cat out.txt → built by chant
verify $ grep -q "built by chant" out.txt
 PASS  build
 PASS  verify
PASS: chant-generated pipeline built and executed in Docker
```

## Choices

- **`gitlab-ci-local`, not `gitlab-runner exec`** — `exec` was removed in gitlab-runner 16.0. `gitlab-ci-local` is the maintained local runner and supports stages/needs/artifacts.
- **On-demand, not gating CI** — `just gitlab-runtime-e2e`. It needs Docker + network and is slower/flakier than unit tests, so it stays out of the merge-gating CI to keep main green. The script cleanly **skips** (exit 0) when Docker is unavailable.

## Files
- `test/gitlab-runtime-e2e/{src/pipeline.infra.ts,build.ts,README.md}`, `test/gitlab-runtime-e2e.sh`, `just gitlab-runtime-e2e`

No production code changes; full unit suite green, core tsc clean.