### PR TITLE
feat(audit): chant audit CLI command (#353)

### DIFF
--- a/packages/core/src/cli/commands/__fixtures__/audit-repo/.github/workflows/ci.yml
+++ b/packages/core/src/cli/commands/__fixtures__/audit-repo/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: CI
+on:
+  push:
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: acme/deploy-action@v1
+      - run: npm ci

--- a/packages/core/src/cli/commands/audit.test.ts
+++ b/packages/core/src/cli/commands/audit.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from "vitest";
+import { fileURLToPath } from "url";
+import { auditCommand, discoverCiFiles } from "./audit";
+
+const REPO = fileURLToPath(new URL("./__fixtures__/audit-repo", import.meta.url));
+
+describe("auditCommand", () => {
+  test("discovers CI files under a repo root", () => {
+    const files = discoverCiFiles(REPO);
+    expect(files.map((f) => f.path)).toContain(".github/workflows/ci.yml");
+    expect(files.every((f) => f.lexicon === "github")).toBe(true);
+  });
+
+  test("reports merge-worthy findings on the fixture repo", async () => {
+    const result = await auditCommand({ path: REPO, format: "stylish" });
+    expect(result.success).toBe(true);
+    const ids = new Set(result.findings.map((f) => f.checkId));
+    expect(ids).toContain("GHA033");
+    expect(ids).toContain("GHA021");
+    expect(result.output).toContain("Merge-worthy:");
+  });
+
+  test("--json emits parseable findings", async () => {
+    const result = await auditCommand({ path: REPO, format: "json" });
+    const parsed = JSON.parse(result.output);
+    expect(Array.isArray(parsed.findings)).toBe(true);
+    expect(parsed.scanned).toContain(".github/workflows/ci.yml");
+  });
+
+  test("--fail-on merge-worthy exits nonzero when merge-worthy findings exist", async () => {
+    const fail = await auditCommand({ path: REPO, failOn: "merge-worthy" });
+    expect(fail.exitCode).toBe(1);
+    const none = await auditCommand({ path: REPO, failOn: "none" });
+    expect(none.exitCode).toBe(0);
+  });
+
+  test("--tier merge-worthy filters out report-only findings", async () => {
+    const all = await auditCommand({ path: REPO, tier: "all" });
+    const mw = await auditCommand({ path: REPO, tier: "merge-worthy" });
+    expect(mw.findings.length).toBeLessThanOrEqual(all.findings.length);
+    expect(mw.findings.some((f) => f.checkId === "GHA022")).toBe(false); // report-only
+  });
+
+  test("a path with no CI files succeeds with a clear message", async () => {
+    const tmp = fileURLToPath(new URL(".", import.meta.url)); // commands dir, no CI files
+    const result = await auditCommand({ path: tmp });
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("No CI files found");
+  });
+
+  test("sarif output is valid JSON with results", async () => {
+    const result = await auditCommand({ path: REPO, format: "sarif" });
+    const sarif = JSON.parse(result.output);
+    expect(sarif.version).toBe("2.1.0");
+    expect(sarif.runs[0].results.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/cli/commands/audit.ts
+++ b/packages/core/src/cli/commands/audit.ts
@@ -1,0 +1,179 @@
+/**
+ * `chant audit` — run chant's CI security checks against an existing repo's
+ * pipeline YAML and emit a tiered report. Does not require a chant project;
+ * it reads `.github/workflows`, `.gitlab-ci.yml`, and `.forgejo/workflows`
+ * directly and runs the real post-synth checks via the audit core.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { join, relative } from "path";
+import { auditFiles, type AuditInput, type AuditFinding, type AuditLexicon } from "../../audit/core";
+import { RULE_CATALOG } from "../../audit/catalog";
+import { renderMarkdown } from "../../audit/report";
+import type { Severity } from "../../lint/rule";
+
+export type AuditFormat = "stylish" | "json" | "sarif" | "markdown";
+export type AuditTier = "merge-worthy" | "all";
+export type AuditFailOn = "merge-worthy" | "warning" | "none";
+
+export interface AuditCommandOptions {
+  /** Repo root (or any dir) to scan. */
+  path: string;
+  format?: AuditFormat;
+  /** Restrict findings to a tier (default "all"). */
+  tier?: AuditTier;
+  /** Exit-code policy (default "none" — read-only friendly). */
+  failOn?: AuditFailOn;
+}
+
+export interface AuditCommandResult {
+  success: boolean;
+  /** Rendered report in the requested format. */
+  output: string;
+  findings: AuditFinding[];
+  /** Files that were scanned (relative to the root). */
+  scanned: string[];
+  exitCode: number;
+  error?: string;
+}
+
+function isYaml(name: string): boolean {
+  return name.endsWith(".yml") || name.endsWith(".yaml");
+}
+
+function collectDir(root: string, dir: string, lexicon: AuditLexicon, out: AuditInput[]): void {
+  const abs = join(root, dir);
+  if (!existsSync(abs) || !statSync(abs).isDirectory()) return;
+  for (const name of readdirSync(abs).sort()) {
+    if (!isYaml(name)) continue;
+    const full = join(abs, name);
+    if (!statSync(full).isFile()) continue;
+    out.push({ path: relative(root, full), content: readFileSync(full, "utf-8"), lexicon });
+  }
+}
+
+/** Discover CI files under a repo root. */
+export function discoverCiFiles(root: string): AuditInput[] {
+  const inputs: AuditInput[] = [];
+  collectDir(root, ".github/workflows", "github", inputs);
+  collectDir(root, ".forgejo/workflows", "forgejo", inputs);
+  const gitlab = join(root, ".gitlab-ci.yml");
+  if (existsSync(gitlab) && statSync(gitlab).isFile()) {
+    inputs.push({ path: ".gitlab-ci.yml", content: readFileSync(gitlab, "utf-8"), lexicon: "gitlab" });
+  }
+  return inputs;
+}
+
+function isMergeWorthy(f: AuditFinding): boolean {
+  return RULE_CATALOG[f.checkId]?.tier === "merge-worthy";
+}
+
+function exitCodeFor(findings: AuditFinding[], failOn: AuditFailOn): number {
+  if (failOn === "merge-worthy") return findings.some(isMergeWorthy) ? 1 : 0;
+  if (failOn === "warning") {
+    return findings.some((f) => f.severity === "error" || f.severity === "warning") ? 1 : 0;
+  }
+  return 0;
+}
+
+function sarifLevel(sev: Severity): string {
+  return sev === "error" ? "error" : sev === "warning" ? "warning" : "note";
+}
+
+function renderStylish(findings: AuditFinding[], scanned: string[]): string {
+  const lines: string[] = [];
+  const mw = findings.filter(isMergeWorthy);
+  const ro = findings.filter((f) => !isMergeWorthy(f));
+  lines.push(
+    `Audited ${scanned.length} CI file${scanned.length === 1 ? "" : "s"} — ` +
+      `${findings.length} finding${findings.length === 1 ? "" : "s"} ` +
+      `(${mw.length} merge-worthy, ${ro.length} report-only).`,
+  );
+  const section = (title: string, list: AuditFinding[]) => {
+    if (list.length === 0) return;
+    lines.push("", title);
+    for (const f of list) {
+      const where = f.entity ? `${f.file} (${f.entity})` : f.file;
+      const title = RULE_CATALOG[f.checkId]?.title ?? f.checkId;
+      lines.push(`  [${f.checkId}] ${f.severity}  ${where}  — ${title}`);
+    }
+  };
+  section("Merge-worthy:", mw);
+  section("Report-only:", ro);
+  return lines.join("\n");
+}
+
+function renderSarif(findings: AuditFinding[]): string {
+  const ruleIds = [...new Set(findings.map((f) => f.checkId))].sort();
+  const rules = ruleIds.map((id) => {
+    const m = RULE_CATALOG[id];
+    return {
+      id,
+      name: m?.title ?? id,
+      shortDescription: { text: m?.title ?? id },
+      helpUri: m?.authority?.[0]?.url,
+    };
+  });
+  const results = findings.map((f) => ({
+    ruleId: f.checkId,
+    level: sarifLevel(f.severity),
+    message: { text: f.message },
+    locations: [{ physicalLocation: { artifactLocation: { uri: f.file } } }],
+  }));
+  return JSON.stringify(
+    {
+      $schema: "https://json.schemastore.org/sarif-2.1.0.json",
+      version: "2.1.0",
+      runs: [{ tool: { driver: { name: "chant-audit", informationUri: "https://intentius.io/chant/", rules } }, results }],
+    },
+    null,
+    2,
+  );
+}
+
+/** Run the audit and produce a rendered result. */
+export async function auditCommand(options: AuditCommandOptions): Promise<AuditCommandResult> {
+  const format = options.format ?? "stylish";
+  const tier = options.tier ?? "all";
+  const failOn = options.failOn ?? "none";
+
+  if (!existsSync(options.path)) {
+    return { success: false, output: "", findings: [], scanned: [], exitCode: 1, error: `Path not found: ${options.path}` };
+  }
+
+  const inputs = discoverCiFiles(options.path);
+  const scanned = inputs.map((i) => i.path);
+
+  if (inputs.length === 0) {
+    return { success: true, output: `No CI files found under ${options.path}.`, findings: [], scanned: [], exitCode: 0 };
+  }
+
+  let findings = await auditFiles(inputs);
+  if (tier === "merge-worthy") findings = findings.filter(isMergeWorthy);
+
+  let output: string;
+  switch (format) {
+    case "json":
+      output = JSON.stringify({ scanned, findings }, null, 2);
+      break;
+    case "sarif":
+      output = renderSarif(findings);
+      break;
+    case "markdown":
+      output = renderMarkdown(findings, { target: options.path });
+      break;
+    default:
+      output = renderStylish(findings, scanned);
+  }
+
+  return { success: true, output, findings, scanned, exitCode: exitCodeFor(findings, failOn) };
+}
+
+/** Print an audit result to stdout. */
+export function printAuditResult(result: AuditCommandResult): void {
+  if (!result.success) {
+    console.error(result.error ?? "Audit failed");
+    return;
+  }
+  console.log(result.output);
+}

--- a/packages/core/src/cli/handlers/misc.ts
+++ b/packages/core/src/cli/handlers/misc.ts
@@ -1,9 +1,38 @@
 import { listCommand, printListResult } from "../commands/list";
 import { describeCommand, printDescribeResult } from "../commands/describe";
 import { importCommand, importFromLive, printImportResult } from "../commands/import";
+import { auditCommand, printAuditResult, type AuditFormat, type AuditTier, type AuditFailOn } from "../commands/audit";
 import type { ResourceSelector } from "../../lexicon";
 import { formatError, formatSuccess, formatWarning } from "../format";
 import type { CommandContext } from "../registry";
+
+const AUDIT_FORMATS: AuditFormat[] = ["stylish", "json", "sarif", "markdown"];
+const AUDIT_TIERS: AuditTier[] = ["merge-worthy", "all"];
+const AUDIT_FAIL_ON: AuditFailOn[] = ["merge-worthy", "warning", "none"];
+
+export async function runAudit(ctx: CommandContext): Promise<number> {
+  const { args } = ctx;
+
+  const format: AuditFormat = args.json ? "json" : ((args.format || "stylish") as AuditFormat);
+  if (!AUDIT_FORMATS.includes(format)) {
+    console.error(formatError({ message: `Invalid --format: ${format}. Expected one of ${AUDIT_FORMATS.join(", ")}.` }));
+    return 1;
+  }
+  const tier = (args.tier ?? "all") as AuditTier;
+  if (!AUDIT_TIERS.includes(tier)) {
+    console.error(formatError({ message: `Invalid --tier: ${tier}. Expected one of ${AUDIT_TIERS.join(", ")}.` }));
+    return 1;
+  }
+  const failOn = (args.failOn ?? "none") as AuditFailOn;
+  if (!AUDIT_FAIL_ON.includes(failOn)) {
+    console.error(formatError({ message: `Invalid --fail-on: ${failOn}. Expected one of ${AUDIT_FAIL_ON.join(", ")}.` }));
+    return 1;
+  }
+
+  const result = await auditCommand({ path: args.path, format, tier, failOn });
+  printAuditResult(result);
+  return result.exitCode;
+}
 
 export async function runList(ctx: CommandContext): Promise<number> {
   const { args } = ctx;

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -11,7 +11,7 @@ import { runLint } from "./handlers/lint";
 import { runDevGenerate, runDevPublish, runDevOnboard, runDevCheckLexicon, runDevUnknown } from "./handlers/dev";
 import { runServeLsp, runServeMcp, runServeUnknown } from "./handlers/serve";
 import { runInit, runInitLexicon } from "./handlers/init";
-import { runList, runDescribe, runImport, runUpdate, runDoctor } from "./handlers/misc";
+import { runList, runDescribe, runImport, runAudit, runUpdate, runDoctor } from "./handlers/misc";
 import { runVendor } from "./handlers/vendor";
 import { runMigrate } from "./handlers/migrate";
 import { runLifecycleSnapshot, runLifecycleShow, runLifecycleDiff, runLifecyclePlan, runLifecycleAffected, runLifecycleLog, runLifecycleUnknown } from "./handlers/lifecycle";
@@ -118,6 +118,10 @@ export function parseArgs(args: string[]): ParsedArgs {
       result.src = args[++i];
     } else if (arg === "--env") {
       result.env = args[++i];
+    } else if (arg === "--tier") {
+      result.tier = args[++i];
+    } else if (arg === "--fail-on") {
+      result.failOn = args[++i];
     } else if (arg === "--stacks") {
       result.stacks = true;
     } else if (arg === "--base") {
@@ -169,6 +173,9 @@ Commands:
   describe              Show the effective config for one component
   vendor                Pull pinned, checksummed patterns into your repo
   import                Import external template into TypeScript
+  audit [path]          Audit a repo's CI YAML for security issues
+                        (--format stylish|json|sarif|markdown,
+                         --tier merge-worthy|all, --fail-on merge-worthy|warning|none)
   migrate <file>        Translate a workflow between lexicons
                         (default: --from github --to gitlab)
 
@@ -287,6 +294,7 @@ const registry: CommandDef[] = [
   { name: "list", handler: runList },
   { name: "describe", handler: runDescribe },
   { name: "import", handler: runImport },
+  { name: "audit", handler: runAudit },
   { name: "migrate", handler: runMigrate },
   { name: "init", handler: runInit },
   { name: "init lexicon", handler: runInitLexicon },

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -63,6 +63,10 @@ export interface ParsedArgs {
   head?: string;
   /** `chant lifecycle affected --include-dependents` — add downstream consumers */
   includeDependents?: boolean;
+  /** `chant audit --tier merge-worthy|all` */
+  tier?: string;
+  /** `chant audit --fail-on merge-worthy|warning|none` */
+  failOn?: string;
 }
 
 /**


### PR DESCRIPTION
Part of #350. Closes #353.

Adds `chant audit [path]` — scans an existing repo's CI YAML and prints a tiered report. No chant project required.

## Behaviour
- Discovers `.github/workflows/*.{yml,yaml}`, `.gitlab-ci.yml`, `.forgejo/workflows/*.{yml,yaml}`; runs the audit core; joins findings with the catalog.
- Formats: `stylish` (default), `json`, `sarif`, `markdown` (`--format`/`-f`; `--json` shortcut).
- `--tier merge-worthy|all` (default all); `--fail-on merge-worthy|warning|none` (default `none`).
- Not `requiresPlugins`: loads the CI lexicons itself, so it audits an external dir without a chant config.

## Verified
Real CLI run on the fixture prints:
```
Audited 1 CI file — 4 findings (3 merge-worthy, 1 report-only).
Merge-worthy:
  [GHA021] warning  .github/workflows/ci.yml (build)  — actions/checkout not pinned to a SHA
  [GHA029] warning  ...
  [GHA033] warning  ...
Report-only:
  [GHA022] info  ...
```

7 new tests; `just build`, `eslint`, and the existing 196 CLI/command tests pass locally.