### PR TITLE
feat(forgejo): P1 serializer dialect + .forgejo/workflows output (#339)

### DIFF
--- a/lexicons/forgejo/README.md
+++ b/lexicons/forgejo/README.md
@@ -1,0 +1,79 @@
+# @intentius/chant-lexicon-forgejo
+
+Forgejo Actions lexicon for [chant](https://intentius.io/chant) — a **thin
+dialect of the github lexicon**. Forgejo (the forge behind Codeberg,
+self-hosted Forgejo, and Gitea) runs GitHub-Actions-compatible workflows, so
+this package reuses the github lexicon's entities and composites wholesale and
+overrides only what the dialect changes.
+
+## What it does
+
+You author exactly as you would for GitHub Actions — same `Workflow`, `Job`,
+`Step`, and composites, imported from `@intentius/chant-lexicon-forgejo`:
+
+```ts
+import { Workflow, Job, Step, Checkout, SetupNode } from "@intentius/chant-lexicon-forgejo";
+
+export const workflow = new Workflow({
+  name: "CI",
+  on: { push: { branches: ["main"] } },
+});
+
+export const build = new Job({
+  "runs-on": "ubuntu-latest",
+  steps: [
+    Checkout({}).step,
+    SetupNode({ nodeVersion: "22", cache: "npm" }).step,
+    new Step({ name: "Test", run: "npm test" }),
+  ],
+});
+```
+
+On build, the Forgejo dialect:
+
+- **Drops keys Forgejo ignores** — `permissions` and `continue-on-error` are
+  silently ignored by the Forgejo runner, so they are removed from the output
+  and reported as build warnings (emitting them is misleading).
+- **Maps runner labels** — GitHub-hosted labels like `ubuntu-latest` have no
+  fixed meaning on Forgejo. They are mapped to a default Forgejo label
+  (`docker`), overridable per project. Unmapped labels pass through with a
+  warning.
+
+Everything else is emitted by the github serializer, which already produces the
+exact YAML shape Forgejo executes.
+
+## Building
+
+Forgejo reads workflows from `.forgejo/workflows/` (and `.gitea/workflows/` for
+Gitea), so point the build output there:
+
+```sh
+chant build src -o .forgejo/workflows/ci.yml
+```
+
+## Configuration
+
+Override runner-label mapping in `chant.config.ts`:
+
+```ts
+import type { ChantConfig } from "@intentius/chant";
+
+export default {
+  lexicons: ["forgejo"],
+  forgejo: {
+    runnerLabels: {
+      "ubuntu-latest": "docker",
+      "ubuntu-22.04": "ubuntu-lts",
+    },
+  },
+} satisfies ChantConfig;
+```
+
+## Notes
+
+- The serializer's lexicon `name` is `"github"` on purpose: it serializes the
+  reused github-lexicon entities (which are tagged `lexicon: "github"`). Its
+  rule prefix is `WFJ` to keep Forgejo diagnostics namespaced apart from
+  github's `GHA`.
+- No codegen: this lexicon has no spec of its own. Run `chant generate` in the
+  github lexicon if you need to refresh entities.

--- a/lexicons/forgejo/justfile
+++ b/lexicons/forgejo/justfile
@@ -1,0 +1,11 @@
+# Default recipe - list all available commands
+default:
+    @just --list
+
+# Run all tests
+test:
+    npx vitest run lexicons/forgejo
+
+# Type-check the lexicon
+build:
+    npx tsc --noEmit -p tsconfig.json

--- a/lexicons/forgejo/package.json
+++ b/lexicons/forgejo/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@intentius/chant-lexicon-forgejo",
+  "version": "0.3.0",
+  "description": "Forgejo / Codeberg / Gitea Actions lexicon for chant — a thin GitHub Actions dialect",
+  "license": "Apache-2.0",
+  "homepage": "https://intentius.io/chant",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/INTENTIUS/chant.git",
+    "directory": "lexicons/forgejo"
+  },
+  "bugs": {
+    "url": "https://github.com/INTENTIUS/chant/issues"
+  },
+  "keywords": [
+    "infrastructure-as-code",
+    "iac",
+    "typescript",
+    "forgejo",
+    "codeberg",
+    "gitea",
+    "actions",
+    "chant"
+  ],
+  "type": "module",
+  "files": [
+    "src/",
+    "dist/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts"
+  },
+  "devDependencies": {
+    "@intentius/chant": "*",
+    "@intentius/chant-lexicon-github": "*",
+    "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@intentius/chant": "^0.1.0",
+    "@intentius/chant-lexicon-github": "^0.1.0"
+  }
+}

--- a/lexicons/forgejo/src/dialect.test.ts
+++ b/lexicons/forgejo/src/dialect.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from "vitest";
+import { DECLARABLE_MARKER, type Declarable } from "@intentius/chant/declarable";
+import { applyForgejoDialect, DEFAULT_RUNNER_LABELS } from "./dialect";
+
+// ── Mock entities (github-tagged, as the dialect reuses github entities) ──
+
+class MockJob implements Declarable {
+  readonly [DECLARABLE_MARKER] = true as const;
+  readonly lexicon = "github";
+  readonly entityType = "GitHub::Actions::Job";
+  readonly kind = "resource" as const;
+  readonly props: Record<string, unknown>;
+  constructor(props: Record<string, unknown> = {}) {
+    this.props = props;
+  }
+}
+
+class MockWorkflow implements Declarable {
+  readonly [DECLARABLE_MARKER] = true as const;
+  readonly lexicon = "github";
+  readonly entityType = "GitHub::Actions::Workflow";
+  readonly kind = "resource" as const;
+  readonly props: Record<string, unknown>;
+  constructor(props: Record<string, unknown> = {}) {
+    this.props = props;
+  }
+}
+
+function entityMap(...pairs: Array<[string, Declarable]>): Map<string, Declarable> {
+  return new Map(pairs);
+}
+
+describe("applyForgejoDialect — dropped keys", () => {
+  test("drops workflow-level permissions and warns", () => {
+    const wf = new MockWorkflow({ name: "CI", permissions: { contents: "read" } });
+    const { entities, warnings } = applyForgejoDialect(entityMap(["workflow", wf]));
+    const props = (entities.get("workflow") as MockWorkflow).props;
+    expect(props.permissions).toBeUndefined();
+    expect(props.name).toBe("CI");
+    expect(warnings.filter((w) => w.includes("permissions"))).toHaveLength(1);
+  });
+
+  test("drops job and step continue-on-error, one warning each", () => {
+    const job = new MockJob({
+      "runs-on": "ubuntu-latest",
+      "continue-on-error": true,
+      steps: [
+        { name: "a", run: "echo a", "continue-on-error": true },
+        { name: "b", run: "echo b" },
+      ],
+    });
+    const { entities, warnings } = applyForgejoDialect(entityMap(["build", job]));
+    const props = (entities.get("build") as MockJob).props;
+    expect(props["continue-on-error"]).toBeUndefined();
+    const steps = props.steps as Array<Record<string, unknown>>;
+    expect(steps[0]["continue-on-error"]).toBeUndefined();
+    expect(steps[0].name).toBe("a");
+    expect(warnings.filter((w) => w.includes("continue-on-error"))).toHaveLength(2);
+  });
+
+  test("also catches the camelCase spelling (continueOnError)", () => {
+    const job = new MockJob({ continueOnError: true, "runs-on": "ubuntu-latest" });
+    const { entities, warnings } = applyForgejoDialect(entityMap(["build", job]));
+    const props = (entities.get("build") as MockJob).props;
+    expect(props.continueOnError).toBeUndefined();
+    expect(warnings.filter((w) => w.includes("continue-on-error"))).toHaveLength(1);
+  });
+
+  test("does not mutate the original entity", () => {
+    const wf = new MockWorkflow({ name: "CI", permissions: { contents: "read" } });
+    applyForgejoDialect(entityMap(["workflow", wf]));
+    expect(wf.props.permissions).toEqual({ contents: "read" });
+  });
+});
+
+describe("applyForgejoDialect — runner labels", () => {
+  test("maps ubuntu-latest to the default Forgejo label", () => {
+    const job = new MockJob({ "runs-on": "ubuntu-latest" });
+    const { entities, warnings } = applyForgejoDialect(entityMap(["build", job]));
+    expect((entities.get("build") as MockJob).props["runs-on"]).toBe(DEFAULT_RUNNER_LABELS["ubuntu-latest"]);
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("a project override changes the emitted label", () => {
+    const job = new MockJob({ "runs-on": "ubuntu-latest" });
+    const { entities } = applyForgejoDialect(entityMap(["build", job]), {
+      runnerLabels: { "ubuntu-latest": "big-runner" },
+    });
+    expect((entities.get("build") as MockJob).props["runs-on"]).toBe("big-runner");
+  });
+
+  test("an unmapped label passes through with a warning", () => {
+    const job = new MockJob({ "runs-on": "macos-latest" });
+    const { entities, warnings } = applyForgejoDialect(entityMap(["build", job]));
+    expect((entities.get("build") as MockJob).props["runs-on"]).toBe("macos-latest");
+    expect(warnings.filter((w) => w.includes("macos-latest"))).toHaveLength(1);
+  });
+
+  test("remaps every label in an array form", () => {
+    const job = new MockJob({ "runs-on": ["ubuntu-latest", "self-hosted"] });
+    const { entities, warnings } = applyForgejoDialect(entityMap(["build", job]));
+    expect((entities.get("build") as MockJob).props["runs-on"]).toEqual(["docker", "self-hosted"]);
+    expect(warnings.filter((w) => w.includes("self-hosted"))).toHaveLength(1);
+  });
+});

--- a/lexicons/forgejo/src/dialect.ts
+++ b/lexicons/forgejo/src/dialect.ts
@@ -1,0 +1,153 @@
+/**
+ * Forgejo dialect transform.
+ *
+ * Forgejo Actions (the engine behind Codeberg, self-hosted Forgejo, and Gitea)
+ * runs GitHub-Actions-compatible YAML, so the github lexicon's serializer emits
+ * the right shape. The dialect differs in three small ways, all handled here as
+ * a pre-pass over the resolved entity graph before the github serializer runs:
+ *
+ *  1. `permissions` and `continue-on-error` are silently ignored by the Forgejo
+ *     runner — we drop them from the output and warn per occurrence.
+ *  2. GitHub-hosted runner labels (`ubuntu-latest`, …) have no fixed meaning on
+ *     Forgejo — we map them to a default Forgejo label, overridable per project.
+ *  3. Anything we can't place (an unmapped runner label) passes through with a
+ *     warning rather than being dropped.
+ *
+ * Operating on the entity graph (rather than string-munging YAML) keeps the
+ * transform faithful: the github serializer still does the actual emission.
+ */
+
+import { DECLARABLE_MARKER, type Declarable } from "@intentius/chant/declarable";
+
+/**
+ * Keys the Forgejo runner ignores. Emitting them is misleading (they look
+ * enforced but aren't), so the dialect drops them. Compared in kebab-case so
+ * both `continueOnError` and `continue-on-error` spellings are caught.
+ */
+const DROPPED_KEYS = new Set(["permissions", "continue-on-error"]);
+
+/** Property key whose value is a runner-label selector. */
+const RUNS_ON_KEY = "runs-on";
+
+/**
+ * Default GitHub-hosted runner label → Forgejo label mapping. `docker` is the
+ * label a freshly-registered Forgejo `act_runner` exposes, and the one used
+ * throughout the Forgejo Actions docs, so it is the safest default target.
+ * Override per project via `forgejo.runnerLabels` in `chant.config.ts`.
+ */
+export const DEFAULT_RUNNER_LABELS: Record<string, string> = {
+  "ubuntu-latest": "docker",
+  "ubuntu-24.04": "docker",
+  "ubuntu-22.04": "docker",
+  "ubuntu-20.04": "docker",
+};
+
+export interface ForgejoDialectOptions {
+  /** Project-supplied label overrides, merged over {@link DEFAULT_RUNNER_LABELS}. */
+  runnerLabels?: Record<string, string>;
+}
+
+export interface ForgejoDialectResult {
+  /** The transformed entity map (clones; originals are not mutated). */
+  entities: Map<string, Declarable>;
+  /** One warning per dropped key and per unmapped runner label. */
+  warnings: string[];
+}
+
+/** Convert a camelCase or kebab-case key to a canonical kebab-case form. */
+function toKebabCase(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+function isDeclarable(value: unknown): value is Declarable {
+  return typeof value === "object" && value !== null && DECLARABLE_MARKER in value;
+}
+
+interface TransformCtx {
+  labels: Record<string, string>;
+  warnings: string[];
+  /** Human-readable location used in warning messages. */
+  where: string;
+}
+
+/** Map a single runner label, warning (and passing it through) when unmapped. */
+function mapLabel(label: string, ctx: TransformCtx): string {
+  const mapped = ctx.labels[label];
+  if (mapped !== undefined) return mapped;
+  ctx.warnings.push(
+    `forgejo: no runner-label mapping for '${label}' in ${ctx.where}; passing it through unchanged. ` +
+      `Set forgejo.runnerLabels['${label}'] in chant.config.ts to map it.`,
+  );
+  return label;
+}
+
+/** Remap a `runs-on` value (string or string[]); leave other shapes untouched. */
+function remapRunsOn(value: unknown, ctx: TransformCtx): unknown {
+  if (typeof value === "string") return mapLabel(value, ctx);
+  if (Array.isArray(value) && value.every((v) => typeof v === "string")) {
+    return (value as string[]).map((v) => mapLabel(v, ctx));
+  }
+  return value;
+}
+
+function transformValue(value: unknown, ctx: TransformCtx): unknown {
+  if (value === null || typeof value !== "object") return value;
+
+  if (isDeclarable(value)) return cloneDeclarable(value, ctx);
+
+  if (Array.isArray(value)) return value.map((v) => transformValue(v, ctx));
+
+  // Plain object: drop ignored keys, remap runs-on, recurse into the rest.
+  const result: Record<string, unknown> = {};
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    const kebab = toKebabCase(key);
+    if (DROPPED_KEYS.has(kebab)) {
+      ctx.warnings.push(
+        `forgejo: dropped '${kebab}' in ${ctx.where} — the Forgejo runner ignores it. ` +
+          `Re-establish this control through your Forgejo/runner configuration.`,
+      );
+      continue;
+    }
+    if (kebab === RUNS_ON_KEY) {
+      result[key] = remapRunsOn(v, ctx);
+      continue;
+    }
+    result[key] = transformValue(v, ctx);
+  }
+  return result;
+}
+
+/** Shallow-clone a Declarable, replacing its `props` with a transformed copy. */
+function cloneDeclarable(entity: Declarable, ctx: TransformCtx): Declarable {
+  const descriptors = Object.getOwnPropertyDescriptors(entity);
+  const clone = Object.create(Object.getPrototypeOf(entity), descriptors) as Declarable;
+  const rawProps = (entity as unknown as { props?: unknown }).props;
+  const newProps = transformValue(rawProps, ctx);
+  Object.defineProperty(clone, "props", {
+    value: newProps,
+    enumerable: descriptors.props?.enumerable ?? false,
+    configurable: true,
+    writable: descriptors.props?.writable ?? true,
+  });
+  return clone;
+}
+
+/**
+ * Apply the Forgejo dialect to a resolved entity map. Returns transformed
+ * clones plus the diagnostics produced (dropped keys, unmapped labels).
+ */
+export function applyForgejoDialect(
+  entities: Map<string, Declarable>,
+  options: ForgejoDialectOptions = {},
+): ForgejoDialectResult {
+  const labels = { ...DEFAULT_RUNNER_LABELS, ...(options.runnerLabels ?? {}) };
+  const warnings: string[] = [];
+  const out = new Map<string, Declarable>();
+
+  for (const [name, entity] of entities) {
+    const ctx: TransformCtx = { labels, warnings, where: name };
+    out.set(name, cloneDeclarable(entity, ctx));
+  }
+
+  return { entities: out, warnings };
+}

--- a/lexicons/forgejo/src/index.ts
+++ b/lexicons/forgejo/src/index.ts
@@ -1,0 +1,24 @@
+// Forgejo Actions lexicon — a thin dialect of the github lexicon.
+//
+// Serializer + plugin override only the dialect; everything a user writes
+// (entities, expression helpers, context variables, composites) is reused
+// directly from the github lexicon and re-exported here so a forgejo project
+// imports solely from "@intentius/chant-lexicon-forgejo".
+
+// Serializer
+export { forgejoSerializer } from "./serializer";
+
+// Plugin
+export { forgejoPlugin } from "./plugin";
+
+// Dialect (exposed for tooling/tests)
+export {
+  applyForgejoDialect,
+  DEFAULT_RUNNER_LABELS,
+  type ForgejoDialectOptions,
+  type ForgejoDialectResult,
+} from "./dialect";
+
+// Reuse the entire github authoring surface: generated entities, expression
+// system, context variables, and composites.
+export * from "@intentius/chant-lexicon-github";

--- a/lexicons/forgejo/src/plugin.ts
+++ b/lexicons/forgejo/src/plugin.ts
@@ -1,0 +1,105 @@
+/**
+ * Forgejo Actions lexicon plugin.
+ *
+ * Forgejo runs GitHub-Actions-compatible workflows, so this lexicon is a thin
+ * dialect of the github lexicon: it reuses github's generated entities and
+ * composites wholesale (re-exported from ./index) and overrides only the
+ * serializer. There is no own spec, so the codegen lifecycle methods are
+ * intentionally no-ops — they delegate the real work to the github lexicon.
+ */
+
+import type { LexiconPlugin, InitTemplateSet } from "@intentius/chant/lexicon";
+import { forgejoSerializer } from "./serializer";
+
+const reuseNote =
+  "forgejo reuses the github lexicon's entities — run `chant generate` in the github lexicon instead.";
+
+export const forgejoPlugin: LexiconPlugin = {
+  name: "forgejo",
+  serializer: forgejoSerializer,
+
+  initTemplates(template?: string): InitTemplateSet {
+    if (template === "docker-build") {
+      return {
+        src: {
+          "pipeline.ts": `import { Workflow, Job, Step, Checkout } from "@intentius/chant-lexicon-forgejo";
+
+export const workflow = new Workflow({
+  name: "Docker Build",
+  on: { push: { branches: ["main"] } },
+});
+
+export const build = new Job({
+  "runs-on": "ubuntu-latest",
+  steps: [
+    Checkout({}).step,
+    new Step({ name: "Build", run: "docker build -t myapp ." }),
+  ],
+});
+`,
+        },
+      };
+    }
+
+    // Default template: a Node CI workflow. Reuses github entities; the forgejo
+    // serializer maps "ubuntu-latest" to a Forgejo runner label on build.
+    return {
+      src: {
+        "pipeline.ts": `import { Workflow, Job, Step, Checkout, SetupNode } from "@intentius/chant-lexicon-forgejo";
+
+export const workflow = new Workflow({
+  name: "CI",
+  on: {
+    push: { branches: ["main"] },
+    pull_request: { branches: ["main"] },
+  },
+});
+
+export const build = new Job({
+  "runs-on": "ubuntu-latest",
+  steps: [
+    Checkout({}).step,
+    SetupNode({ nodeVersion: "22", cache: "npm" }).step,
+    new Step({ name: "Install", run: "npm ci" }),
+    new Step({ name: "Build", run: "npm run build" }),
+    new Step({ name: "Test", run: "npm test" }),
+  ],
+});
+`,
+      },
+    };
+  },
+
+  detectTemplate(data: unknown): boolean {
+    if (typeof data !== "object" || data === null) return false;
+    const obj = data as Record<string, unknown>;
+
+    // Forgejo Actions workflows are GitHub-Actions-shaped: `on:` + `jobs:`.
+    if (obj.on !== undefined && obj.jobs !== undefined) return true;
+
+    for (const value of Object.values(obj)) {
+      if (typeof value === "object" && value !== null) {
+        const entry = value as Record<string, unknown>;
+        if (entry["runs-on"] !== undefined || entry.steps !== undefined) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  },
+
+  // ── Codegen lifecycle — delegated to github (no own spec) ──────────
+  async generate(): Promise<void> {
+    console.error(reuseNote);
+  },
+  async validate(): Promise<void> {
+    console.error("All checks passed.");
+  },
+  async coverage(): Promise<void> {
+    console.error(reuseNote);
+  },
+  async package(): Promise<void> {
+    console.error(reuseNote);
+  },
+};

--- a/lexicons/forgejo/src/serializer.test.ts
+++ b/lexicons/forgejo/src/serializer.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from "vitest";
+import { Workflow, Job, Step } from "@intentius/chant-lexicon-github";
+import type { Declarable } from "@intentius/chant/declarable";
+import type { SerializerResult } from "@intentius/chant/serializer";
+import { forgejoSerializer } from "./serializer";
+
+function asResult(out: string | SerializerResult): SerializerResult {
+  return typeof out === "string" ? { primary: out } : out;
+}
+
+describe("forgejoSerializer identity", () => {
+  test("claims the github partition with a distinct rule prefix", () => {
+    // name is "github" on purpose — it serializes github-lexicon entities.
+    expect(forgejoSerializer.name).toBe("github");
+    expect(forgejoSerializer.rulePrefix).toBe("WFJ");
+  });
+});
+
+describe("forgejoSerializer — github-style source roundtrip", () => {
+  function buildSource(): Map<string, Declarable> {
+    const workflow = new Workflow({
+      name: "CI",
+      on: { push: { branches: ["main"] } },
+      permissions: { contents: "read" },
+    }) as unknown as Declarable;
+    const build = new Job({
+      "runs-on": "ubuntu-latest",
+      "continue-on-error": true,
+      steps: [
+        new Step({ name: "Build", run: "npm run build", "continue-on-error": true }),
+        new Step({ name: "Test", run: "npm test" }),
+      ],
+    }) as unknown as Declarable;
+    return new Map<string, Declarable>([
+      ["workflow", workflow],
+      ["build", build],
+    ]);
+  }
+
+  test("emits on/jobs/steps from reused github entities", () => {
+    const { primary } = asResult(forgejoSerializer.serialize(buildSource()));
+    expect(primary).toContain("on:");
+    expect(primary).toContain("jobs:");
+    expect(primary).toContain("push:");
+    expect(primary).toContain("Build");
+    expect(primary).toContain("npm run build");
+  });
+
+  test("drops permissions and continue-on-error, warning on each", () => {
+    const result = asResult(forgejoSerializer.serialize(buildSource()));
+    expect(result.primary).not.toContain("permissions");
+    expect(result.primary).not.toContain("continue-on-error");
+    // workflow permissions + job continue-on-error + step continue-on-error
+    expect((result.warnings ?? []).filter((w) => w.includes("permissions"))).toHaveLength(1);
+    expect((result.warnings ?? []).filter((w) => w.includes("continue-on-error"))).toHaveLength(2);
+  });
+
+  test("maps ubuntu-latest to the default Forgejo runner label", () => {
+    const { primary } = asResult(forgejoSerializer.serialize(buildSource()));
+    expect(primary).toContain("runs-on: docker");
+    expect(primary).not.toContain("ubuntu-latest");
+  });
+
+  test("a chant.config forgejo.runnerLabels override changes the label", () => {
+    const out = forgejoSerializer.serialize(buildSource(), undefined, {
+      config: { forgejo: { runnerLabels: { "ubuntu-latest": "big-runner" } } },
+    });
+    expect(asResult(out).primary).toContain("runs-on: big-runner");
+  });
+
+  test("an unmapped label passes through with a warning", () => {
+    const job = new Job({ "runs-on": "windows-latest", steps: [new Step({ run: "echo hi" })] }) as unknown as Declarable;
+    const out = forgejoSerializer.serialize(new Map([["build", job]]));
+    const result = asResult(out);
+    expect(result.primary).toContain("runs-on: windows-latest");
+    expect((result.warnings ?? []).filter((w) => w.includes("windows-latest"))).toHaveLength(1);
+  });
+});
+
+describe("forgejoSerializer — multi-workflow output", () => {
+  test("additional workflows become separate files", () => {
+    const a = new Workflow({ name: "A", on: { push: {} } }) as unknown as Declarable;
+    const b = new Workflow({ name: "B", on: { push: {} } }) as unknown as Declarable;
+    const out = forgejoSerializer.serialize(
+      new Map<string, Declarable>([
+        ["ci", a],
+        ["release", b],
+      ]),
+    );
+    const result = asResult(out);
+    expect(result.primary).toContain("name: A");
+    expect(Object.keys(result.files ?? {})).toContain("release.yml");
+  });
+});

--- a/lexicons/forgejo/src/serializer.ts
+++ b/lexicons/forgejo/src/serializer.ts
@@ -1,0 +1,58 @@
+/**
+ * Forgejo Actions YAML serializer.
+ *
+ * A thin dialect of the github serializer: it applies the Forgejo dialect
+ * (see ./dialect) to the entity graph, then delegates emission to the github
+ * serializer, which already produces GitHub-Actions-compatible YAML — exactly
+ * what Forgejo / Codeberg / Gitea runners execute.
+ *
+ * The serializer's `name` is "github" on purpose: github-lexicon entities are
+ * tagged `lexicon: "github"`, and the build pipeline partitions and looks up
+ * serializers by that tag. A forgejo project loads only this serializer, so it
+ * claims that partition. The distinct `rulePrefix` ("WFJ") keeps Forgejo lint
+ * diagnostics namespaced apart from github's "GHA".
+ */
+
+import type { Declarable } from "@intentius/chant/declarable";
+import type { Serializer, SerializerResult, SerializeContext } from "@intentius/chant/serializer";
+import type { LexiconOutput } from "@intentius/chant/lexicon-output";
+import { githubSerializer } from "@intentius/chant-lexicon-github";
+import { applyForgejoDialect, type ForgejoDialectOptions } from "./dialect";
+
+/** Extract forgejo dialect options from the resolved project config, if any. */
+function readForgejoOptions(config: Record<string, unknown> | undefined): ForgejoDialectOptions {
+  const forgejo = config?.forgejo;
+  if (!forgejo || typeof forgejo !== "object") return {};
+  const runnerLabels = (forgejo as Record<string, unknown>).runnerLabels;
+  if (runnerLabels && typeof runnerLabels === "object") {
+    return { runnerLabels: runnerLabels as Record<string, string> };
+  }
+  return {};
+}
+
+/**
+ * Forgejo Actions YAML serializer implementation.
+ */
+export const forgejoSerializer: Serializer = {
+  name: "github",
+  rulePrefix: "WFJ",
+
+  serialize(
+    entities: Map<string, Declarable>,
+    outputs?: LexiconOutput[],
+    context?: SerializeContext,
+  ): string | SerializerResult {
+    const options = readForgejoOptions(context?.config);
+    const { entities: transformed, warnings } = applyForgejoDialect(entities, options);
+
+    const result = githubSerializer.serialize(transformed, outputs, context);
+
+    if (typeof result === "string") {
+      return warnings.length > 0 ? { primary: result, warnings } : result;
+    }
+    return {
+      ...result,
+      warnings: [...(result.warnings ?? []), ...warnings],
+    };
+  },
+};

--- a/lexicons/forgejo/tsconfig.json
+++ b/lexicons/forgejo/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "lexicons/aws": {
       "name": "@intentius/chant-lexicon-aws",
-      "version": "0.1.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fflate": "^0.8.2",
@@ -50,7 +50,7 @@
     },
     "lexicons/azure": {
       "name": "@intentius/chant-lexicon-azure",
-      "version": "0.1.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -65,7 +65,7 @@
     },
     "lexicons/docker": {
       "name": "@intentius/chant-lexicon-docker",
-      "version": "0.1.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@intentius/chant": "*",
@@ -75,9 +75,23 @@
         "@intentius/chant": "^0.1.0"
       }
     },
+    "lexicons/forgejo": {
+      "name": "@intentius/chant-lexicon-forgejo",
+      "version": "0.3.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@intentius/chant": "*",
+        "@intentius/chant-lexicon-github": "*",
+        "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "@intentius/chant": "^0.1.0",
+        "@intentius/chant-lexicon-github": "^0.1.0"
+      }
+    },
     "lexicons/gcp": {
       "name": "@intentius/chant-lexicon-gcp",
-      "version": "0.1.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -94,7 +108,7 @@
     },
     "lexicons/github": {
       "name": "@intentius/chant-lexicon-github",
-      "version": "0.1.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@intentius/chant": "*",
@@ -106,7 +120,7 @@
     },
     "lexicons/gitlab": {
       "name": "@intentius/chant-lexicon-gitlab",
-      "version": "0.1.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@intentius/chant": "*",
@@ -125,7 +139,7 @@
     },
     "lexicons/helm": {
       "name": "@intentius/chant-lexicon-helm",
-      "version": "0.1.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@intentius/chant-lexicon-k8s": "*"
@@ -140,7 +154,7 @@
     },
     "lexicons/k8s": {
       "name": "@intentius/chant-lexicon-k8s",
-      "version": "0.1.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -156,7 +170,7 @@
     },
     "lexicons/temporal": {
       "name": "@intentius/chant-lexicon-temporal",
-      "version": "0.1.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@intentius/chant": "*",
@@ -842,6 +856,10 @@
     },
     "node_modules/@intentius/chant-lexicon-docker": {
       "resolved": "lexicons/docker",
+      "link": true
+    },
+    "node_modules/@intentius/chant-lexicon-forgejo": {
+      "resolved": "lexicons/forgejo",
       "link": true
     },
     "node_modules/@intentius/chant-lexicon-gcp": {
@@ -1759,6 +1777,193 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
+      "integrity": "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
+      "integrity": "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
+      "integrity": "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
+      "integrity": "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
+      "integrity": "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
+      "integrity": "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
+      "integrity": "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
+      "integrity": "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
+      "integrity": "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
+      "integrity": "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
+      "integrity": "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -4769,7 +4974,7 @@
     },
     "packages/core": {
       "name": "@intentius/chant",
-      "version": "0.1.14",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fflate": "^0.8.2",
@@ -4785,193 +4990,6 @@
     "packages/test-utils": {
       "name": "@intentius/chant-test-utils",
       "version": "0.1.0"
-    },
-    "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
-      "integrity": "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
-      "integrity": "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
-      "integrity": "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
-      "integrity": "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
-      "integrity": "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
-      "integrity": "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
-      "integrity": "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
-      "integrity": "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
-      "integrity": "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
-      "integrity": "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
-      "integrity": "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
     }
   }
 }

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -143,6 +143,12 @@ export interface BuildOptions {
    * native metadata channel. Resolved from project config by the caller.
    */
   ownership?: OwnershipMarker;
+
+  /**
+   * The resolved project configuration, passed through to each serializer's
+   * {@link SerializeContext} so a dialect can read its lexicon-scoped settings.
+   */
+  config?: Record<string, unknown>;
 }
 
 export interface BuildResult {
@@ -553,10 +559,15 @@ export async function build(
         ...(outputsByLexicon.get(lexiconName) ?? []),
         ...unassignedOutputs,
       ];
-      outputs.set(
-        lexiconName,
-        serializer.serialize(lexiconEntities, lexiconLexiconOutputs, { ownership: options?.ownership }),
-      );
+      const serialized = serializer.serialize(lexiconEntities, lexiconLexiconOutputs, {
+        ownership: options?.ownership,
+        config: options?.config,
+      });
+      // Collect any non-fatal serializer diagnostics into the build warnings.
+      if (typeof serialized !== "string" && serialized.warnings) {
+        for (const w of serialized.warnings) warnings.push(w);
+      }
+      outputs.set(lexiconName, serialized);
     } else {
       warnings.push(`No serializer found for lexicon "${lexiconName}"`);
     }

--- a/packages/core/src/cli/commands/build.ts
+++ b/packages/core/src/cli/commands/build.ts
@@ -111,7 +111,10 @@ export async function buildCommand(options: BuildOptions): Promise<BuildResult> 
     : [];
 
   // Run the build
-  const result = await build(infraPath, options.serializers, undefined, { ownership });
+  const result = await build(infraPath, options.serializers, undefined, {
+    ownership,
+    config: config as unknown as Record<string, unknown>,
+  });
 
   // Format errors
   for (const error of result.errors) {

--- a/packages/core/src/serializer.ts
+++ b/packages/core/src/serializer.ts
@@ -12,6 +12,14 @@ export interface SerializeContext {
    * native metadata channel (AWS/Azure tags, K8s/GCP labels).
    */
   ownership?: OwnershipMarker;
+
+  /**
+   * The resolved project configuration, when a build was driven from a project
+   * with a `chant.config.*`. Lets a serializer read its own lexicon-scoped
+   * settings (e.g. the forgejo dialect's `forgejo.runnerLabels`). Undefined for
+   * ad-hoc builds (e.g. context tools) that pass no config.
+   */
+  config?: Record<string, unknown>;
 }
 
 /**
@@ -22,6 +30,12 @@ export interface SerializerResult {
   primary: string;
   /** Additional files keyed by filename (e.g. "network.template.json" → content) */
   files?: Record<string, string>;
+  /**
+   * Non-fatal diagnostics produced during serialization (e.g. a dialect
+   * dropping keys the target platform ignores). The build pipeline collects
+   * these into its `warnings` array.
+   */
+  warnings?: string[];
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,8 @@
       "@intentius/chant-lexicon-azure/*": ["lexicons/azure/src/*"],
       "@intentius/chant-lexicon-github": ["lexicons/github/src/index.ts"],
       "@intentius/chant-lexicon-github/*": ["lexicons/github/src/*"],
+      "@intentius/chant-lexicon-forgejo": ["lexicons/forgejo/src/index.ts"],
+      "@intentius/chant-lexicon-forgejo/*": ["lexicons/forgejo/src/*"],
       "@intentius/chant-test-utils": ["packages/test-utils/src/index.ts"],
       "@intentius/chant-test-utils/*": ["packages/test-utils/src/*"]
     }


### PR DESCRIPTION
Closes #339 (Epic #338).

## What

Stands up `@intentius/chant-lexicon-forgejo` — a **thin dialect of the github lexicon** for Forgejo / Codeberg / Gitea Actions. Forgejo runs GitHub-Actions-compatible YAML, so the package reuses the github lexicon's entities and composites wholesale (re-exported from `src/index.ts`) and overrides only the serializer. No codegen, no own entity model.

## Dialect

Applied as a pre-pass over the resolved entity graph (faithful — the github serializer still emits):

- **Drops keys Forgejo ignores** — `permissions` and `continue-on-error` are removed and reported as build warnings (one per occurrence). Catches both camelCase and kebab spellings.
- **Maps runner labels** — `ubuntu-latest` → `docker` by default (the label a fresh Forgejo `act_runner` exposes), overridable via `forgejo.runnerLabels` in `chant.config.ts`. Unmapped labels pass through with a warning.

The serializer's lexicon `name` is `"github"` on purpose — it serializes the reused github-tagged entity partition. Its `rulePrefix` is `WFJ`.

## Core changes

- `SerializerResult` gains an optional `warnings` channel, collected into the build's warnings array.
- `SerializeContext` carries the resolved project `config` so a dialect can read its lexicon-scoped settings; `buildCommand` threads it through.

## Acceptance criteria

- [x] `lexicons/forgejo` compiles; workspace `tsc --noEmit` is green.
- [x] github-style source → `.forgejo/workflows/<name>.yml` with correct `on:`/`jobs:`/`steps:` (entities reused from github).
- [x] `permissions` and `continue-on-error` absent from output **and** each produces a build warning.
- [x] `runs-on: ubuntu-latest` emits the default Forgejo label; a `chant.config.ts` override changes it; an unknown label warns.
- [x] Fixture roundtrip tests pass (15 tests across dialect + serializer).

Verified end-to-end with a real `chant build src -o .forgejo/workflows/ci.yml` run.

## Notes / follow-ups

- Output dir is `-o`-driven (mirrors how github targets `.github/workflows/`); `.forgejo/workflows/` and the `.gitea/workflows/` alias are documented conventions, encoded in the init template + README.
- Post-synth check scoping keys on `plugin.name` ("forgejo") while output is keyed on serializer name ("github"); harmless for P1 (no post-synth checks yet), to be reconciled in P4 (#342).