### PR TITLE
feat(forgejo): P3 migrationSource(github) + forgejo:compare (#341)

### DIFF
--- a/lexicons/forgejo/README.md
+++ b/lexicons/forgejo/README.md
@@ -58,6 +58,34 @@ Gitea), so point the build output there:
 chant build src -o .forgejo/workflows/ci.yml
 ```
 
+## Migrating from GitHub Actions
+
+Because github → forgejo YAML is near-identical, the migration is thin — it
+applies the same dialect as a build. Its real value is the **compare**: what the
+move costs.
+
+```sh
+chant migrate .github/workflows/ci.yml --to forgejo -o .forgejo/workflows/ci.yml --validate
+```
+
+`--validate` prints a **Security posture** report classifying each property's
+fate across the edge:
+
+| Fate | Meaning |
+|---|---|
+| `translated` | carried across as-is |
+| `approximated` | carried with a close equivalent |
+| `needs-review` | confirm/adjust on Forgejo (unresolved `uses:`, unmapped runner label) |
+| `lost` | the Forgejo runner ignores it (`permissions`, `continue-on-error`) |
+
+The same view is available to agents as the `forgejo:compare` MCP tool, which
+takes a workflow file and returns per-property fates plus summary counts —
+read-only.
+
+> Note: flow-style YAML (`branches: [main]`) is parsed by chant's lightweight
+> core parser, which keeps it as a scalar; prefer block style in sources you
+> intend to migrate. This is shared with the github import path.
+
 ## Configuration
 
 Override runner-label mapping in `chant.config.ts`:

--- a/lexicons/forgejo/src/dialect.ts
+++ b/lexicons/forgejo/src/dialect.ts
@@ -145,6 +145,29 @@ function cloneDeclarable(entity: Declarable, ctx: TransformCtx): Declarable {
   return clone;
 }
 
+export interface TransformObjectResult {
+  /** The transformed plain value (clone; the input is not mutated). */
+  value: unknown;
+  /** One warning per dropped key, unmapped label, and unresolved action ref. */
+  warnings: string[];
+}
+
+/**
+ * Apply the Forgejo dialect to a plain object — e.g. a parsed GitHub Actions
+ * workflow during migration, rather than the resolved entity graph. Same
+ * rules as {@link applyForgejoDialect}: drop ignored keys, remap runner
+ * labels, resolve `uses:` refs.
+ */
+export function transformWorkflowObject(
+  obj: unknown,
+  options: ForgejoDialectOptions = {},
+): TransformObjectResult {
+  const labels = { ...DEFAULT_RUNNER_LABELS, ...(options.runnerLabels ?? {}) };
+  const warnings: string[] = [];
+  const ctx: TransformCtx = { labels, actionsRoot: options.actionsRoot, warnings, where: "workflow" };
+  return { value: transformValue(obj, ctx), warnings };
+}
+
 /**
  * Apply the Forgejo dialect to a resolved entity map. Returns transformed
  * clones plus the diagnostics produced (dropped keys, unmapped labels).

--- a/lexicons/forgejo/src/index.ts
+++ b/lexicons/forgejo/src/index.ts
@@ -14,10 +14,26 @@ export { forgejoPlugin } from "./plugin";
 // Dialect (exposed for tooling/tests)
 export {
   applyForgejoDialect,
+  transformWorkflowObject,
   DEFAULT_RUNNER_LABELS,
   type ForgejoDialectOptions,
   type ForgejoDialectResult,
+  type TransformObjectResult,
 } from "./dialect";
+
+// github → forgejo migration
+export {
+  transform,
+  detectGitHubWorkflow,
+  type MigrateOptions,
+  type MigrationResult,
+} from "./migrate/from-github";
+export {
+  analyzeForgejoSecurity,
+  renderSecurityPosture,
+  type SecurityFate,
+  type SecurityRecord,
+} from "./migrate/from-github/security";
 
 // Action-reference resolver (exposed for tooling/tests)
 export {

--- a/lexicons/forgejo/src/mcp/context-tools.ts
+++ b/lexicons/forgejo/src/mcp/context-tools.ts
@@ -1,0 +1,55 @@
+/**
+ * Read-only MCP tools for the forgejo lexicon.
+ *
+ * `forgejo:compare` is the lead value of the lexicon: given a GitHub Actions
+ * workflow, it reports which properties survive a move to Forgejo and which
+ * weaken or drop (the migration safety view). It builds/analyzes only — it
+ * never touches a live forge or writes anything.
+ */
+
+import type { McpToolContribution } from "@intentius/chant/mcp/types";
+import { resolve } from "path";
+import { readFile } from "fs/promises";
+import { transform, detectGitHubWorkflow } from "../migrate/from-github";
+
+const compareTool: McpToolContribution = {
+  name: "forgejo:compare",
+  description:
+    "Given a GitHub Actions workflow file, migrate it to Forgejo and report which properties survive the move and which weaken or are lost (the migration safety view). Returns a per-property fate (translated/approximated/needs-review/lost) plus summary counts. Read-only — analyzes, never writes.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      file: { type: "string", description: "Path to a .github/workflows/*.yml workflow file to migrate and compare" },
+    },
+    required: ["file"],
+  },
+  async handler(params: Record<string, unknown>): Promise<unknown> {
+    const file = resolve((params.file as string) ?? "");
+    let content: string;
+    try {
+      content = await readFile(file, "utf8");
+    } catch {
+      return { file: params.file ?? null, found: false, note: "could not read the workflow file" };
+    }
+    if (!detectGitHubWorkflow(content)) {
+      return { file: params.file ?? null, found: false, note: "file does not look like a GitHub Actions workflow" };
+    }
+
+    const migration = await transform(content, { security: true, sourceFile: file });
+    const properties = migration.provenance.map((r) => ({
+      property: r.security.property,
+      fate: r.security.fate,
+      severity: r.security.severity,
+      sourceKey: r.sourceKey,
+      reestablish: r.security.reestablish ?? null,
+      note: r.note ?? null,
+    }));
+    const summary: Record<string, number> = { translated: 0, approximated: 0, "needs-review": 0, lost: 0 };
+    for (const p of properties) summary[p.fate] = (summary[p.fate] ?? 0) + 1;
+    return { found: true, properties, summary };
+  },
+};
+
+export function forgejoContextTools(): McpToolContribution[] {
+  return [compareTool];
+}

--- a/lexicons/forgejo/src/migrate.mcp.test.ts
+++ b/lexicons/forgejo/src/migrate.mcp.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Smoke test for the forgejo MCP `forgejo:compare` tool. Exercises the
+ * handler directly (the tool contract is a plain async function from
+ * inputSchema params to a result object).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { forgejoPlugin } from "./plugin";
+
+const GHA_WORKFLOW = `name: CI
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: some-org/custom-action@v1
+      - run: npm test
+`;
+
+let dir: string;
+let file: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "fj-compare-"));
+  file = join(dir, "ci.yml");
+  writeFileSync(file, GHA_WORKFLOW);
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("forgejo MCP compare tool", () => {
+  test("registered in mcpTools", () => {
+    const tools = forgejoPlugin.mcpTools?.() ?? [];
+    expect(tools.map((t) => t.name)).toContain("forgejo:compare");
+  });
+
+  test("reports per-property fates and summary counts", async () => {
+    const tools = forgejoPlugin.mcpTools?.() ?? [];
+    const compare = tools.find((t) => t.name === "forgejo:compare");
+    expect(compare).toBeDefined();
+
+    const result = (await compare!.handler({ file })) as {
+      found: boolean;
+      properties: Array<{ property: string; fate: string }>;
+      summary: Record<string, number>;
+    };
+
+    expect(result.found).toBe(true);
+    const fates = result.properties.map((p) => p.fate);
+    expect(fates).toContain("lost"); // permissions
+    expect(fates).toContain("needs-review"); // unmapped action ref
+    expect(result.summary.lost).toBeGreaterThanOrEqual(1);
+    expect(result.summary["needs-review"]).toBeGreaterThanOrEqual(1);
+  });
+
+  test("returns found:false for a non-workflow file", async () => {
+    const tools = forgejoPlugin.mcpTools?.() ?? [];
+    const compare = tools.find((t) => t.name === "forgejo:compare");
+    const other = join(dir, "not-a-workflow.yml");
+    writeFileSync(other, "foo: bar\n");
+    const result = (await compare!.handler({ file: other })) as { found: boolean };
+    expect(result.found).toBe(false);
+  });
+});

--- a/lexicons/forgejo/src/migrate.test.ts
+++ b/lexicons/forgejo/src/migrate.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from "vitest";
+import { transform, detectGitHubWorkflow } from "./migrate/from-github";
+import { forgejoPlugin } from "./plugin";
+
+const GHA_WORKFLOW = `name: CI
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: some-org/custom-action@v1
+      - run: npm test
+`;
+
+describe("github → forgejo transform", () => {
+  test("emits forgejo YAML with the dialect applied", async () => {
+    const { output } = await transform(GHA_WORKFLOW, { sourceFile: "ci.yml" });
+    expect(output).toContain("runs-on: docker");
+    expect(output).not.toContain("permissions");
+    expect(output).not.toContain("continue-on-error");
+    expect(output).toContain("https://code.forgejo.org/actions/checkout@v4");
+    // unmapped ref still present (passed through), surfaced in the compare
+    expect(output).toContain("some-org/custom-action@v1");
+  });
+
+  test("classifies property fates (provenance + posture)", async () => {
+    const { provenance, securityPosture, diagnostics } = await transform(GHA_WORKFLOW, { sourceFile: "ci.yml" });
+    const rules = provenance.map((r) => r.rule);
+    expect(rules).toContain("MIG-FJ-PERMISSIONS");
+    expect(rules).toContain("MIG-FJ-CONTINUE-ON-ERROR");
+    expect(rules).toContain("MIG-FJ-ACTION-UNRESOLVED");
+    expect(provenance.find((r) => r.rule === "MIG-FJ-PERMISSIONS")?.security.fate).toBe("lost");
+    expect(securityPosture).toContain("## Security posture");
+    expect(diagnostics.length).toBe(provenance.length);
+  });
+
+  test("emit: ts produces a chant pipeline importing from forgejo", async () => {
+    const { output } = await transform(GHA_WORKFLOW, { emit: "ts", sourceFile: "ci.yml" });
+    expect(output).toContain("@intentius/chant-lexicon-forgejo");
+    expect(output).not.toContain("@intentius/chant-lexicon-github");
+  });
+
+  test("detectGitHubWorkflow recognizes a workflow", () => {
+    expect(detectGitHubWorkflow(GHA_WORKFLOW)).toBe(true);
+    expect(detectGitHubWorkflow("foo: bar\n")).toBe(false);
+  });
+});
+
+describe("forgejoPlugin.migrationSource", () => {
+  test("supports github only", () => {
+    expect(forgejoPlugin.migrationSource?.("github")).toBeDefined();
+    expect(forgejoPlugin.migrationSource?.("gitlab")).toBeUndefined();
+  });
+
+  test("transform mirrors the gitlab MigrationResult shape", async () => {
+    const source = forgejoPlugin.migrationSource?.("github");
+    expect(source?.detect(GHA_WORKFLOW)).toBe(true);
+    const result = await source!.transform(GHA_WORKFLOW, { emit: "yaml", sourceFile: "ci.yml" });
+    expect(result.output).toContain("runs-on: docker");
+    expect(Array.isArray(result.provenance)).toBe(true);
+    expect(Array.isArray(result.diagnostics)).toBe(true);
+    expect(result.securityPosture).toContain("Security posture");
+  });
+});

--- a/lexicons/forgejo/src/migrate/from-github/index.ts
+++ b/lexicons/forgejo/src/migrate/from-github/index.ts
@@ -1,0 +1,103 @@
+/**
+ * github → forgejo migration entry point.
+ *
+ * Thin by design: Forgejo Actions YAML *is* GitHub Actions YAML, so the
+ * migration applies the same dialect as a `chant build` (drop ignored keys,
+ * resolve `uses:` refs, map runner labels) and emits the result. No stage
+ * inference, job→script rewrite, or `!reference` intrinsic like the gitlab
+ * migration needs. The differentiated value is the security-fate **compare**
+ * (see ./security).
+ */
+
+import type { LintDiagnostic } from "@intentius/chant/lint/rule";
+import { parseYAML, emitYAML } from "@intentius/chant/yaml";
+import { transformWorkflowObject } from "../../dialect";
+import {
+  analyzeForgejoSecurity,
+  provenanceToDiagnostics,
+  renderSecurityPosture,
+  type SecurityRecord,
+} from "./security";
+
+export interface MigrateOptions {
+  /** Output format. Defaults to "yaml". */
+  emit?: "yaml" | "ts";
+  /** Source file path (display only). */
+  sourceFile?: string;
+  /** Escalate needs-review/lost findings to errors. */
+  strict?: boolean;
+  /** Accepted for parity with the core MigrationSource contract; forgejo
+   *  always runs the (cheap) security analysis. */
+  security?: boolean;
+  /** Accepted for parity; forgejo has no composite rewriter. */
+  useComposites?: boolean;
+}
+
+export interface MigrationResult {
+  /** Rendered output (forgejo YAML by default, chant TS when emit: "ts"). */
+  output: string;
+  /** Per-property security-fate records. */
+  provenance: SecurityRecord[];
+  /** SARIF-shaped diagnostics derived from the records. */
+  diagnostics: LintDiagnostic[];
+  /** Markdown "Security posture" section. */
+  securityPosture: string;
+}
+
+/** Emit a parsed/transformed workflow object back to YAML. */
+function emitForgejoYaml(value: unknown): string {
+  const body = emitYAML(value, 0);
+  return (body.startsWith("\n") ? body.slice(1) : body) + "\n";
+}
+
+/** Emit a chant TypeScript pipeline (authored github-style, imported from forgejo). */
+async function emitTs(content: string, opts: MigrateOptions): Promise<string> {
+  const { GitHubActionsParser } = await import("@intentius/chant-lexicon-github/import/parser");
+  const { GitHubActionsGenerator } = await import("@intentius/chant-lexicon-github/import/generator");
+  const ir = new GitHubActionsParser().parse(content);
+  const files = new GitHubActionsGenerator().generate(ir);
+  const banner =
+    `// Migrated from ${opts.sourceFile ?? "(stdin)"} by chant migrate (github → forgejo).\n` +
+    `// Authored github-style; the forgejo lexicon applies its dialect on build.\n\n`;
+  return (
+    banner +
+    files
+      .map((f) => f.content.replace(/@intentius\/chant-lexicon-github/g, "@intentius/chant-lexicon-forgejo"))
+      .join("\n")
+  );
+}
+
+/**
+ * Migrate a GitHub Actions workflow into a Forgejo workflow.
+ *
+ * @param content raw .github/workflows/*.yml content
+ * @param opts    migration options
+ */
+export async function transform(content: string, opts: MigrateOptions = {}): Promise<MigrationResult> {
+  const source = parseYAML(content);
+
+  let output: string;
+  if (opts.emit === "ts") {
+    output = await emitTs(content, opts);
+  } else {
+    const { value } = transformWorkflowObject(source);
+    output = emitForgejoYaml(value);
+  }
+
+  // The compare is computed against the *source* — that's where the dropped
+  // keys still exist — so it reports what the move costs.
+  const provenance = analyzeForgejoSecurity(source, { sourceFile: opts.sourceFile });
+  const diagnostics = provenanceToDiagnostics(provenance, { strict: opts.strict });
+  const securityPosture = renderSecurityPosture(provenance);
+
+  return { output, provenance, diagnostics, securityPosture };
+}
+
+/**
+ * Lightweight detector: does this content look like a GitHub Actions workflow?
+ * Used by the plugin's `migrationSource("github")`.
+ */
+export function detectGitHubWorkflow(content: string): boolean {
+  if (!/^\s*jobs\s*:/m.test(content)) return false;
+  return /^\s*on\s*:/m.test(content) || /^\s*runs-on\s*:/m.test(content);
+}

--- a/lexicons/forgejo/src/migrate/from-github/security.test.ts
+++ b/lexicons/forgejo/src/migrate/from-github/security.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect } from "vitest";
+import { parseYAML } from "@intentius/chant/yaml";
+import { analyzeForgejoSecurity, renderSecurityPosture, provenanceToDiagnostics } from "./security";
+
+function analyze(yaml: string) {
+  return analyzeForgejoSecurity(parseYAML(yaml), { sourceFile: "ci.yml" });
+}
+
+describe("analyzeForgejoSecurity — fate classes", () => {
+  test("workflow-level permissions is lost", () => {
+    const records = analyze(`on: push
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`);
+    const perm = records.filter((r) => r.rule === "MIG-FJ-PERMISSIONS");
+    expect(perm).toHaveLength(1);
+    expect(perm[0].security.fate).toBe("lost");
+  });
+
+  test("continue-on-error is lost (job and step)", () => {
+    const records = analyze(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - run: echo a
+        continue-on-error: true
+`);
+    const coe = records.filter((r) => r.rule === "MIG-FJ-CONTINUE-ON-ERROR");
+    expect(coe).toHaveLength(2);
+    expect(coe.every((r) => r.security.fate === "lost")).toBe(true);
+  });
+
+  test("an unmapped action ref needs review", () => {
+    const records = analyze(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: some-org/custom-action@v1
+`);
+    const act = records.filter((r) => r.rule === "MIG-FJ-ACTION-UNRESOLVED");
+    expect(act).toHaveLength(1);
+    expect(act[0].security.fate).toBe("needs-review");
+  });
+
+  test("a mapped action ref produces no finding", () => {
+    const records = analyze(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`);
+    expect(records.filter((r) => r.rule === "MIG-FJ-ACTION-UNRESOLVED")).toHaveLength(0);
+  });
+
+  test("an unmapped runner label needs review; a mapped one does not", () => {
+    const records = analyze(`on: push
+jobs:
+  a:
+    runs-on: macos-latest
+    steps:
+      - run: echo a
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo b
+`);
+    const labels = records.filter((r) => r.rule === "MIG-FJ-RUNNER-LABEL");
+    expect(labels).toHaveLength(1);
+    expect(labels[0].note).toContain("macos-latest");
+  });
+});
+
+describe("renderSecurityPosture", () => {
+  test("renders a table with fate rows", () => {
+    const records = analyze(`on: push
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`);
+    const md = renderSecurityPosture(records);
+    expect(md).toContain("## Security posture");
+    expect(md).toContain("MIG-FJ-PERMISSIONS");
+    expect(md).toContain("lost");
+  });
+
+  test("clean workflow reports no weakening", () => {
+    const md = renderSecurityPosture([]);
+    expect(md).toContain("No security-relevant properties weaken or drop");
+  });
+});
+
+describe("provenanceToDiagnostics", () => {
+  test("emits one diagnostic per record; --strict escalates to error", () => {
+    const records = analyze(`on: push
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`);
+    expect(provenanceToDiagnostics(records)).toHaveLength(1);
+    expect(provenanceToDiagnostics(records)[0].severity).toBe("warning");
+    expect(provenanceToDiagnostics(records, { strict: true })[0].severity).toBe("error");
+  });
+});

--- a/lexicons/forgejo/src/migrate/from-github/security.ts
+++ b/lexicons/forgejo/src/migrate/from-github/security.ts
@@ -1,0 +1,195 @@
+/**
+ * Security-fate model for the github → forgejo migration edge.
+ *
+ * github → forgejo YAML is near-identical, so the migration itself is thin. The
+ * differentiated value is the **compare**: classifying what survives the move
+ * and what Forgejo silently drops. Most properties translate verbatim; the
+ * useful findings are the keys the Forgejo runner ignores (`permissions`,
+ * `continue-on-error` → `lost`) plus refs/labels that need attention
+ * (unresolved `uses:`, unmapped runner labels → `needs-review`).
+ *
+ * Mirrors the gitlab lexicon's fate model (translated / approximated /
+ * needs-review / lost) but for the Forgejo edge — kept local so the forgejo
+ * lexicon does not depend on the gitlab one.
+ */
+
+import type { LintDiagnostic } from "@intentius/chant/lint/rule";
+import { DEFAULT_RUNNER_LABELS } from "../../dialect";
+import { resolveActionRef } from "../../actions";
+
+export type SecurityFate = "translated" | "approximated" | "needs-review" | "lost";
+
+export interface SecurityProvenance {
+  /** Human label for the property (e.g. "Least-privilege permissions"). */
+  property: string;
+  /** What happened to the property as it crossed the github → forgejo edge. */
+  fate: SecurityFate;
+  /** Diagnostic severity for this finding. */
+  severity: "error" | "warning" | "info";
+  /** How to re-establish the property on Forgejo, when it doesn't carry. */
+  reestablish?: string;
+}
+
+/** A migration provenance record carrying a security classification. */
+export interface SecurityRecord {
+  /** YAML-ish path in the source (e.g. "jobs.build.steps[1].uses"). */
+  sourceKey: string;
+  /** Source file name (for diagnostics). */
+  sourceFile?: string;
+  /** Functional category (forgejo migration only emits security records). */
+  category: "needs-review" | "skipped" | "synthesis";
+  /** Rule ID (MIG-FJ-*). */
+  rule: string;
+  /** Human-readable explanation. */
+  note?: string;
+  /** Security classification. */
+  security: SecurityProvenance;
+}
+
+function toKebabCase(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+/**
+ * Classify the fate of security-relevant properties in a parsed GitHub Actions
+ * workflow as it migrates to Forgejo. Walks the source object so occurrence
+ * counts (and paths) are precise.
+ */
+export function analyzeForgejoSecurity(
+  workflow: unknown,
+  opts: { sourceFile?: string } = {},
+): SecurityRecord[] {
+  const records: SecurityRecord[] = [];
+  const file = opts.sourceFile;
+
+  function visit(value: unknown, path: string): void {
+    if (value === null || typeof value !== "object") return;
+
+    if (Array.isArray(value)) {
+      value.forEach((v, i) => visit(v, `${path}[${i}]`));
+      return;
+    }
+
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      const kebab = toKebabCase(key);
+      const childPath = path ? `${path}.${key}` : key;
+
+      if (kebab === "permissions") {
+        records.push({
+          sourceKey: childPath,
+          sourceFile: file,
+          category: "skipped",
+          rule: "MIG-FJ-PERMISSIONS",
+          note: `permissions: is ignored by the Forgejo runner — the least-privilege control is lost. Re-establish it through your Forgejo/runner and repository token settings.`,
+          security: { property: "Least-privilege permissions", fate: "lost", severity: "warning", reestablish: "Forgejo runner/token settings" },
+        });
+        continue; // don't descend into a dropped subtree
+      }
+
+      if (kebab === "continue-on-error") {
+        records.push({
+          sourceKey: childPath,
+          sourceFile: file,
+          category: "skipped",
+          rule: "MIG-FJ-CONTINUE-ON-ERROR",
+          note: `continue-on-error is ignored by the Forgejo runner — the failure-tolerance control is lost. A failing step/job will fail the run.`,
+          security: { property: "continue-on-error tolerance", fate: "lost", severity: "warning" },
+        });
+        continue;
+      }
+
+      if (kebab === "uses" && typeof v === "string") {
+        const { warning } = resolveActionRef(v);
+        if (warning) {
+          records.push({
+            sourceKey: childPath,
+            sourceFile: file,
+            category: "needs-review",
+            rule: "MIG-FJ-ACTION-UNRESOLVED",
+            note: `Action ref '${v}' has no built-in Forgejo mapping and won't resolve from a GitHub Marketplace. Use a full repository URL or mirror it under forgejo.actionsRoot.`,
+            security: { property: "Action reference", fate: "needs-review", severity: "warning" },
+          });
+        }
+        continue;
+      }
+
+      if (kebab === "runs-on") {
+        for (const label of runnerLabels(v)) {
+          if (DEFAULT_RUNNER_LABELS[label] === undefined) {
+            records.push({
+              sourceKey: childPath,
+              sourceFile: file,
+              category: "needs-review",
+              rule: "MIG-FJ-RUNNER-LABEL",
+              note: `Runner label '${label}' has no built-in Forgejo mapping. Confirm a Forgejo runner advertises it, or map it via forgejo.runnerLabels.`,
+              security: { property: "Runner label", fate: "needs-review", severity: "warning" },
+            });
+          }
+        }
+        continue;
+      }
+
+      visit(v, childPath);
+    }
+  }
+
+  visit(workflow, "");
+  return records;
+}
+
+function runnerLabels(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === "string");
+  return [];
+}
+
+/**
+ * Convert security records into SARIF-shaped diagnostics. Security findings
+ * always emit a diagnostic at their severity, escalated to `error` under
+ * `--strict` when the property was lost or needs review.
+ */
+export function provenanceToDiagnostics(
+  records: SecurityRecord[],
+  opts: { strict?: boolean } = {},
+): LintDiagnostic[] {
+  return records.map((r) => {
+    const escalate = opts.strict && (r.security.fate === "lost" || r.security.fate === "needs-review");
+    return {
+      file: r.sourceFile ?? "<input>",
+      line: 1,
+      column: 1,
+      ruleId: r.rule,
+      severity: escalate ? "error" : r.security.severity,
+      message: r.note ?? r.rule,
+    };
+  });
+}
+
+interface PostureLine {
+  property: string;
+  fate: SecurityFate;
+  rule: string;
+  count: number;
+}
+
+/** Render a "Security posture" Markdown section from the security records. */
+export function renderSecurityPosture(records: SecurityRecord[]): string {
+  if (records.length === 0) {
+    return "## Security posture\n\nNo security-relevant properties weaken or drop at the Forgejo migration edge.\n";
+  }
+
+  const byRule = new Map<string, PostureLine>();
+  for (const r of records) {
+    const existing = byRule.get(r.rule);
+    if (existing) existing.count += 1;
+    else byRule.set(r.rule, { property: r.security.property, fate: r.security.fate, rule: r.rule, count: 1 });
+  }
+
+  let out = "## Security posture\n\n";
+  out += "| Property | Fate | Rule | Count |\n|---|---|---|---|\n";
+  for (const line of byRule.values()) {
+    out += `| ${line.property} | ${line.fate} | ${line.rule} | ${line.count} |\n`;
+  }
+  out += "\nFates: **translated** (carried as-is) · **approximated** · **needs-review** (confirm/adjust on Forgejo) · **lost** (the Forgejo runner ignores the property).\n";
+  return out;
+}

--- a/lexicons/forgejo/src/plugin.ts
+++ b/lexicons/forgejo/src/plugin.ts
@@ -8,8 +8,9 @@
  * intentionally no-ops — they delegate the real work to the github lexicon.
  */
 
-import type { LexiconPlugin, InitTemplateSet } from "@intentius/chant/lexicon";
+import type { LexiconPlugin, InitTemplateSet, MigrationSource } from "@intentius/chant/lexicon";
 import { forgejoSerializer } from "./serializer";
+import { forgejoContextTools } from "./mcp/context-tools";
 
 const reuseNote =
   "forgejo reuses the github lexicon's entities — run `chant generate` in the github lexicon instead.";
@@ -87,6 +88,37 @@ export const build = new Job({
     }
 
     return false;
+  },
+
+  migrationSource(from: string): MigrationSource | undefined {
+    if (from !== "github") return undefined;
+    return {
+      detect(content: string): boolean {
+        // Inline heuristic — keeps the migrate code out of the import graph
+        // until a transform actually runs.
+        if (!/^\s*jobs\s*:/m.test(content)) return false;
+        return /^\s*on\s*:/m.test(content) || /^\s*runs-on\s*:/m.test(content);
+      },
+      async transform(content: string, opts) {
+        const { transform } = await import("./migrate/from-github");
+        const result = await transform(content, {
+          emit: opts.emit,
+          sourceFile: opts.sourceFile,
+          strict: opts.strict,
+          security: opts.security,
+        });
+        return {
+          output: result.output,
+          provenance: result.provenance as unknown as Array<Record<string, unknown>>,
+          diagnostics: result.diagnostics as unknown as Array<Record<string, unknown>>,
+          securityPosture: result.securityPosture,
+        };
+      },
+    };
+  },
+
+  mcpTools() {
+    return [...forgejoContextTools()];
   },
 
   // ── Codegen lifecycle — delegated to github (no own spec) ──────────


### PR DESCRIPTION
Closes #341 (Epic #338). Depends on #339 (P1) + #340 (P2), both merged. **This is the epic's lead value.**

## What

github → forgejo YAML is near-identical, so the migration is **thin** — it reuses the P1 dialect + P2 resolver (drop `permissions`/`continue-on-error`, remap runner labels, resolve `uses:`) and emits the result. No stage inference, no job→script rewrite, no `!reference` like the gitlab migration needed. The differentiated value is the **compare**: a per-property security-fate report of what the move costs.

## Pieces

- **`src/migrate/from-github/security.ts`** — security-fate model for the Forgejo edge (`translated`/`approximated`/`needs-review`/`lost`), mirroring the gitlab model but kept local (no gitlab dependency). New `MIG-FJ-*` rules:
  - dropped `permissions` → **lost**
  - dropped `continue-on-error` → **lost**
  - unresolved action ref → **needs-review**
  - unmapped runner label → **needs-review**
  - plus `renderSecurityPosture` (markdown) + `provenanceToDiagnostics`.
- **`src/migrate/from-github/index.ts`** — `transform()` → `{ output, provenance, diagnostics, securityPosture }`. YAML by default; `emit: "ts"` delegates to the github generator with the import specifier swapped to forgejo.
- **`dialect.ts`** — `transformWorkflowObject()` applies the dialect to a parsed workflow object (vs the entity graph) for the migration output.
- **`plugin.ts`** — `migrationSource("github")` + `mcpTools()` registering `forgejo:compare`, a read-only MCP tool returning per-property fates + summary counts.

## Acceptance criteria

- [x] `forgejo:compare` on a workflow with `permissions:` reports it `lost`.
- [x] A workflow with an unmapped `uses:` reports `needs-review`.
- [x] `chant migrate --to forgejo <gha.yml>` emits `.forgejo/workflows` output + provenance + diagnostics, mirroring the gitlab path.
- [x] Security-posture markdown renders.
- [x] Fixture tests for each fate class (48 forgejo tests total).

Verified end-to-end: `chant migrate ci.yml --to forgejo --validate` emits the transformed YAML and a Security posture table (permissions/continue-on-error → lost, unresolved ref → needs-review).

## Note

Flow-style YAML (`branches: [main]`) is kept as a scalar by chant's lightweight core parser — a pre-existing limitation shared with the github import path (the github parser uses the same core `parseYAML`), not introduced here. Documented in the README.