### PR TITLE
feat(forgejo): P2 uses: action-ref resolver + unmapped-ref report (#340)

### DIFF
--- a/lexicons/forgejo/README.md
+++ b/lexicons/forgejo/README.md
@@ -38,6 +38,13 @@ On build, the Forgejo dialect:
   fixed meaning on Forgejo. They are mapped to a default Forgejo label
   (`docker`), overridable per project. Unmapped labels pass through with a
   warning.
+- **Resolves `uses:` action refs** — Forgejo has no GitHub Marketplace, so a
+  bare `uses: actions/checkout@v4` is rewritten to a resolvable form. Common
+  `actions/*` are mapped under an actions root (`https://code.forgejo.org` by
+  default, overridable via `forgejo.actionsRoot`); `docker/*` are pinned to
+  their full GitHub URL. Local (`./…`), `docker://`, and full-URL refs pass
+  through untouched. Anything else passes through **and is reported** as a
+  warning so it's never silently unresolvable.
 
 Everything else is emitted by the github serializer, which already produces the
 exact YAML shape Forgejo executes.
@@ -65,6 +72,8 @@ export default {
       "ubuntu-latest": "docker",
       "ubuntu-22.04": "ubuntu-lts",
     },
+    // Base for resolving mirrored `uses:` action refs.
+    actionsRoot: "https://code.forgejo.org",
   },
 } satisfies ChantConfig;
 ```

--- a/lexicons/forgejo/src/actions.test.ts
+++ b/lexicons/forgejo/src/actions.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from "vitest";
+import { resolveActionRef, DEFAULT_ACTIONS_ROOT } from "./actions";
+
+describe("resolveActionRef — mapped actions", () => {
+  test("rewrites actions/checkout@v4 under the default actions root", () => {
+    const { rewritten, warning } = resolveActionRef("actions/checkout@v4");
+    expect(rewritten).toBe(`${DEFAULT_ACTIONS_ROOT}/actions/checkout@v4`);
+    expect(warning).toBeUndefined();
+  });
+
+  test("rewrites the common actions/* set", () => {
+    for (const name of [
+      "actions/setup-node",
+      "actions/setup-go",
+      "actions/setup-python",
+      "actions/cache",
+      "actions/upload-artifact",
+      "actions/download-artifact",
+    ]) {
+      const { rewritten, warning } = resolveActionRef(`${name}@v4`);
+      expect(rewritten).toBe(`${DEFAULT_ACTIONS_ROOT}/${name}@v4`);
+      expect(warning).toBeUndefined();
+    }
+  });
+
+  test("pins docker/* to a full GitHub URL, independent of the actions root", () => {
+    const { rewritten, warning } = resolveActionRef("docker/build-push-action@v5", {
+      actionsRoot: "https://example.test",
+    });
+    expect(rewritten).toBe("https://github.com/docker/build-push-action@v5");
+    expect(warning).toBeUndefined();
+  });
+
+  test("preserves a subpath", () => {
+    const { rewritten } = resolveActionRef("actions/cache/restore@v4");
+    expect(rewritten).toBe(`${DEFAULT_ACTIONS_ROOT}/actions/cache/restore@v4`);
+  });
+
+  test("handles a ref with no version", () => {
+    const { rewritten } = resolveActionRef("actions/checkout");
+    expect(rewritten).toBe(`${DEFAULT_ACTIONS_ROOT}/actions/checkout`);
+  });
+});
+
+describe("resolveActionRef — actionsRoot override", () => {
+  test("override changes the base for mirrored actions", () => {
+    const { rewritten } = resolveActionRef("actions/checkout@v4", {
+      actionsRoot: "https://codeberg.org",
+    });
+    expect(rewritten).toBe("https://codeberg.org/actions/checkout@v4");
+  });
+
+  test("a trailing slash on the root is normalized", () => {
+    const { rewritten } = resolveActionRef("actions/checkout@v4", {
+      actionsRoot: "https://codeberg.org/",
+    });
+    expect(rewritten).toBe("https://codeberg.org/actions/checkout@v4");
+  });
+});
+
+describe("resolveActionRef — unmapped refs", () => {
+  test("passes an unmapped owner/repo through and reports it", () => {
+    const { rewritten, warning } = resolveActionRef("some-org/custom-action@v1");
+    expect(rewritten).toBe("some-org/custom-action@v1");
+    expect(warning).toBeDefined();
+    expect(warning).toContain("some-org/custom-action@v1");
+  });
+});
+
+describe("resolveActionRef — already-resolvable refs", () => {
+  test.each([
+    "./.forgejo/actions/local",
+    "../shared/action",
+    "docker://alpine:3.20",
+    "https://codeberg.org/actions/checkout@v4",
+    "http://example.test/x@v1",
+  ])("leaves %s untouched without warning", (ref) => {
+    const { rewritten, warning } = resolveActionRef(ref);
+    expect(rewritten).toBe(ref);
+    expect(warning).toBeUndefined();
+  });
+});

--- a/lexicons/forgejo/src/actions.ts
+++ b/lexicons/forgejo/src/actions.ts
@@ -1,0 +1,112 @@
+/**
+ * Forgejo `uses:` action-reference resolver.
+ *
+ * GitHub Actions resolves a bare `uses: actions/checkout@v4` against the GitHub
+ * Marketplace. Forgejo / Codeberg / Gitea runners have no Marketplace, so such a
+ * ref must be rewritten to a form their runner can fetch — a full repository URL,
+ * or a path under a configured actions root that mirrors the action.
+ *
+ * The resolver rewrites a built-in set of common actions and reports anything it
+ * can't place as a diagnostic (never dropping or silently passing it through).
+ */
+
+/**
+ * Default actions root. `code.forgejo.org` hosts the Forgejo `actions/*` mirror
+ * (checkout, setup-*, cache, upload/download-artifact, …). Override per project
+ * via `forgejo.actionsRoot` in `chant.config.ts`.
+ */
+export const DEFAULT_ACTIONS_ROOT = "https://code.forgejo.org";
+
+/**
+ * Where a known action resolves:
+ *  - `mirror`: `<actionsRoot>/<repo>` — follows the configured actions root.
+ *  - `url`:    an absolute base URL — independent of the actions root (used for
+ *              actions not carried by the Forgejo mirror, e.g. `docker/*`).
+ */
+export type ActionTarget = { kind: "mirror"; repo: string } | { kind: "url"; url: string };
+
+/** Built-in mapping of GitHub action `owner/repo` → Forgejo-resolvable target. */
+export const KNOWN_ACTIONS: Record<string, ActionTarget> = {
+  // actions/* — mirrored on the Forgejo actions root.
+  "actions/checkout": { kind: "mirror", repo: "actions/checkout" },
+  "actions/setup-node": { kind: "mirror", repo: "actions/setup-node" },
+  "actions/setup-go": { kind: "mirror", repo: "actions/setup-go" },
+  "actions/setup-python": { kind: "mirror", repo: "actions/setup-python" },
+  "actions/setup-java": { kind: "mirror", repo: "actions/setup-java" },
+  "actions/setup-dotnet": { kind: "mirror", repo: "actions/setup-dotnet" },
+  "actions/cache": { kind: "mirror", repo: "actions/cache" },
+  "actions/upload-artifact": { kind: "mirror", repo: "actions/upload-artifact" },
+  "actions/download-artifact": { kind: "mirror", repo: "actions/download-artifact" },
+  // docker/* — not on the Forgejo mirror; pin to the full GitHub URL, which
+  // Forgejo runners can fetch directly.
+  "docker/build-push-action": { kind: "url", url: "https://github.com/docker/build-push-action" },
+  "docker/login-action": { kind: "url", url: "https://github.com/docker/login-action" },
+  "docker/setup-buildx-action": { kind: "url", url: "https://github.com/docker/setup-buildx-action" },
+  "docker/setup-qemu-action": { kind: "url", url: "https://github.com/docker/setup-qemu-action" },
+  "docker/metadata-action": { kind: "url", url: "https://github.com/docker/metadata-action" },
+};
+
+export interface ActionResolveOptions {
+  /** Base for `mirror` targets; defaults to {@link DEFAULT_ACTIONS_ROOT}. */
+  actionsRoot?: string;
+  /** Mapping table to use; defaults to {@link KNOWN_ACTIONS}. */
+  known?: Record<string, ActionTarget>;
+}
+
+export interface ActionResolveResult {
+  /** The rewritten (or unchanged) `uses:` ref. */
+  rewritten: string;
+  /** Set when the ref could not be resolved — surfaced as a build warning. */
+  warning?: string;
+}
+
+/** A ref that already resolves on Forgejo as-is needs no rewrite and no warning. */
+function isAlreadyResolvable(ref: string): boolean {
+  return (
+    ref.startsWith("./") ||
+    ref.startsWith("../") ||
+    ref.startsWith(".\\") ||
+    ref.startsWith("docker://") ||
+    /^https?:\/\//.test(ref)
+  );
+}
+
+/**
+ * Resolve a single `uses:` action ref to a Forgejo-resolvable form.
+ */
+export function resolveActionRef(ref: string, options: ActionResolveOptions = {}): ActionResolveResult {
+  const trimmed = ref.trim();
+  if (trimmed === "" || isAlreadyResolvable(trimmed)) return { rewritten: ref };
+
+  const root = (options.actionsRoot ?? DEFAULT_ACTIONS_ROOT).replace(/\/+$/, "");
+  const known = options.known ?? KNOWN_ACTIONS;
+
+  const atIndex = trimmed.lastIndexOf("@");
+  const path = atIndex >= 0 ? trimmed.slice(0, atIndex) : trimmed;
+  const version = atIndex >= 0 ? trimmed.slice(atIndex + 1) : "";
+
+  const segments = path.split("/");
+  if (segments.length < 2) {
+    return { rewritten: ref, warning: unresolvedWarning(trimmed) };
+  }
+
+  const actionName = `${segments[0]}/${segments[1]}`;
+  const subpath = segments.slice(2).join("/");
+  const target = known[actionName];
+  if (!target) {
+    return { rewritten: ref, warning: unresolvedWarning(trimmed) };
+  }
+
+  const base = target.kind === "mirror" ? `${root}/${target.repo}` : target.url;
+  const withSubpath = subpath ? `${base}/${subpath}` : base;
+  const rewritten = version ? `${withSubpath}@${version}` : withSubpath;
+  return { rewritten };
+}
+
+function unresolvedWarning(ref: string): string {
+  return (
+    `forgejo: unresolved action ref '${ref}' — it has no built-in mapping and won't ` +
+    `resolve from a GitHub Marketplace on Forgejo. Use a full repository URL, or mirror ` +
+    `it under forgejo.actionsRoot in chant.config.ts.`
+  );
+}

--- a/lexicons/forgejo/src/dialect.ts
+++ b/lexicons/forgejo/src/dialect.ts
@@ -18,6 +18,7 @@
  */
 
 import { DECLARABLE_MARKER, type Declarable } from "@intentius/chant/declarable";
+import { resolveActionRef } from "./actions";
 
 /**
  * Keys the Forgejo runner ignores. Emitting them is misleading (they look
@@ -28,6 +29,9 @@ const DROPPED_KEYS = new Set(["permissions", "continue-on-error"]);
 
 /** Property key whose value is a runner-label selector. */
 const RUNS_ON_KEY = "runs-on";
+
+/** Property key whose value is an action/workflow reference. */
+const USES_KEY = "uses";
 
 /**
  * Default GitHub-hosted runner label → Forgejo label mapping. `docker` is the
@@ -45,6 +49,8 @@ export const DEFAULT_RUNNER_LABELS: Record<string, string> = {
 export interface ForgejoDialectOptions {
   /** Project-supplied label overrides, merged over {@link DEFAULT_RUNNER_LABELS}. */
   runnerLabels?: Record<string, string>;
+  /** Base for resolving mirrored `uses:` action refs (see ./actions). */
+  actionsRoot?: string;
 }
 
 export interface ForgejoDialectResult {
@@ -65,6 +71,7 @@ function isDeclarable(value: unknown): value is Declarable {
 
 interface TransformCtx {
   labels: Record<string, string>;
+  actionsRoot?: string;
   warnings: string[];
   /** Human-readable location used in warning messages. */
   where: string;
@@ -112,6 +119,12 @@ function transformValue(value: unknown, ctx: TransformCtx): unknown {
       result[key] = remapRunsOn(v, ctx);
       continue;
     }
+    if (kebab === USES_KEY && typeof v === "string") {
+      const { rewritten, warning } = resolveActionRef(v, { actionsRoot: ctx.actionsRoot });
+      if (warning) ctx.warnings.push(`${warning} (in ${ctx.where})`);
+      result[key] = rewritten;
+      continue;
+    }
     result[key] = transformValue(v, ctx);
   }
   return result;
@@ -145,7 +158,7 @@ export function applyForgejoDialect(
   const out = new Map<string, Declarable>();
 
   for (const [name, entity] of entities) {
-    const ctx: TransformCtx = { labels, warnings, where: name };
+    const ctx: TransformCtx = { labels, actionsRoot: options.actionsRoot, warnings, where: name };
     out.set(name, cloneDeclarable(entity, ctx));
   }
 

--- a/lexicons/forgejo/src/index.ts
+++ b/lexicons/forgejo/src/index.ts
@@ -19,6 +19,16 @@ export {
   type ForgejoDialectResult,
 } from "./dialect";
 
+// Action-reference resolver (exposed for tooling/tests)
+export {
+  resolveActionRef,
+  DEFAULT_ACTIONS_ROOT,
+  KNOWN_ACTIONS,
+  type ActionTarget,
+  type ActionResolveOptions,
+  type ActionResolveResult,
+} from "./actions";
+
 // Reuse the entire github authoring surface: generated entities, expression
 // system, context variables, and composites.
 export * from "@intentius/chant-lexicon-github";

--- a/lexicons/forgejo/src/serializer.test.ts
+++ b/lexicons/forgejo/src/serializer.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect } from "vitest";
-import { Workflow, Job, Step } from "@intentius/chant-lexicon-github";
+import { Workflow, Job, Step, Checkout, SetupNode } from "@intentius/chant-lexicon-github";
 import type { Declarable } from "@intentius/chant/declarable";
 import type { SerializerResult } from "@intentius/chant/serializer";
 import { forgejoSerializer } from "./serializer";
+import { DEFAULT_ACTIONS_ROOT } from "./actions";
 
 function asResult(out: string | SerializerResult): SerializerResult {
   return typeof out === "string" ? { primary: out } : out;
@@ -74,6 +75,37 @@ describe("forgejoSerializer — github-style source roundtrip", () => {
     const result = asResult(out);
     expect(result.primary).toContain("runs-on: windows-latest");
     expect((result.warnings ?? []).filter((w) => w.includes("windows-latest"))).toHaveLength(1);
+  });
+});
+
+describe("forgejoSerializer — uses: action resolution", () => {
+  function withSteps(...steps: unknown[]): Map<string, Declarable> {
+    const job = new Job({ "runs-on": "ubuntu-latest", steps }) as unknown as Declarable;
+    return new Map<string, Declarable>([["build", job]]);
+  }
+
+  test("rewrites composite-emitted action refs under the actions root", () => {
+    const { primary } = asResult(
+      forgejoSerializer.serialize(withSteps(Checkout({}).step, SetupNode({ nodeVersion: "22" }).step)),
+    );
+    expect(primary).toContain(`uses: ${DEFAULT_ACTIONS_ROOT}/actions/checkout@v4`);
+    expect(primary).toContain(`uses: ${DEFAULT_ACTIONS_ROOT}/actions/setup-node@v4`);
+  });
+
+  test("forgejo.actionsRoot override changes the rewritten base", () => {
+    const out = forgejoSerializer.serialize(withSteps(Checkout({}).step), undefined, {
+      config: { forgejo: { actionsRoot: "https://codeberg.org" } },
+    });
+    expect(asResult(out).primary).toContain("uses: https://codeberg.org/actions/checkout@v4");
+  });
+
+  test("an unmapped action ref is passed through and reported", () => {
+    const step = new Step({ name: "Custom", uses: "some-org/custom-action@v1" });
+    const result = asResult(forgejoSerializer.serialize(withSteps(step)));
+    expect(result.primary).toContain("uses: some-org/custom-action@v1");
+    const refWarnings = (result.warnings ?? []).filter((w) => w.includes("some-org/custom-action@v1"));
+    expect(refWarnings).toHaveLength(1);
+    expect(refWarnings[0]).toContain("unresolved action ref");
   });
 });
 

--- a/lexicons/forgejo/src/serializer.ts
+++ b/lexicons/forgejo/src/serializer.ts
@@ -23,11 +23,15 @@ import { applyForgejoDialect, type ForgejoDialectOptions } from "./dialect";
 function readForgejoOptions(config: Record<string, unknown> | undefined): ForgejoDialectOptions {
   const forgejo = config?.forgejo;
   if (!forgejo || typeof forgejo !== "object") return {};
-  const runnerLabels = (forgejo as Record<string, unknown>).runnerLabels;
-  if (runnerLabels && typeof runnerLabels === "object") {
-    return { runnerLabels: runnerLabels as Record<string, string> };
+  const obj = forgejo as Record<string, unknown>;
+  const options: ForgejoDialectOptions = {};
+  if (obj.runnerLabels && typeof obj.runnerLabels === "object") {
+    options.runnerLabels = obj.runnerLabels as Record<string, string>;
   }
-  return {};
+  if (typeof obj.actionsRoot === "string") {
+    options.actionsRoot = obj.actionsRoot;
+  }
+  return options;
 }
 
 /**


### PR DESCRIPTION
Closes #340 (Epic #338). Depends on #339 (P1, merged).

## What

Forgejo / Codeberg / Gitea runners have no GitHub Marketplace, so a bare `uses: actions/checkout@v4` won't resolve. This adds an action-reference resolver, applied in the same dialect pre-pass as P1 (rewrites the ref **source** — it does not translate to a different primitive).

## Resolver (`src/actions.ts`)

- Common `actions/*` (checkout, setup-node/go/python/java/dotnet, cache, upload/download-artifact) rewrite to `<actionsRoot>/<repo>@<ref>`. `actionsRoot` defaults to `https://code.forgejo.org` (the Forgejo actions mirror), overridable via `forgejo.actionsRoot`.
- `docker/*` pin to their full GitHub URL (not on the Forgejo mirror), independent of the actions root.
- Local (`./…`, `../…`), `docker://`, and full-URL refs pass through untouched.
- **Unmapped** `owner/repo` refs pass through **and are reported** as a build warning listing the ref — never silently unresolvable.
- Subpaths (`actions/cache/restore@v4`) and version-less refs are handled.

## Acceptance criteria

- [x] `actions/checkout@v4` and the common set rewrite to resolvable refs under the default actions root.
- [x] `forgejo.actionsRoot` override in `chant.config.ts` changes the rewritten base.
- [x] An unmapped `uses:` produces a diagnostic listing the ref; build still succeeds.
- [x] Fixture tests cover mapped refs, overridden root, subpaths, already-resolvable refs, and unmapped refs (31 tests total).

Verified end-to-end: a real `chant build` rewrites `actions/checkout@v4` → `https://code.forgejo.org/actions/checkout@v4` and warns on an unmapped ref.