### PR TITLE
test+docs(forgejo): runtime E2E + dedicated lexicon docs page (#347)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -105,6 +105,7 @@ export default defineConfig({
 						{ label: 'Helm Charts', link: '/lexicons/helm/' },
 						{ label: 'GitHub Actions', link: '/lexicons/github/' },
 						{ label: 'GitLab CI/CD', link: '/lexicons/gitlab/' },
+						{ label: 'Forgejo Actions', slug: 'lexicons/forgejo' },
 						{ label: 'Docker', link: '/lexicons/docker/' },
 						{ label: 'Temporal', link: '/lexicons/temporal/' },
 					],

--- a/docs/src/content/docs/lexicons/forgejo.mdx
+++ b/docs/src/content/docs/lexicons/forgejo.mdx
@@ -1,0 +1,135 @@
+---
+title: Forgejo Actions
+description: The Forgejo / Codeberg / Gitea Actions lexicon — a thin GitHub Actions dialect, with github→forgejo migration and the forgejo:compare safety view
+---
+
+`@intentius/chant-lexicon-forgejo` targets **Forgejo Actions** — the CI behind
+[Codeberg](https://codeberg.org), self-hosted [Forgejo](https://forgejo.org),
+and [Gitea](https://about.gitea.com). Forgejo runs **GitHub-Actions-compatible**
+workflows, so the lexicon is a **thin dialect of the [github lexicon](/chant/lexicons/github/)**:
+it reuses github's entities and composites wholesale and overrides only the
+serializer. One package covers Codeberg, self-hosted Forgejo, and Gitea.
+
+## Authoring
+
+Author exactly as you would for GitHub Actions — the same `Workflow`, `Job`,
+`Step`, and composites — but import from `@intentius/chant-lexicon-forgejo`:
+
+```ts
+import { Workflow, Job, Step, Checkout, SetupNode } from "@intentius/chant-lexicon-forgejo";
+
+export const workflow = new Workflow({
+  name: "CI",
+  on: { push: { branches: ["main"] } },
+});
+
+export const build = new Job({
+  "runs-on": "ubuntu-latest",
+  steps: [
+    Checkout({}).step,
+    SetupNode({ nodeVersion: "22", cache: "npm" }).step,
+    new Step({ name: "Test", run: "npm test" }),
+  ],
+});
+```
+
+## Build
+
+Forgejo reads workflows from `.forgejo/workflows/` (or `.gitea/workflows/` for
+Gitea), so point the output there — the same way the github lexicon targets
+`.github/workflows/`:
+
+```sh
+chant build src -o .forgejo/workflows/ci.yml
+```
+
+## The dialect
+
+Forgejo Actions YAML *is* GitHub Actions YAML, so the github serializer already
+emits the right shape. On build, the dialect adjusts three things:
+
+| Concern | Behavior |
+|---|---|
+| **Ignored keys** | `permissions` and `continue-on-error` are silently ignored by the Forgejo runner. They are dropped from the output, each with a build warning (emitting them is misleading — they look enforced but aren't). |
+| **Runner labels** | GitHub-hosted labels like `ubuntu-latest` have no fixed meaning on Forgejo. They map to a default label (`docker`), overridable via `forgejo.runnerLabels`. A surviving GitHub-hosted label is flagged by **WFJ011**. |
+| **`uses:` refs** | Forgejo has no GitHub Marketplace. Common `actions/*` rewrite under an actions root (`https://code.forgejo.org` by default), `docker/*` pin to their full GitHub URL, and local / `docker://` / full-URL refs pass through. An unresolved ref is flagged by **WFJ010**. |
+
+## Configuration
+
+Override the runner-label map and the actions root in `chant.config.ts`:
+
+```ts
+import type { ChantConfig } from "@intentius/chant";
+
+export default {
+  lexicons: ["forgejo"],
+  forgejo: {
+    runnerLabels: {
+      "ubuntu-latest": "docker",
+      "ubuntu-22.04": "ubuntu-lts",
+    },
+    actionsRoot: "https://code.forgejo.org",
+  },
+} satisfies ChantConfig;
+```
+
+## Migrating from GitHub Actions
+
+Because github → forgejo YAML is near-identical, the migration is thin — it
+applies the same dialect as a build. Its real value is the **compare**: what the
+move costs.
+
+```sh
+chant migrate .github/workflows/ci.yml --to forgejo -o .forgejo/workflows/ci.yml --validate
+```
+
+`--validate` prints a **Security posture** report classifying each property's
+fate across the edge:
+
+| Fate | Meaning |
+|---|---|
+| `translated` | carried across as-is |
+| `approximated` | carried with a close equivalent |
+| `needs-review` | confirm/adjust on Forgejo (unresolved `uses:`, unmapped runner label) |
+| `lost` | the Forgejo runner ignores it (`permissions`, `continue-on-error`) |
+
+The same view is available to agents as the `forgejo:compare` MCP tool, which
+takes a workflow file and returns per-property fates plus summary counts —
+read-only.
+
+## Read-only context tools
+
+The forgejo lexicon ships the full `forgejo:*` [read-only context tools](/chant/guide/agent-integration/#read-only-context-tools)
+(`checks`, `workflow`, `references`, `affected`, `workflow-yaml`, `source`,
+`owns`, `compare`). Each builds from source and returns what chant already
+computes — without touching any live forge.
+
+## Lint checks
+
+Two post-synth checks specific to the Forgejo edge, surfaced in `chant build`,
+`chant lint`, and `forgejo:checks`:
+
+- **WFJ010** — an unresolved action reference (a `uses:` with no
+  Forgejo-resolvable form).
+- **WFJ011** — a GitHub-hosted runner label (`macos-*` / `windows-*`, or an
+  unmapped `ubuntu-*`) with no Forgejo equivalent.
+
+## Runtime observation
+
+N/A — workflow definitions are git-tracked, so drift is a `git diff`, the same
+rationale as the github and gitlab lexicons. The lexicon implements neither
+`describeResources()` nor `listArtifacts()` and is warn-skipped on `--live`.
+
+## Validating execution
+
+A runtime E2E (`just forgejo-runtime-e2e`) builds a workflow and **runs** the
+generated `.forgejo/workflows/ci.yml` in Docker via a Forgejo runner
+(`forgejo-runner` / `act_runner` / `act` `exec`), proving Forgejo Actions
+accepts and executes chant's output. On-demand — it needs Docker and a runner
+tool, and is not part of the gating CI.
+
+## Caveats
+
+Flow-style YAML (`branches: [main]`) is parsed by chant's lightweight core
+parser, which keeps it as a scalar — prefer block style in sources you intend to
+migrate. This is shared with the github import path.

--- a/docs/src/content/docs/lexicons/overview.mdx
+++ b/docs/src/content/docs/lexicons/overview.mdx
@@ -16,7 +16,7 @@ A **lexicon** is a collection of types and semantic lint rules for an operationa
 | Helm | `@intentius/chant-lexicon-helm` | 10+ resources | [Reference](/chant/lexicons/helm/) |
 | GitHub Actions | `@intentius/chant-lexicon-github` | 3 resources, 14 composites | [Reference](/chant/lexicons/github/) |
 | GitLab CI/CD | `@intentius/chant-lexicon-gitlab` | 3 resources, 16 properties | [Reference](/chant/lexicons/gitlab/) — also ships [GitHub Actions migration](/chant/lexicons/gitlab/migration/) |
-| Forgejo Actions (Codeberg / Gitea) | `@intentius/chant-lexicon-forgejo` | thin github dialect (reuses github entities) | [README](https://github.com/INTENTIUS/chant/blob/main/lexicons/forgejo/README.md) — ships [GitHub Actions migration + `forgejo:compare`](/chant/guide/agent-integration/#read-only-context-tools) |
+| Forgejo Actions (Codeberg / Gitea) | `@intentius/chant-lexicon-forgejo` | thin github dialect (reuses github entities) | [Reference](/chant/lexicons/forgejo/) — ships GitHub Actions migration + `forgejo:compare` |
 | Docker | `@intentius/chant-lexicon-docker` | 6 resources (Compose + Dockerfile) | [Reference](/chant/lexicons/docker/) |
 | Temporal | `@intentius/chant-lexicon-temporal` | 4 resources + Op workflow engine | [Reference](/chant/lexicons/temporal/) |
 
@@ -45,7 +45,7 @@ The **Ownership** column shows the marker channel a lexicon queries for the `--o
 
 The GitLab lexicon ships a `chant migrate` source for `from: github` — translates `.github/workflows/*.yml` into `.gitlab-ci.yml` (or typed chant TypeScript), with provenance recorded as SARIF and a curated mapping table for the top 33 marketplace actions. See [GitLab → Migration](/chant/lexicons/gitlab/migration/) for the full surface, or the [`chant migrate` CLI reference](/chant/cli/migrate/).
 
-The Forgejo lexicon implements the same `migrationSource("github")` hook — a **thin** edge, since Forgejo runs GitHub-Actions-compatible YAML. Its value is the [`forgejo:compare`](/chant/guide/agent-integration/#read-only-context-tools) safety view: a per-property security-fate report of what the move costs (`permissions`/`continue-on-error` → lost, unresolved `uses:` → needs-review).
+The [Forgejo lexicon](/chant/lexicons/forgejo/) implements the same `migrationSource("github")` hook — a **thin** edge, since Forgejo runs GitHub-Actions-compatible YAML. Its value is the `forgejo:compare` safety view: a per-property security-fate report of what the move costs (`permissions`/`continue-on-error` → lost, unresolved `uses:` → needs-review).
 
 Future lexicons can opt into the same machinery by implementing `migrationSource(from: string)` on their plugin.
 

--- a/docs/src/content/docs/whats-new.mdx
+++ b/docs/src/content/docs/whats-new.mdx
@@ -22,14 +22,14 @@ chant now exposes what `chant build` already computes about a pipeline — its j
 
 ## Forgejo lexicon (Codeberg / Forgejo / Gitea)
 
-A new lexicon for **Forgejo Actions** — the CI behind Codeberg, self-hosted Forgejo, and Gitea — built as a **thin dialect of the github lexicon**. Forgejo runs GitHub-Actions-compatible YAML, so you author exactly as for GitHub (same entities and composites, imported from `@intentius/chant-lexicon-forgejo`) and the dialect applies on build. The differentiated value is the github→forgejo **compare**: what the move silently costs.
+A new lexicon for **[Forgejo Actions](/chant/lexicons/forgejo/)** — the CI behind Codeberg, self-hosted Forgejo, and Gitea — built as a **thin dialect of the github lexicon**. Forgejo runs GitHub-Actions-compatible YAML, so you author exactly as for GitHub (same entities and composites, imported from `@intentius/chant-lexicon-forgejo`) and the dialect applies on build. The differentiated value is the github→forgejo **compare**: what the move silently costs.
 
 | # | Capability |
 |---|---|
 | [#339](https://github.com/INTENTIUS/chant/pull/343) | Serializer dialect — emits `.forgejo/workflows/` (or `.gitea/workflows/`); drops keys the Forgejo runner ignores (`permissions`, `continue-on-error`) with build warnings; maps runner labels (`ubuntu-latest` → `docker`, override via `forgejo.runnerLabels`) |
 | [#340](https://github.com/INTENTIUS/chant/pull/344) | `uses:` action-ref resolver — Forgejo has no Marketplace, so common `actions/*` rewrite under `forgejo.actionsRoot` (default `https://code.forgejo.org`), `docker/*` pin to GitHub URLs, and unmapped refs are reported |
 | [#341](https://github.com/INTENTIUS/chant/pull/345) | `chant migrate --to forgejo` + the [`forgejo:compare`](/chant/guide/agent-integration/#read-only-context-tools) MCP tool — a per-property security-fate report (translated / approximated / needs-review / lost) of what survives the move |
-| [#342](https://github.com/INTENTIUS/chant/issues/342) | Parity surface — the full `forgejo:*` [read-only context tools](/chant/guide/agent-integration/#read-only-context-tools), WFJ010/011 lint checks, init templates, a `chant-forgejo` skill, and docs |
+| [#342](https://github.com/INTENTIUS/chant/pull/346) | Parity surface — the full `forgejo:*` [read-only context tools](/chant/guide/agent-integration/#read-only-context-tools), WFJ010/011 lint checks, init templates, a `chant-forgejo` skill, and a [reference page](/chant/lexicons/forgejo/) |
 
 ## CI/CD pipeline security audit
 

--- a/justfile
+++ b/justfile
@@ -58,6 +58,10 @@ smoke-npm-registry:
 gitlab-runtime-e2e:
     bash test/gitlab-runtime-e2e.sh
 
+# Run a chant-generated Forgejo workflow in Docker (forgejo-runner/act exec; on-demand, needs Docker)
+forgejo-runtime-e2e:
+    bash test/forgejo-runtime-e2e.sh
+
 # Run all smoke tests
 smoke: smoke-workspace smoke-npm
 

--- a/test/forgejo-runtime-e2e.sh
+++ b/test/forgejo-runtime-e2e.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Forgejo runtime E2E: build a chant workflow and ACTUALLY RUN it in Docker.
+#
+# Unlike the post-synth checks (which prove the YAML is well-formed) and the
+# smoke tests (which prove the package installs), this proves a Forgejo runner
+# accepts and executes chant's generated `.forgejo/workflows/ci.yml` — the
+# `runs-on` label the dialect maps to (`ubuntu-latest` -> `docker`), step
+# ordering, and `needs:` ordering across jobs.
+#
+# Forgejo Actions run on the same engine as `act` (nektos/act); Forgejo's own
+# runner is `forgejo-runner` / `act_runner`, whose `exec` subcommand runs a
+# workflow locally without a server. This script uses whichever of
+# `forgejo-runner`, `act_runner`, or `act` is on PATH.
+#
+# On-demand only — NOT part of the gating CI. It needs Docker + a runner tool
+# and is inherently slower/flakier than unit tests. Run it yourself:
+#
+#   just forgejo-runtime-e2e        (or)   bash test/forgejo-runtime-e2e.sh
+#
+# Override the image the `docker` label maps to with FORGEJO_E2E_IMAGE.
+#
+# Exit codes: 0 pass or cleanly skipped (no Docker / no runner tool); non-zero
+# on a real failure.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE="$ROOT/test/forgejo-runtime-e2e"
+IMAGE="${FORGEJO_E2E_IMAGE:-node:20-bookworm-slim}"
+
+skip() { echo "SKIP: $1"; exit 0; }
+
+# ── Preconditions ────────────────────────────────────────────────────────────
+command -v docker >/dev/null 2>&1 || skip "docker not installed"
+docker info >/dev/null 2>&1 || skip "docker daemon not reachable"
+
+# Pick a Forgejo-compatible runner. `exec` subcommand for the runners; bare for act.
+RUNNER=""
+RUNNER_KIND=""
+for cand in forgejo-runner act_runner act; do
+  if command -v "$cand" >/dev/null 2>&1; then
+    RUNNER="$cand"
+    [ "$cand" = "act" ] && RUNNER_KIND="act" || RUNNER_KIND="exec"
+    break
+  fi
+done
+[ -n "$RUNNER" ] || skip "no Forgejo runner found (install forgejo-runner, act_runner, or act)"
+
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# ── 1. Build the fixture workflow → .forgejo/workflows/ci.yml ────────────────
+echo "=== Building fixture workflow ==="
+npx tsx "$FIXTURE/build.ts" "$WORK"
+echo "--- generated .forgejo/workflows/ci.yml ---"
+cat "$WORK/.forgejo/workflows/ci.yml"
+echo "-------------------------------------------"
+
+# A runner expects a git repo at the root.
+( cd "$WORK" && git init -q && git add -A && git -c user.email=e2e@chant -c user.name=chant commit -qm fixture )
+
+# ── 2. Run the workflow with the Forgejo runner ──────────────────────────────
+echo "=== Running workflow ($RUNNER, label docker -> $IMAGE) ==="
+LOG="$WORK/run.log"
+cd "$WORK"
+case "$RUNNER_KIND" in
+  exec) RUN=( "$RUNNER" exec -W .forgejo/workflows/ci.yml -P "docker=$IMAGE" ) ;;
+  act)  RUN=( "$RUNNER" push -W .forgejo/workflows/ci.yml -P "docker=$IMAGE" ) ;;
+esac
+if ! "${RUN[@]}" 2>&1 | tee "$LOG"; then
+  echo "FAIL: the runner reported a job failure"
+  exit 1
+fi
+
+# ── 3. Assert both jobs ran, in order ────────────────────────────────────────
+# `verify` needs `build`, so seeing both markers proves the runner honored the
+# dialect's runner label, ran the steps, and respected the needs edge.
+grep -q "BUILD-OK" "$LOG"  || { echo "FAIL: build job did not run its steps"; exit 1; }
+grep -q "VERIFY-OK" "$LOG" || { echo "FAIL: verify job (needs: build) did not run"; exit 1; }
+
+echo "PASS: chant-generated Forgejo workflow built and executed in Docker"

--- a/test/forgejo-runtime-e2e/README.md
+++ b/test/forgejo-runtime-e2e/README.md
@@ -1,0 +1,28 @@
+# Forgejo runtime E2E
+
+Proves a Forgejo runner actually **accepts and executes** chant's generated
+`.forgejo/workflows/ci.yml` — not just that the YAML is well-formed (the
+post-synth WFJ checks already cover that) or that the package installs (the
+smoke tests cover that).
+
+`src/pipeline.ts` is a minimal, dependency-free workflow (only `run:` shell
+steps — no `uses:`, whose resolution is unit-tested; `runs-on: ubuntu-latest`,
+which the dialect maps to the Forgejo `docker` label; two jobs with a `needs:`
+edge). `build.ts` builds it to a real `.forgejo/workflows/ci.yml`;
+`../forgejo-runtime-e2e.sh` then runs that workflow in Docker and asserts both
+jobs run, in order (the `BUILD-OK` and `VERIFY-OK` markers).
+
+Forgejo Actions run on the same engine as [`act`](https://github.com/nektos/act);
+Forgejo's own runner is `forgejo-runner` / `act_runner`, whose `exec` subcommand
+runs a workflow locally without a server. The script uses whichever of
+`forgejo-runner`, `act_runner`, or `act` is on PATH.
+
+## Run
+
+```bash
+just forgejo-runtime-e2e        # or: bash test/forgejo-runtime-e2e.sh
+```
+
+On-demand only. It needs Docker + a runner tool, so it is **not** part of the
+gating CI; it cleanly skips (exit 0) when neither is available. Override the
+image the `docker` label maps to with `FORGEJO_E2E_IMAGE`.

--- a/test/forgejo-runtime-e2e/build.ts
+++ b/test/forgejo-runtime-e2e/build.ts
@@ -1,0 +1,43 @@
+/**
+ * Build the runtime-E2E fixture workflow (./src) and write the generated
+ * `.forgejo/workflows/ci.yml` into the output directory passed as argv[2].
+ *
+ * Kept out of ./src so discovery doesn't import this driver. Run by
+ * test/forgejo-runtime-e2e.sh before handing the workflow to a Forgejo runner.
+ */
+
+import { build } from "@intentius/chant/build";
+import { getPrimaryOutput } from "@intentius/chant/lint/post-synth";
+import { forgejoSerializer } from "@intentius/chant-lexicon-forgejo/serializer";
+import { mkdirSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = process.argv[2];
+if (!outDir) {
+  console.error("usage: tsx build.ts <output-dir>");
+  process.exit(2);
+}
+
+const result = await build(join(here, "src"), [forgejoSerializer]);
+if (result.errors.length > 0) {
+  console.error("build failed:");
+  for (const e of result.errors) console.error("  " + (e.message ?? String(e)));
+  process.exit(1);
+}
+
+// The forgejo serializer is registered under the "github" lexicon (it
+// serializes the reused github entities).
+const out = result.outputs.get("github");
+const yaml = out ? getPrimaryOutput(out) : "";
+if (!yaml) {
+  console.error("no Forgejo workflow produced");
+  process.exit(1);
+}
+
+const dir = join(outDir, ".forgejo", "workflows");
+mkdirSync(dir, { recursive: true });
+const dest = join(dir, "ci.yml");
+writeFileSync(dest, yaml);
+console.log(`wrote ${dest}`);

--- a/test/forgejo-runtime-e2e/src/pipeline.ts
+++ b/test/forgejo-runtime-e2e/src/pipeline.ts
@@ -1,0 +1,31 @@
+/**
+ * Self-contained Forgejo workflow used by the runtime E2E
+ * (test/forgejo-runtime-e2e.sh).
+ *
+ * Deliberately minimal and dependency-free — only `run:` shell steps, no
+ * `uses:` (action resolution is unit-tested) — so a Forgejo runner can execute
+ * it without network. It exercises the parts a runtime check should prove work
+ * end to end: the `runs-on` label the dialect maps to (`ubuntu-latest` →
+ * `docker`), step ordering within a job, and `needs:` ordering across jobs.
+ */
+
+import { Workflow, Job, Step } from "@intentius/chant-lexicon-forgejo";
+
+export const workflow = new Workflow({
+  name: "ci",
+  on: { push: { branches: ["main"] } },
+});
+
+export const build = new Job({
+  "runs-on": "ubuntu-latest",
+  steps: [
+    new Step({ name: "write", run: 'echo "built by chant" > out.txt' }),
+    new Step({ name: "check", run: 'grep -q "built by chant" out.txt && echo "BUILD-OK"' }),
+  ],
+});
+
+export const verify = new Job({
+  "runs-on": "ubuntu-latest",
+  needs: ["build"],
+  steps: [new Step({ name: "verify", run: 'echo "VERIFY-OK ran after build"' })],
+});


### PR DESCRIPTION
Closes #347. Closes the two validation/docs gaps left after the Forgejo epic (#338).

## 1. Runtime E2E

On-demand, not gating CI — mirrors `just gitlab-runtime-e2e`.

- **`test/forgejo-runtime-e2e/`** — a chant workflow fixture (`runs-on: ubuntu-latest` → mapped to `docker`, two jobs with a `needs:` edge, pure `run:` steps so no external action fetch) built to `.forgejo/workflows/ci.yml` via the forgejo serializer.
- **`test/forgejo-runtime-e2e.sh`** — runs the generated workflow in Docker via a Forgejo runner (`forgejo-runner` / `act_runner` / `act` `exec` — same engine Forgejo runs on), asserting both jobs run in order (`BUILD-OK` + `VERIFY-OK`, which proves the dialect's `docker` runner label, step ordering, and the `needs:` edge all execute). Skips cleanly (exit 0) when Docker or a runner tool is absent.
- **`just forgejo-runtime-e2e`** recipe + fixture README.

Validated here: the build half produces correct YAML (`runs-on: docker`, the `needs:` edge, both markers), and the script skips cleanly with no runner installed. The execution half runs with Docker + a runner (the sandbox has no registry network to pull one) — same on-demand posture as the gitlab E2E.

## 2. Dedicated docs page

- **`docs/.../lexicons/forgejo.mdx`** — a reference page at `/chant/lexicons/forgejo/`: authoring, the dialect (dropped keys / runner labels / `uses:` resolution), build, github→forgejo migration + `forgejo:compare` security-fate, the `forgejo:*` context tools, lint checks, runtime observation N/A, and the runtime-E2E pointer. (A single main-site page — a full codegen'd docs site is overkill for a thin dialect.)
- Sidebar entry added; `lexicons/overview` and the whats-new Forgejo rows now link to the page instead of the README/anchor placeholders.

Verified the main docs site **builds** locally and the page generates at `dist/lexicons/forgejo/index.html`; CI `link-check` validates the links.

## Acceptance

- [x] `bash test/forgejo-runtime-e2e.sh` builds the fixture and (with Docker + a runner) runs the generated workflow, asserting success; skips cleanly without them.
- [x] `just forgejo-runtime-e2e` recipe + fixture README.
- [x] `/chant/lexicons/forgejo/` page exists and the docs site builds.
- [x] Linked from `lexicons/overview.mdx` and the whats-new rows.

## Note

`CLAUDE.md` is gitignored in this repo (untracked), so the runtime-E2E note there is local-only — consistent with the existing GitLab runtime-E2E note. The `just` recipe + fixture README cover in-repo discoverability.