### PR TITLE
ci(publish): publish @intentius/chant-lexicon-forgejo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,6 +87,13 @@ jobs:
           P=$(npm view @intentius/chant-lexicon-github version 2>/dev/null || echo "none")
           [ "$V" = "$P" ] && echo "Already at $V, skipping" || npm publish --access public --provenance
 
+      - name: Publish @intentius/chant-lexicon-forgejo
+        working-directory: lexicons/forgejo
+        run: |
+          V=$(node -e "process.stdout.write(require('./package.json').version)")
+          P=$(npm view @intentius/chant-lexicon-forgejo version 2>/dev/null || echo "none")
+          [ "$V" = "$P" ] && echo "Already at $V, skipping" || npm publish --access public --provenance
+
       - name: Publish @intentius/chant-lexicon-k8s
         working-directory: lexicons/k8s
         run: |


### PR DESCRIPTION
`publish.yml` enumerates packages explicitly, and the new **forgejo** lexicon was never added — so `chant-v0.4.0` published core + the 9 existing lexicons to npm but **not** `@intentius/chant-lexicon-forgejo` (it 404s on npm). The run went green because it published everything in its list.

Adds the forgejo publish step (same pattern as the others). No `test`-job prepack line — forgejo has no codegen and ships `src/` directly (its main export is `src/index.ts`, like every other lexicon); a prepack would error on a missing script. `npx vitest run` already covers forgejo's tests.

After merge I'll re-run `publish.yml` via `workflow_dispatch`: the version-guarded steps skip the already-published 0.4.0 packages and publish forgejo@0.4.0.