### PR TITLE
feat(forgejo): P4 context tools + lint + skill + docs (#342)

### DIFF
--- a/docs/src/content/docs/guide/agent-integration.mdx
+++ b/docs/src/content/docs/guide/agent-integration.mdx
@@ -98,6 +98,19 @@ The GitHub lexicon ships the parallel set for Actions workflows:
 | `github:affected` | If I change this job, what re-runs? |
 | `github:workflow-yaml` | The generated workflow YAML |
 
+The Forgejo lexicon (Codeberg / self-hosted Forgejo / Gitea) ships the same set, plus the migration safety view:
+
+| MCP tool | Answers |
+|----------|---------|
+| `forgejo:checks` | Is there anything that won't work on Forgejo? (WFJ findings: unresolved action refs, GitHub-hosted runner labels) |
+| `forgejo:workflow` | What does this workflow do? (triggers, jobs, run order) |
+| `forgejo:references` | What actions/images does it pull in, and are they pinned to a commit SHA? |
+| `forgejo:affected` | If I change this job, what re-runs? |
+| `forgejo:workflow-yaml` | The generated Forgejo workflow YAML |
+| `forgejo:source` | Where did this job come from in my TypeScript? (file + composite) |
+| `forgejo:owns` | Is this job declared by chant in this project? |
+| `forgejo:compare` | If I migrate this GitHub workflow to Forgejo, which safety properties survive? |
+
 Every one of these reads the build only — no live instance, no run history, no writes. That boundary is deliberate: chant is a context *producer*, complementary to (not a copy of) the live tooling an agent already uses.
 
 ## Ops

--- a/docs/src/content/docs/lexicons/overview.mdx
+++ b/docs/src/content/docs/lexicons/overview.mdx
@@ -16,6 +16,7 @@ A **lexicon** is a collection of types and semantic lint rules for an operationa
 | Helm | `@intentius/chant-lexicon-helm` | 10+ resources | [Reference](/chant/lexicons/helm/) |
 | GitHub Actions | `@intentius/chant-lexicon-github` | 3 resources, 14 composites | [Reference](/chant/lexicons/github/) |
 | GitLab CI/CD | `@intentius/chant-lexicon-gitlab` | 3 resources, 16 properties | [Reference](/chant/lexicons/gitlab/) — also ships [GitHub Actions migration](/chant/lexicons/gitlab/migration/) |
+| Forgejo Actions (Codeberg / Gitea) | `@intentius/chant-lexicon-forgejo` | thin github dialect (reuses github entities) | [README](https://github.com/INTENTIUS/chant/blob/main/lexicons/forgejo/README.md) — ships [GitHub Actions migration + `forgejo:compare`](/chant/guide/agent-integration/#read-only-context-tools) |
 | Docker | `@intentius/chant-lexicon-docker` | 6 resources (Compose + Dockerfile) | [Reference](/chant/lexicons/docker/) |
 | Temporal | `@intentius/chant-lexicon-temporal` | 4 resources + Op workflow engine | [Reference](/chant/lexicons/temporal/) |
 
@@ -34,6 +35,7 @@ Lexicons opt into the `chant lifecycle diff <env> --live` pipeline by implementi
 | Docker |  | ✅ | — | `docker ps`, `docker image ls`, `docker network ls` (NDJSON) |
 | GitHub Actions |  |  | — | N/A — workflow definitions are git-tracked; drift is `git diff` ([rationale](https://github.com/INTENTIUS/chant/blob/main/lexicons/github/README.md#runtime-observation-na)) |
 | GitLab CI/CD |  |  | — | N/A — same rationale ([README](https://github.com/INTENTIUS/chant/blob/main/lexicons/gitlab/README.md#runtime-observation-na)) |
+| Forgejo Actions |  |  | — | N/A — workflow definitions are git-tracked; drift is `git diff` (same as github) |
 
 Lexicons that implement neither are warn-skipped — `--live` doesn't fail the whole command for them.
 
@@ -42,6 +44,8 @@ The **Ownership** column shows the marker channel a lexicon queries for the `--o
 ## Cross-lexicon migration
 
 The GitLab lexicon ships a `chant migrate` source for `from: github` — translates `.github/workflows/*.yml` into `.gitlab-ci.yml` (or typed chant TypeScript), with provenance recorded as SARIF and a curated mapping table for the top 33 marketplace actions. See [GitLab → Migration](/chant/lexicons/gitlab/migration/) for the full surface, or the [`chant migrate` CLI reference](/chant/cli/migrate/).
+
+The Forgejo lexicon implements the same `migrationSource("github")` hook — a **thin** edge, since Forgejo runs GitHub-Actions-compatible YAML. Its value is the [`forgejo:compare`](/chant/guide/agent-integration/#read-only-context-tools) safety view: a per-property security-fate report of what the move costs (`permissions`/`continue-on-error` → lost, unresolved `uses:` → needs-review).
 
 Future lexicons can opt into the same machinery by implementing `migrationSource(from: string)` on their plugin.
 

--- a/docs/src/content/docs/whats-new.mdx
+++ b/docs/src/content/docs/whats-new.mdx
@@ -20,6 +20,17 @@ chant now exposes what `chant build` already computes about a pipeline — its j
 | [#329](https://github.com/INTENTIUS/chant/issues/329), [#332](https://github.com/INTENTIUS/chant/pull/332) | [`chant lifecycle plan --report gitlab-mr`](/chant/cli/lifecycle/) + the `MrPlanReport` composite — publish the plan as the GitLab **merge-request plan widget** (`artifacts:reports:terraform`); counts only (create/update/delete) |
 | [#336](https://github.com/INTENTIUS/chant/pull/336) | A Docker **runtime E2E** (`just gitlab-runtime-e2e`) that actually executes a chant-generated `.gitlab-ci.yml` via `gitlab-ci-local` — proves GitLab CI accepts and runs the output, not just that it is well-formed |
 
+## Forgejo lexicon (Codeberg / Forgejo / Gitea)
+
+A new lexicon for **Forgejo Actions** — the CI behind Codeberg, self-hosted Forgejo, and Gitea — built as a **thin dialect of the github lexicon**. Forgejo runs GitHub-Actions-compatible YAML, so you author exactly as for GitHub (same entities and composites, imported from `@intentius/chant-lexicon-forgejo`) and the dialect applies on build. The differentiated value is the github→forgejo **compare**: what the move silently costs.
+
+| # | Capability |
+|---|---|
+| [#339](https://github.com/INTENTIUS/chant/pull/343) | Serializer dialect — emits `.forgejo/workflows/` (or `.gitea/workflows/`); drops keys the Forgejo runner ignores (`permissions`, `continue-on-error`) with build warnings; maps runner labels (`ubuntu-latest` → `docker`, override via `forgejo.runnerLabels`) |
+| [#340](https://github.com/INTENTIUS/chant/pull/344) | `uses:` action-ref resolver — Forgejo has no Marketplace, so common `actions/*` rewrite under `forgejo.actionsRoot` (default `https://code.forgejo.org`), `docker/*` pin to GitHub URLs, and unmapped refs are reported |
+| [#341](https://github.com/INTENTIUS/chant/pull/345) | `chant migrate --to forgejo` + the [`forgejo:compare`](/chant/guide/agent-integration/#read-only-context-tools) MCP tool — a per-property security-fate report (translated / approximated / needs-review / lost) of what survives the move |
+| [#342](https://github.com/INTENTIUS/chant/issues/342) | Parity surface — the full `forgejo:*` [read-only context tools](/chant/guide/agent-integration/#read-only-context-tools), WFJ010/011 lint checks, init templates, a `chant-forgejo` skill, and docs |
+
 ## CI/CD pipeline security audit
 
 A workflow/pipeline security pass across the github and gitlab lexicons, split along chant's architectural boundary: deterministic checks run in the pure build, live-resolution checks run in the operational layer. Both lexicons were abstracted to the **same core problems** — pin & vet external references, least-privilege tokens, trust boundaries against untrusted input, secret containment, unsound expressions, artifact/cache hygiene — so the GitHub → GitLab migration can map problem → problem and carry the security invariant across the edge.

--- a/lexicons/forgejo/src/dialect.test.ts
+++ b/lexicons/forgejo/src/dialect.test.ts
@@ -89,17 +89,16 @@ describe("applyForgejoDialect — runner labels", () => {
     expect((entities.get("build") as MockJob).props["runs-on"]).toBe("big-runner");
   });
 
-  test("an unmapped label passes through with a warning", () => {
+  test("an unmapped label passes through unchanged (reported by WFJ011, not here)", () => {
     const job = new MockJob({ "runs-on": "macos-latest" });
     const { entities, warnings } = applyForgejoDialect(entityMap(["build", job]));
     expect((entities.get("build") as MockJob).props["runs-on"]).toBe("macos-latest");
-    expect(warnings.filter((w) => w.includes("macos-latest"))).toHaveLength(1);
+    expect(warnings.filter((w) => w.includes("macos-latest"))).toHaveLength(0);
   });
 
-  test("remaps every label in an array form", () => {
+  test("remaps every label in an array form, leaving unmapped ones untouched", () => {
     const job = new MockJob({ "runs-on": ["ubuntu-latest", "self-hosted"] });
-    const { entities, warnings } = applyForgejoDialect(entityMap(["build", job]));
+    const { entities } = applyForgejoDialect(entityMap(["build", job]));
     expect((entities.get("build") as MockJob).props["runs-on"]).toEqual(["docker", "self-hosted"]);
-    expect(warnings.filter((w) => w.includes("self-hosted"))).toHaveLength(1);
   });
 });

--- a/lexicons/forgejo/src/dialect.ts
+++ b/lexicons/forgejo/src/dialect.ts
@@ -77,15 +77,14 @@ interface TransformCtx {
   where: string;
 }
 
-/** Map a single runner label, warning (and passing it through) when unmapped. */
+/**
+ * Map a single runner label, passing it through unchanged when unmapped. An
+ * unmapped label that survives into the output is reported by the WFJ011
+ * post-synth check (which surfaces in both `chant build` and `chant lint`),
+ * so the dialect doesn't also warn here — that would double-report.
+ */
 function mapLabel(label: string, ctx: TransformCtx): string {
-  const mapped = ctx.labels[label];
-  if (mapped !== undefined) return mapped;
-  ctx.warnings.push(
-    `forgejo: no runner-label mapping for '${label}' in ${ctx.where}; passing it through unchanged. ` +
-      `Set forgejo.runnerLabels['${label}'] in chant.config.ts to map it.`,
-  );
-  return label;
+  return ctx.labels[label] ?? label;
 }
 
 /** Remap a `runs-on` value (string or string[]); leave other shapes untouched. */
@@ -120,9 +119,10 @@ function transformValue(value: unknown, ctx: TransformCtx): unknown {
       continue;
     }
     if (kebab === USES_KEY && typeof v === "string") {
-      const { rewritten, warning } = resolveActionRef(v, { actionsRoot: ctx.actionsRoot });
-      if (warning) ctx.warnings.push(`${warning} (in ${ctx.where})`);
-      result[key] = rewritten;
+      // Rewrite to a Forgejo-resolvable form. An unresolved ref that survives
+      // is reported by the WFJ010 post-synth check (build + lint), so the
+      // dialect doesn't also warn here — that would double-report.
+      result[key] = resolveActionRef(v, { actionsRoot: ctx.actionsRoot }).rewritten;
       continue;
     }
     result[key] = transformValue(v, ctx);

--- a/lexicons/forgejo/src/lint/post-synth/wfj.test.ts
+++ b/lexicons/forgejo/src/lint/post-synth/wfj.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from "vitest";
+import type { PostSynthContext } from "@intentius/chant/lint/post-synth";
+import { wfj010 } from "./wfj010";
+import { wfj011 } from "./wfj011";
+
+function makeCtx(yaml: string): PostSynthContext {
+  return {
+    outputs: new Map([["github", yaml]]),
+    entities: new Map(),
+    buildResult: {
+      outputs: new Map([["github", yaml]]),
+      entities: new Map(),
+      warnings: [],
+      errors: [],
+      sourceFileCount: 1,
+    },
+  };
+}
+
+describe("WFJ010: unresolved action reference", () => {
+  test("flags a bare owner/repo ref", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: docker
+    steps:
+      - uses: some-org/custom-action@v1
+`;
+    const diags = wfj010.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WFJ010");
+    expect(diags[0].message).toContain("some-org/custom-action@v1");
+  });
+
+  test("does not flag a resolved full-URL ref", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: docker
+    steps:
+      - uses: https://code.forgejo.org/actions/checkout@v4
+`;
+    expect(wfj010.check(makeCtx(yaml))).toHaveLength(0);
+  });
+});
+
+describe("WFJ011: GitHub-hosted runner label", () => {
+  test("flags a macos-latest label", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - run: echo hi
+`;
+    const diags = wfj011.check(makeCtx(yaml));
+    expect(diags).toHaveLength(1);
+    expect(diags[0].checkId).toBe("WFJ011");
+    expect(diags[0].message).toContain("macos-latest");
+  });
+
+  test("does not flag a mapped Forgejo label", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: docker
+    steps:
+      - run: echo hi
+`;
+    expect(wfj011.check(makeCtx(yaml))).toHaveLength(0);
+  });
+});

--- a/lexicons/forgejo/src/lint/post-synth/wfj010.ts
+++ b/lexicons/forgejo/src/lint/post-synth/wfj010.ts
@@ -1,0 +1,38 @@
+/**
+ * WFJ010: Unresolved action reference.
+ *
+ * After the forgejo dialect runs, every `uses:` should be a Forgejo-resolvable
+ * form (a full URL, a local `./` action, or `docker://`). A bare `owner/repo@ref`
+ * that survives into the output won't resolve — Forgejo has no GitHub
+ * Marketplace. Flags it so it's caught in `chant lint` / `forgejo:checks`, not
+ * only as a build-time warning.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput } from "@intentius/chant/lint/post-synth";
+import { extractActionRefs } from "@intentius/chant-lexicon-github/lint/post-synth/yaml-helpers";
+import { resolveActionRef } from "../../actions";
+
+export const wfj010: PostSynthCheck = {
+  id: "WFJ010",
+  description: "Unresolved action reference (won't resolve on Forgejo)",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const ref of extractActionRefs(yaml)) {
+        if (resolveActionRef(ref.ref).warning) {
+          diagnostics.push({
+            checkId: "WFJ010",
+            severity: "warning",
+            message: `Job "${ref.job}" references '${ref.ref}', which has no Forgejo-resolvable form. Use a full repository URL or map it under forgejo.actionsRoot.`,
+            entity: ref.job,
+            lexicon: "forgejo",
+          });
+        }
+      }
+    }
+    return diagnostics;
+  },
+};

--- a/lexicons/forgejo/src/lint/post-synth/wfj011.ts
+++ b/lexicons/forgejo/src/lint/post-synth/wfj011.ts
@@ -1,0 +1,41 @@
+/**
+ * WFJ011: GitHub-hosted runner label.
+ *
+ * `runs-on` labels like `macos-latest` / `windows-latest` name GitHub-hosted
+ * runners that don't exist on Forgejo, and `ubuntu-*` labels that the dialect
+ * didn't map (e.g. when mapping is overridden away) won't be advertised by a
+ * default Forgejo runner. Flags any such label that survives into the output.
+ */
+
+import type { PostSynthCheck, PostSynthContext, PostSynthDiagnostic } from "@intentius/chant/lint/post-synth";
+import { getPrimaryOutput } from "@intentius/chant/lint/post-synth";
+import { extractRunsOnByJob } from "@intentius/chant-lexicon-github/lint/post-synth/yaml-helpers";
+
+/** Labels that name a GitHub-hosted runner image (no fixed Forgejo equivalent). */
+const GITHUB_HOSTED = /^(ubuntu|macos|windows)-/;
+
+export const wfj011: PostSynthCheck = {
+  id: "WFJ011",
+  description: "GitHub-hosted runner label with no Forgejo equivalent",
+
+  check(ctx: PostSynthContext): PostSynthDiagnostic[] {
+    const diagnostics: PostSynthDiagnostic[] = [];
+    for (const [, output] of ctx.outputs) {
+      const yaml = getPrimaryOutput(output);
+      for (const [job, labels] of extractRunsOnByJob(yaml)) {
+        for (const label of labels) {
+          if (GITHUB_HOSTED.test(label)) {
+            diagnostics.push({
+              checkId: "WFJ011",
+              severity: "warning",
+              message: `Job "${job}" runs on '${label}', a GitHub-hosted runner label with no Forgejo equivalent. Map it via forgejo.runnerLabels or target a label your Forgejo runners advertise.`,
+              entity: job,
+              lexicon: "forgejo",
+            });
+          }
+        }
+      }
+    }
+    return diagnostics;
+  },
+};

--- a/lexicons/forgejo/src/mcp/context-tools.test.ts
+++ b/lexicons/forgejo/src/mcp/context-tools.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Smoke tests for the forgejo read-only context tools. Each builds a small
+ * temp project from source and exercises the tool handler directly.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { forgejoContextTools } from "./context-tools";
+
+const SOURCE = `import { Workflow, Job, Step, Checkout } from "@intentius/chant-lexicon-forgejo";
+
+export const workflow = new Workflow({
+  name: "CI",
+  on: { push: { branches: ["main"] } },
+});
+
+export const build = new Job({
+  "runs-on": "ubuntu-latest",
+  steps: [
+    Checkout({}).step,
+    new Step({ name: "Custom", uses: "some-org/custom-action@v1" }),
+    new Step({ name: "Test", run: "npm test" }),
+  ],
+});
+
+export const deploy = new Job({
+  "runs-on": "ubuntu-latest",
+  needs: ["build"],
+  steps: [new Step({ name: "Deploy", run: "./deploy.sh" })],
+});
+`;
+
+let dir: string;
+const tools = forgejoContextTools();
+const tool = (name: string) => tools.find((t) => t.name === name)!;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "fj-ctx-"));
+  mkdirSync(join(dir, "src"));
+  writeFileSync(join(dir, "src", "pipeline.ts"), SOURCE);
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("forgejo context tools", () => {
+  test("all expected tools are registered", () => {
+    expect(tools.map((t) => t.name)).toEqual([
+      "forgejo:checks",
+      "forgejo:workflow",
+      "forgejo:references",
+      "forgejo:affected",
+      "forgejo:workflow-yaml",
+      "forgejo:source",
+      "forgejo:owns",
+      "forgejo:compare",
+    ]);
+  });
+
+  test("forgejo:workflow returns triggers and jobs", async () => {
+    const result = (await tool("forgejo:workflow").handler({ path: join(dir, "src") })) as {
+      workflow: string;
+      triggers: string[];
+      jobs: Array<{ name: string; runsAfter: string[] }>;
+    };
+    expect(result.workflow).toBe("CI");
+    expect(result.triggers).toContain("push");
+    expect(result.jobs.map((j) => j.name).sort()).toEqual(["build", "deploy"]);
+  });
+
+  test("forgejo:references reports the rewritten + unmapped refs", async () => {
+    const refs = (await tool("forgejo:references").handler({ path: join(dir, "src") })) as Array<{ source: string }>;
+    const sources = refs.map((r) => r.source);
+    expect(sources).toContain("https://code.forgejo.org/actions/checkout@v4");
+    expect(sources).toContain("some-org/custom-action@v1");
+  });
+
+  test("forgejo:checks surfaces the unresolved ref (WFJ010)", async () => {
+    const result = (await tool("forgejo:checks").handler({ path: join(dir, "src") })) as {
+      findings: Array<{ id: string }>;
+    };
+    expect(result.findings.some((f) => f.id === "WFJ010")).toBe(true);
+  });
+
+  test("forgejo:affected traces the needs chain", async () => {
+    const result = (await tool("forgejo:affected").handler({ path: join(dir, "src"), job: "build" })) as {
+      wouldRerun: string[];
+    };
+    expect(result.wouldRerun).toContain("deploy");
+  });
+
+  test("forgejo:owns reports a declared job as owned", async () => {
+    const result = (await tool("forgejo:owns").handler({ path: join(dir, "src"), job: "build" })) as { owned: boolean };
+    expect(result.owned).toBe(true);
+  });
+});

--- a/lexicons/forgejo/src/mcp/context-tools.ts
+++ b/lexicons/forgejo/src/mcp/context-tools.ts
@@ -1,55 +1,263 @@
 /**
  * Read-only MCP tools for the forgejo lexicon.
  *
- * `forgejo:compare` is the lead value of the lexicon: given a GitHub Actions
- * workflow, it reports which properties survive a move to Forgejo and which
- * weaken or drop (the migration safety view). It builds/analyzes only — it
- * never touches a live forge or writes anything.
+ * The forgejo counterpart to the github/gitlab context tools (#327): expose
+ * what `chant build` already computes about a Forgejo workflow — its triggers
+ * and jobs, what it pulls in from outside, its findings, where each job came
+ * from in source — plus `forgejo:compare`, the migration safety view. Because
+ * Forgejo emits GitHub-style YAML, the parsing reuses the github lexicon's
+ * yaml-helpers.
+ *
+ * Every tool builds from source and returns data. None touch a live forge,
+ * read run history, or write anything.
  */
 
+import { build, type BuildResult } from "@intentius/chant/build";
+import { runPostSynthChecks, getPrimaryOutput } from "@intentius/chant/lint/post-synth";
+import { discoverPostSynthChecks } from "@intentius/chant/lint/discover";
+import { getProvenance } from "@intentius/chant/provenance";
 import type { McpToolContribution } from "@intentius/chant/mcp/types";
-import { resolve } from "path";
+import { dirname, join, relative, isAbsolute, resolve } from "path";
 import { readFile } from "fs/promises";
+import { fileURLToPath } from "url";
+import {
+  extractJobs,
+  extractActionRefs,
+  extractImageRefs,
+  extractTriggers,
+  extractWorkflowName,
+} from "@intentius/chant-lexicon-github/lint/post-synth/yaml-helpers";
+import { forgejoSerializer } from "../serializer";
 import { transform, detectGitHubWorkflow } from "../migrate/from-github";
 
-const compareTool: McpToolContribution = {
-  name: "forgejo:compare",
-  description:
-    "Given a GitHub Actions workflow file, migrate it to Forgejo and report which properties survive the move and which weaken or are lost (the migration safety view). Returns a per-property fate (translated/approximated/needs-review/lost) plus summary counts. Read-only — analyzes, never writes.",
-  inputSchema: {
-    type: "object" as const,
-    properties: {
-      file: { type: "string", description: "Path to a .github/workflows/*.yml workflow file to migrate and compare" },
-    },
-    required: ["file"],
-  },
-  async handler(params: Record<string, unknown>): Promise<unknown> {
-    const file = resolve((params.file as string) ?? "");
-    let content: string;
-    try {
-      content = await readFile(file, "utf8");
-    } catch {
-      return { file: params.file ?? null, found: false, note: "could not read the workflow file" };
-    }
-    if (!detectGitHubWorkflow(content)) {
-      return { file: params.file ?? null, found: false, note: "file does not look like a GitHub Actions workflow" };
-    }
+/**
+ * Build the project with the forgejo serializer and return the emitted YAML.
+ * The serializer is registered under the "github" lexicon (it serializes the
+ * reused github entities), so the output is keyed "github".
+ */
+async function buildForgejo(path: string): Promise<{ yaml: string; result: BuildResult }> {
+  const result = await build(path, [forgejoSerializer]);
+  const out = result.outputs.get("github");
+  return { yaml: out ? getPrimaryOutput(out) : "", result };
+}
 
-    const migration = await transform(content, { security: true, sourceFile: file });
-    const properties = migration.provenance.map((r) => ({
-      property: r.security.property,
-      fate: r.security.fate,
-      severity: r.security.severity,
-      sourceKey: r.sourceKey,
-      reestablish: r.security.reestablish ?? null,
-      note: r.note ?? null,
-    }));
-    const summary: Record<string, number> = { translated: 0, approximated: 0, "needs-review": 0, lost: 0 };
-    for (const p of properties) summary[p.fate] = (summary[p.fate] ?? 0) + 1;
-    return { found: true, properties, summary };
+/** Discover the forgejo post-synth checks without depending on the plugin. */
+function forgejoPostSynthChecks() {
+  const dir = join(dirname(fileURLToPath(import.meta.url)), "..", "lint", "post-synth");
+  return discoverPostSynthChecks(dir, import.meta.url);
+}
+
+/** Is a `uses:` ref pinned to a full commit SHA (the only immutable form)? */
+export function actionPinned(ref: string): boolean {
+  const at = ref.lastIndexOf("@");
+  return at !== -1 && /^[0-9a-f]{40}$/.test(ref.slice(at + 1));
+}
+
+/** The YAML job name a build entity serializes to (camelCase → kebab-case). */
+export function jobNameOf(entityName: string): string {
+  return entityName.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+/** Find the build entity whose serialized job name matches `job`. */
+function entityForJob(result: BuildResult, job: string): { name: string; entity: object } | undefined {
+  for (const [name, entity] of result.entities) {
+    if (name === job || jobNameOf(name) === job) return { name, entity };
+  }
+  return undefined;
+}
+
+/** Render a source-file path relative to the project root, when possible. */
+function relSource(root: string, file: string | undefined): string | undefined {
+  if (!file) return undefined;
+  if (!isAbsolute(file)) return file;
+  const rel = relative(root, file);
+  return rel.startsWith("..") ? file : rel;
+}
+
+/** Jobs that would re-run because they depend (transitively) on `job`. */
+export function downstreamJobs(yaml: string, job: string): string[] {
+  const jobs = extractJobs(yaml);
+  const downstreamOf = new Map<string, string[]>();
+  for (const [name, j] of jobs) {
+    for (const dep of j.needs ?? []) {
+      const arr = downstreamOf.get(dep) ?? [];
+      arr.push(name);
+      downstreamOf.set(dep, arr);
+    }
+  }
+  const out = new Set<string>();
+  const queue = [job];
+  while (queue.length) {
+    const cur = queue.shift()!;
+    for (const next of downstreamOf.get(cur) ?? []) {
+      if (!out.has(next)) {
+        out.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  return [...out];
+}
+
+const PATH_INPUT = {
+  type: "object" as const,
+  properties: {
+    path: { type: "string", description: "Path to the chant project directory (default: current directory)" },
   },
 };
 
+const JOB_INPUT = {
+  type: "object" as const,
+  properties: {
+    path: { type: "string", description: "Path to the chant project directory (default: current directory)" },
+    job: { type: "string", description: "Job name (as it appears in the generated YAML)" },
+  },
+  required: ["job"],
+};
+
+/** The read-only context tools for the forgejo lexicon. */
 export function forgejoContextTools(): McpToolContribution[] {
-  return [compareTool];
+  return [
+    {
+      name: "forgejo:checks",
+      description:
+        "Build the workflow and return its Forgejo-specific findings (the WFJ checks: unresolved action refs, GitHub-hosted runner labels) as JSON. Read-only.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml, result } = await buildForgejo((params.path as string) ?? ".");
+        if (!yaml) return { findings: [], note: "no Forgejo workflow produced from this project" };
+        const scoped = { ...result, outputs: new Map([["github", result.outputs.get("github")!]]) };
+        const diags = runPostSynthChecks(forgejoPostSynthChecks(), scoped);
+        return {
+          findings: diags.map((d) => ({ id: d.checkId, severity: d.severity, job: d.entity ?? null, message: d.message })),
+        };
+      },
+    },
+    {
+      name: "forgejo:workflow",
+      description:
+        "Build the workflow and return its triggers and jobs as written (name, what each job runs after, step count) — before anything runs. Read-only.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildForgejo((params.path as string) ?? ".");
+        const jobs = [...extractJobs(yaml).values()].map((j) => ({
+          name: j.name,
+          runsAfter: j.needs ?? [],
+          steps: j.steps?.length ?? 0,
+        }));
+        return { workflow: extractWorkflowName(yaml) ?? null, triggers: Object.keys(extractTriggers(yaml)), jobs };
+      },
+    },
+    {
+      name: "forgejo:references",
+      description:
+        "Build the workflow and list everything it pulls in from outside (actions via uses:, container/service images) and whether each is pinned to an immutable commit SHA. Read-only.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildForgejo((params.path as string) ?? ".");
+        const actions = extractActionRefs(yaml).map((a) => ({
+          kind: a.level === "job" ? ("reusable-workflow" as const) : ("action" as const),
+          job: a.job,
+          source: a.ref,
+          pinned: actionPinned(a.ref),
+        }));
+        const images = extractImageRefs(yaml).map((i) => ({
+          kind: "image" as const,
+          job: i.job,
+          source: i.image,
+          pinned: i.image.includes("@sha256:"),
+        }));
+        return [...actions, ...images];
+      },
+    },
+    {
+      name: "forgejo:affected",
+      description:
+        "Build the workflow and, given a job name, list the jobs that would re-run because they depend on it (the needs chain). Read-only.",
+      inputSchema: JOB_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildForgejo((params.path as string) ?? ".");
+        const job = params.job as string;
+        return { job, wouldRerun: downstreamJobs(yaml, job) };
+      },
+    },
+    {
+      name: "forgejo:workflow-yaml",
+      description: "Build the project and return the generated Forgejo Actions workflow YAML as a string. Read-only.",
+      inputSchema: PATH_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const { yaml } = await buildForgejo((params.path as string) ?? ".");
+        return { yaml };
+      },
+    },
+    {
+      name: "forgejo:source",
+      description:
+        "Build the project and, given a job name, say where it came from in the TypeScript source — the file that declared it and the composite that expanded it, if any. Entity-level provenance, not a YAML-line source map. Read-only.",
+      inputSchema: JOB_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const root = (params.path as string) ?? ".";
+        const { result } = await buildForgejo(root);
+        const job = params.job as string;
+        const found = entityForJob(result, job);
+        if (!found) return { job, found: false, note: "no build entity serializes to that job name" };
+        const prov = getProvenance(found.entity);
+        return { job, found: true, entity: found.name, from: relSource(root, prov?.sourceFile) ?? null, via: prov?.composite ?? null };
+      },
+    },
+    {
+      name: "forgejo:owns",
+      description:
+        "Build the project and report whether a job is declared (owned) by chant in this project's source. For workflow config, ownership means \"declared here\" — Forgejo Actions jobs are not taggable cloud resources, so there is no live ownership marker as there is for cloud lexicons. Read-only.",
+      inputSchema: JOB_INPUT,
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const root = (params.path as string) ?? ".";
+        const { result } = await buildForgejo(root);
+        const job = params.job as string;
+        const found = entityForJob(result, job);
+        return {
+          job,
+          owned: Boolean(found),
+          basis: "declared-in-source",
+          note: "Forgejo Actions jobs are not taggable cloud resources; ownership here means the job is declared by chant in this project. Live ownership markers apply to cloud lexicons (aws/azure/k8s).",
+        };
+      },
+    },
+    {
+      name: "forgejo:compare",
+      description:
+        "Given a GitHub Actions workflow file, migrate it to Forgejo and report which properties survive the move and which weaken or are lost (the migration safety view). Returns a per-property fate (translated/approximated/needs-review/lost) plus summary counts. Read-only — analyzes, never writes.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          file: { type: "string", description: "Path to a .github/workflows/*.yml workflow file to migrate and compare" },
+        },
+        required: ["file"],
+      },
+      async handler(params: Record<string, unknown>): Promise<unknown> {
+        const file = resolve((params.file as string) ?? "");
+        let content: string;
+        try {
+          content = await readFile(file, "utf8");
+        } catch {
+          return { file: params.file ?? null, found: false, note: "could not read the workflow file" };
+        }
+        if (!detectGitHubWorkflow(content)) {
+          return { file: params.file ?? null, found: false, note: "file does not look like a GitHub Actions workflow" };
+        }
+        const migration = await transform(content, { security: true, sourceFile: file });
+        const properties = migration.provenance.map((r) => ({
+          property: r.security.property,
+          fate: r.security.fate,
+          severity: r.security.severity,
+          sourceKey: r.sourceKey,
+          reestablish: r.security.reestablish ?? null,
+          note: r.note ?? null,
+        }));
+        const summary: Record<string, number> = { translated: 0, approximated: 0, "needs-review": 0, lost: 0 };
+        for (const p of properties) summary[p.fate] = (summary[p.fate] ?? 0) + 1;
+        return { found: true, properties, summary };
+      },
+    },
+  ];
 }

--- a/lexicons/forgejo/src/plugin.ts
+++ b/lexicons/forgejo/src/plugin.ts
@@ -9,6 +9,10 @@
  */
 
 import type { LexiconPlugin, InitTemplateSet, MigrationSource } from "@intentius/chant/lexicon";
+import { discoverPostSynthChecks } from "@intentius/chant/lint/discover";
+import { createSkillsLoader, createDiffTool } from "@intentius/chant/lexicon-plugin-helpers";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 import { forgejoSerializer } from "./serializer";
 import { forgejoContextTools } from "./mcp/context-tools";
 
@@ -117,9 +121,41 @@ export const build = new Job({
     };
   },
 
-  mcpTools() {
-    return [...forgejoContextTools()];
+  postSynthChecks() {
+    const dir = join(dirname(fileURLToPath(import.meta.url)), "lint", "post-synth");
+    return discoverPostSynthChecks(dir, import.meta.url);
   },
+
+  mcpTools() {
+    return [
+      createDiffTool(forgejoSerializer, "Compare current build output against previous output for Forgejo Actions", "forgejo"),
+      ...forgejoContextTools(),
+    ];
+  },
+
+  skills: createSkillsLoader(import.meta.url, [
+    {
+      file: "chant-forgejo.md",
+      name: "chant-forgejo",
+      description: "Forgejo / Codeberg / Gitea Actions with chant — build, the dialect (dropped keys, runner labels, uses: resolution), and github→forgejo migration",
+      triggers: [
+        { type: "file-pattern", value: "**/.forgejo/workflows/*.yml" },
+        { type: "file-pattern", value: "**/.gitea/workflows/*.yml" },
+        { type: "context", value: "forgejo" },
+        { type: "context", value: "codeberg" },
+        { type: "context", value: "gitea" },
+      ],
+      parameters: [],
+      examples: [
+        {
+          title: "Build a Forgejo workflow",
+          description: "Author github-style; the forgejo dialect applies on build",
+          input: "Create a CI workflow for Codeberg",
+          output: `chant build src -o .forgejo/workflows/ci.yml`,
+        },
+      ],
+    },
+  ]),
 
   // ── Codegen lifecycle — delegated to github (no own spec) ──────────
   async generate(): Promise<void> {

--- a/lexicons/forgejo/src/serializer.test.ts
+++ b/lexicons/forgejo/src/serializer.test.ts
@@ -69,12 +69,12 @@ describe("forgejoSerializer — github-style source roundtrip", () => {
     expect(asResult(out).primary).toContain("runs-on: big-runner");
   });
 
-  test("an unmapped label passes through with a warning", () => {
+  test("an unmapped label passes through (WFJ011 reports it post-synth, not the serializer)", () => {
     const job = new Job({ "runs-on": "windows-latest", steps: [new Step({ run: "echo hi" })] }) as unknown as Declarable;
     const out = forgejoSerializer.serialize(new Map([["build", job]]));
     const result = asResult(out);
     expect(result.primary).toContain("runs-on: windows-latest");
-    expect((result.warnings ?? []).filter((w) => w.includes("windows-latest"))).toHaveLength(1);
+    expect((result.warnings ?? []).filter((w) => w.includes("windows-latest"))).toHaveLength(0);
   });
 });
 
@@ -99,13 +99,11 @@ describe("forgejoSerializer — uses: action resolution", () => {
     expect(asResult(out).primary).toContain("uses: https://codeberg.org/actions/checkout@v4");
   });
 
-  test("an unmapped action ref is passed through and reported", () => {
+  test("an unmapped action ref is passed through (WFJ010 reports it post-synth)", () => {
     const step = new Step({ name: "Custom", uses: "some-org/custom-action@v1" });
     const result = asResult(forgejoSerializer.serialize(withSteps(step)));
     expect(result.primary).toContain("uses: some-org/custom-action@v1");
-    const refWarnings = (result.warnings ?? []).filter((w) => w.includes("some-org/custom-action@v1"));
-    expect(refWarnings).toHaveLength(1);
-    expect(refWarnings[0]).toContain("unresolved action ref");
+    expect((result.warnings ?? []).filter((w) => w.includes("some-org/custom-action@v1"))).toHaveLength(0);
   });
 });
 

--- a/lexicons/forgejo/src/skills/chant-forgejo.md
+++ b/lexicons/forgejo/src/skills/chant-forgejo.md
@@ -1,0 +1,68 @@
+# chant-forgejo
+
+Forgejo / Codeberg / Gitea Actions with chant.
+
+Forgejo runs **GitHub-Actions-compatible** workflows, so the forgejo lexicon is
+a thin dialect of the github lexicon. You author exactly as you would for GitHub
+Actions — same `Workflow`, `Job`, `Step`, and composites — but import from
+`@intentius/chant-lexicon-forgejo`. The dialect applies on build.
+
+## Authoring
+
+```ts
+import { Workflow, Job, Step, Checkout, SetupNode } from "@intentius/chant-lexicon-forgejo";
+
+export const workflow = new Workflow({
+  name: "CI",
+  on: { push: { branches: ["main"] } },
+});
+
+export const build = new Job({
+  "runs-on": "ubuntu-latest",
+  steps: [
+    Checkout({}).step,
+    SetupNode({ nodeVersion: "22", cache: "npm" }).step,
+    new Step({ name: "Test", run: "npm test" }),
+  ],
+});
+```
+
+## Build
+
+Forgejo reads workflows from `.forgejo/workflows/` (or `.gitea/workflows/` for
+Gitea):
+
+```sh
+chant build src -o .forgejo/workflows/ci.yml
+```
+
+## What the dialect does on build
+
+- **Drops keys the Forgejo runner ignores** — `permissions` and
+  `continue-on-error` are removed (each emits a build warning).
+- **Maps runner labels** — `ubuntu-latest` → `docker` by default; override via
+  `forgejo.runnerLabels` in `chant.config.ts`. Unmapped labels warn.
+- **Resolves `uses:` refs** — common `actions/*` rewrite under
+  `forgejo.actionsRoot` (default `https://code.forgejo.org`); `docker/*` pin to
+  their GitHub URL; unmapped refs warn.
+
+## Migrating from GitHub Actions
+
+```sh
+chant migrate .github/workflows/ci.yml --to forgejo -o .forgejo/workflows/ci.yml --validate
+```
+
+`--validate` prints a **Security posture** report: what survives the move and
+what Forgejo silently drops (`permissions`/`continue-on-error` → lost,
+unresolved `uses:` / unmapped runner labels → needs-review). The same view is
+the `forgejo:compare` MCP tool.
+
+## Read-only context tools (MCP)
+
+- `forgejo:workflow` — triggers and jobs as written
+- `forgejo:references` — external actions/images and whether each is SHA-pinned
+- `forgejo:affected` — jobs that re-run downstream of a given job
+- `forgejo:checks` — Forgejo-specific findings (WFJ010/011)
+- `forgejo:source` / `forgejo:owns` — where a job came from / whether it's declared here
+- `forgejo:workflow-yaml` — the generated YAML
+- `forgejo:compare` — the github→forgejo migration safety view

--- a/packages/core/src/cli/commands/build.ts
+++ b/packages/core/src/cli/commands/build.ts
@@ -140,11 +140,15 @@ export async function buildCommand(options: BuildOptions): Promise<BuildResult> 
       const checks = plugin.postSynthChecks();
       if (checks.length === 0) continue;
 
-      // Scope outputs to this plugin's lexicon so cross-lexicon outputs don't interfere
+      // Scope outputs to this plugin's lexicon so cross-lexicon outputs don't
+      // interfere. Outputs are keyed by the serializer's lexicon name (the
+      // build partition key), which differs from plugin.name for a dialect like
+      // forgejo (plugin "forgejo", serializer "github").
+      const outputKey = plugin.serializer.name;
       const scopedOutputs = new Map<string, string | SerializerResult>();
-      const pluginOutput = result.outputs.get(plugin.name);
+      const pluginOutput = result.outputs.get(outputKey);
       if (pluginOutput !== undefined) {
-        scopedOutputs.set(plugin.name, pluginOutput);
+        scopedOutputs.set(outputKey, pluginOutput);
       }
 
       const scopedResult = { ...result, outputs: scopedOutputs };


### PR DESCRIPTION
Closes #342 (Epic #338). Depends on #339/#340/#341, all merged. **Final phase — completes the epic.**

## What

Rounds the forgejo lexicon out to parity with github/gitlab. Because Forgejo emits GitHub-style YAML, the context tools and yaml parsing reuse the **github** lexicon's helpers.

### Context tools (`src/mcp/context-tools.ts`)
The full `forgejo:*` read-only set, alongside the P3 `forgejo:compare`:
- `forgejo:checks` — WFJ findings
- `forgejo:workflow` — triggers + jobs + run order
- `forgejo:references` — actions/images + SHA-pinned?
- `forgejo:affected` — needs chain
- `forgejo:workflow-yaml` — generated YAML
- `forgejo:source` / `forgejo:owns` — build-provenance (file + composite / declared-here)

All build via `build(path, [forgejoSerializer])` and are read-only.

### Lint deltas (`src/lint/post-synth`)
- **WFJ010** — unresolved action ref (a `uses:` with no Forgejo-resolvable form)
- **WFJ011** — GitHub-hosted runner label (`macos-`/`windows-`/unmapped `ubuntu-`)

Both output-based; surface in `chant build`, `chant lint`, and `forgejo:checks`.

### Dedup (polish)
The dialect previously warned about unmapped labels (P1) and unresolved refs (P2) at serialize time; now WFJ010/011 cover those, so the dialect keeps **only** the dropped-key warnings (`permissions`/`continue-on-error`, which can't be post-synth-checked since they're stripped from output). Result: `chant build` no longer double-warns. The P1/P2 ACs ("an unknown label warns", "unmapped ref produces a diagnostic") still hold — the warning now comes from the post-synth check, visible in both build and lint.

### Skill + docs
- `chant-forgejo` skill + a diff tool.
- Docs: agent-integration tool-table rows, a whats-new section, `lexicons/overview` rows (Available Lexicons, runtime-observation N/A, cross-lexicon migration).

### Core
Post-synth scoping in `cli/commands/build.ts` now keys on the **serializer's** lexicon name (the output partition key) rather than `plugin.name`, so a dialect like forgejo (plugin `forgejo`, serializer `github`) has its checks run during build. No change for github/gitlab where `plugin.name === serializer.name`. (This is the P1 follow-up flagged in #343.)

## Acceptance criteria

- [x] All `forgejo:*` context tools registered and returning data on a sample project (build-based smoke tests).
- [x] Lint flags unresolved action refs and GitHub-hosted runner labels.
- [x] `chant init --lexicon forgejo` scaffolds a buildable project (node-CI default template, shipped in P1).
- [x] Docs: agent-integration tables updated, lexicons/overview rows, whats-new entry.
- [x] 58 forgejo tests pass; github (453) + core build/cli (479) stay green; full-workspace `tsc` clean.

Verified end-to-end: `chant build` emits to `.forgejo/workflows/` with exactly one warning per distinct issue (no duplication), and `forgejo:checks` returns WFJ findings.