### PR TITLE
feat(audit): core audit library (#354)

### DIFF
--- a/packages/core/src/audit/core.test.ts
+++ b/packages/core/src/audit/core.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect } from "vitest";
+import { auditFiles, type AuditInput } from "./core";
+import type { PostSynthCheck } from "../lint/post-synth";
+
+const DIRTY_GH = `name: CI
+on:
+  push:
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: acme/deploy-action@v1
+      - run: npm ci
+`;
+
+const CLEAN_GH = `name: CI
+on:
+  push:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - run: npm ci
+`;
+
+const DIRTY_GL = `variables:
+  DB_PASSWORD: "s3cr3t-hunter2-password-value"
+build:
+  stage: build
+  script:
+    - echo hi
+`;
+
+const DIRTY_FJ = `name: CI
+on:
+  push:
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo hi
+`;
+
+describe("auditFiles", () => {
+  test("flags unpinned action and write-all permissions in a github workflow", async () => {
+    const inputs: AuditInput[] = [
+      { path: ".github/workflows/ci.yml", content: DIRTY_GH, lexicon: "github" },
+    ];
+    const findings = await auditFiles(inputs);
+    const ids = new Set(findings.map((f) => f.checkId));
+
+    expect(ids).toContain("GHA033"); // write-all permissions
+    expect(ids).toContain("GHA021"); // unpinned actions/checkout
+    expect(ids).toContain("GHA029"); // unpinned action reference
+    // Findings are tagged to the source file.
+    expect(findings.every((f) => f.file === ".github/workflows/ci.yml")).toBe(true);
+  });
+
+  test("a hardened github workflow has no permission/pinning security findings", async () => {
+    const findings = await auditFiles([
+      { path: ".github/workflows/ci.yml", content: CLEAN_GH, lexicon: "github" },
+    ]);
+    const ids = new Set(findings.map((f) => f.checkId));
+    expect(ids.has("GHA033")).toBe(false);
+    expect(ids.has("GHA021")).toBe(false);
+    expect(ids.has("GHA029")).toBe(false);
+  });
+
+  test("flags a hardcoded secret in a gitlab pipeline", async () => {
+    const findings = await auditFiles([
+      { path: ".gitlab-ci.yml", content: DIRTY_GL, lexicon: "gitlab" },
+    ]);
+    const ids = new Set(findings.map((f) => f.checkId));
+    expect(ids).toContain("WGL016");
+  });
+
+  test("runs github-tier security checks on forgejo (github-dialect) workflows", async () => {
+    const findings = await auditFiles([
+      { path: ".forgejo/workflows/ci.yml", content: DIRTY_FJ, lexicon: "forgejo" },
+    ]);
+    const ids = new Set(findings.map((f) => f.checkId));
+    // Forgejo workflows are GitHub-syntax, so the GHA security tier applies.
+    expect(ids).toContain("GHA033");
+    expect(ids).toContain("GHA021");
+  });
+
+  test("uses an injected checks provider and tags findings per file", async () => {
+    const fake: PostSynthCheck = {
+      id: "FAKE001",
+      description: "fake",
+      check: () => [{ checkId: "FAKE001", severity: "warning", message: "hit" }],
+    };
+    const findings = await auditFiles(
+      [
+        { path: "a.yml", content: "x", lexicon: "github" },
+        { path: "b.yml", content: "y", lexicon: "github" },
+      ],
+      { checksProvider: async () => [fake] },
+    );
+    expect(findings.map((f) => f.file).sort()).toEqual(["a.yml", "b.yml"]);
+  });
+
+  test("a check that throws does not abort the audit", async () => {
+    const boom: PostSynthCheck = {
+      id: "BOOM",
+      description: "throws",
+      check: () => {
+        throw new Error("bad yaml");
+      },
+    };
+    const ok: PostSynthCheck = {
+      id: "OK001",
+      description: "ok",
+      check: () => [{ checkId: "OK001", severity: "info", message: "ok" }],
+    };
+    const findings = await auditFiles([{ path: "a.yml", content: "x", lexicon: "github" }], {
+      checksProvider: async () => [boom, ok],
+    });
+    expect(findings.map((f) => f.checkId)).toEqual(["OK001"]);
+  });
+});

--- a/packages/core/src/audit/core.ts
+++ b/packages/core/src/audit/core.ts
@@ -1,0 +1,156 @@
+/**
+ * Audit core — run chant's CI security checks against arbitrary repo YAML.
+ *
+ * The post-synth security checks (`lexicons/<lex>/src/lint/post-synth/*.ts`)
+ * read the emitted workflow YAML from `ctx.outputs`, not the chant model
+ * (`ctx.entities`). So an auditor can feed *existing* repo YAML straight in as
+ * a synthetic output and run the real rules — no import-to-chant-model step.
+ *
+ * Each file is audited as its own `primary` output so single-document security
+ * checks (the merge-worthy tier: permissions, pinning, injection, secrets)
+ * fire on every workflow. Cross-file checks (e.g. duplicate workflow names)
+ * only see one file at a time here; that is acceptable because the security
+ * tier is per-document.
+ *
+ * Checks that read `ctx.entities` instead of `ctx.outputs` will not fire on
+ * audited YAML — the security tier is YAML-based, so this is by design.
+ */
+
+import type { Severity } from "../lint/rule";
+import type { PostSynthCheck, PostSynthContext } from "../lint/post-synth";
+import type { SerializerResult } from "../serializer";
+import { loadPlugins } from "../cli/plugins";
+
+/** Lexicons whose post-synth checks the auditor knows how to run. */
+export type AuditLexicon = "github" | "gitlab" | "forgejo";
+
+/** A single CI file to audit. */
+export interface AuditInput {
+  /** Path used to tag findings (e.g. ".github/workflows/ci.yml"). */
+  path: string;
+  /** Raw YAML content of the file. */
+  content: string;
+  /** Which lexicon's checks to run against it. */
+  lexicon: AuditLexicon;
+}
+
+/** A finding produced by a post-synth check against an audited file. */
+export interface AuditFinding {
+  checkId: string;
+  severity: Severity;
+  message: string;
+  /** The audited file this finding came from. */
+  file: string;
+  /** The lexicon that produced the finding. */
+  lexicon: string;
+  /** Optional entity (e.g. job name) the check attached. */
+  entity?: string;
+}
+
+/**
+ * Resolve the post-synth checks for a lexicon. Injectable so the core can be
+ * unit-tested without loading real lexicon packages.
+ */
+export type ChecksProvider = (lexicon: AuditLexicon) => Promise<PostSynthCheck[]>;
+
+const checksCache = new Map<AuditLexicon, PostSynthCheck[]>();
+
+function dedupeById(checks: PostSynthCheck[]): PostSynthCheck[] {
+  const byId = new Map<string, PostSynthCheck>();
+  for (const check of checks) {
+    if (!byId.has(check.id)) byId.set(check.id, check);
+  }
+  return [...byId.values()];
+}
+
+/**
+ * Default provider: load the lexicon plugin(s) and return their post-synth
+ * checks. Forgejo workflows are GitHub-dialect YAML, so the GitHub security
+ * tier is run against them in addition to Forgejo's own checks.
+ */
+async function defaultChecksProvider(lexicon: AuditLexicon): Promise<PostSynthCheck[]> {
+  const cached = checksCache.get(lexicon);
+  if (cached) return cached;
+
+  let checks: PostSynthCheck[];
+  if (lexicon === "forgejo") {
+    const [forgejo, github] = await loadPlugins(["forgejo", "github"]);
+    checks = dedupeById([
+      ...(forgejo?.postSynthChecks?.() ?? []),
+      ...(github?.postSynthChecks?.() ?? []),
+    ]);
+  } else {
+    const [plugin] = await loadPlugins([lexicon]);
+    checks = plugin?.postSynthChecks?.() ?? [];
+  }
+
+  checksCache.set(lexicon, checks);
+  return checks;
+}
+
+/**
+ * Audit a set of CI files and return all findings. Pure with respect to the
+ * filesystem and network — callers supply file contents.
+ */
+export async function auditFiles(
+  inputs: AuditInput[],
+  opts: { checksProvider?: ChecksProvider } = {},
+): Promise<AuditFinding[]> {
+  const provider = opts.checksProvider ?? defaultChecksProvider;
+  const findings: AuditFinding[] = [];
+
+  // Group by lexicon so each plugin's checks are resolved once.
+  const byLexicon = new Map<AuditLexicon, AuditInput[]>();
+  for (const input of inputs) {
+    const list = byLexicon.get(input.lexicon) ?? [];
+    list.push(input);
+    byLexicon.set(input.lexicon, list);
+  }
+
+  for (const [lexicon, files] of byLexicon) {
+    const checks = await provider(lexicon);
+    if (checks.length === 0) continue;
+
+    for (const file of files) {
+      const output: SerializerResult = {
+        primary: file.content,
+        files: { [file.path]: file.content },
+      };
+      const buildResult: PostSynthContext["buildResult"] = {
+        outputs: new Map<string, string | SerializerResult>([[lexicon, output]]),
+        entities: new Map(),
+        warnings: [],
+        errors: [],
+        sourceFileCount: 1,
+      };
+      const ctx: PostSynthContext = {
+        outputs: buildResult.outputs,
+        entities: buildResult.entities,
+        buildResult,
+      };
+
+      for (const check of checks) {
+        let diags;
+        try {
+          diags = check.check(ctx);
+        } catch {
+          // A check that throws on unusual external YAML must not abort the
+          // whole audit. Skip it and keep going.
+          continue;
+        }
+        for (const d of diags) {
+          findings.push({
+            checkId: d.checkId,
+            severity: d.severity,
+            message: d.message,
+            file: file.path,
+            lexicon: d.lexicon ?? lexicon,
+            entity: d.entity,
+          });
+        }
+      }
+    }
+  }
+
+  return findings;
+}


### PR DESCRIPTION
Part of #350. Closes #354.

Adds `packages/core/src/audit/core.ts` — `auditFiles(inputs)` runs the real lexicon post-synth security checks against arbitrary repo YAML.

## Approach
- Builds a synthetic `PostSynthContext` per file (file as its own `primary` output), so single-document security checks fire on every workflow. No import-to-chant-model step — checks read `ctx.outputs`.
- Default checks provider loads lexicon plugins via the existing `loadPlugins` (no new static dep, no core→lexicon cycle). Provider is injectable for unit tests.
- **Forgejo** workflows are GitHub-dialect YAML, so the audit runs the GitHub security tier on them in addition to Forgejo's own WFJ checks.
- Per-check `try/catch` so one malformed external file can't abort the audit.

## Known limitation (documented in code)
Cross-file checks (e.g. GHA006 duplicate workflow names) only see one file at a time; the merge-worthy security tier is per-document, so this is by design.

## Tests
6 tests, exercising the **real** plugins through the default provider:
- github dirty fixture → GHA033 (write-all), GHA021 (unpinned checkout), GHA029 (unpinned third-party)
- hardened github fixture → none of those fire
- gitlab dirty fixture → WGL016 (hardcoded secret)
- forgejo fixture → GHA033/GHA021 (github tier on github-dialect)
- injected provider tags findings per file; a throwing check doesn't abort

`just build`, `eslint`, and the new tests are green locally.