### PR TITLE
feat(audit): remote fetch — audit a git URL (#355)

### DIFF
--- a/packages/core/src/audit/fetch.test.ts
+++ b/packages/core/src/audit/fetch.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect } from "vitest";
+import { fetchCiFiles, parseRepoUrl, FetchError } from "./fetch";
+
+const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64");
+const CI_YAML = "name: CI\non:\n  push:\npermissions: write-all\njobs:\n  build:\n    runs-on: ubuntu-latest\n";
+
+interface Route {
+  match: string;
+  make: () => Response;
+}
+
+function fakeFetch(routes: Route[]) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    for (const r of routes) {
+      if (String(url).includes(r.match)) return r.make();
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+const githubRoutes = (size = 100): Route[] => [
+  {
+    match: "/contents/.github/workflows/ci.yml",
+    make: () => new Response(JSON.stringify({ name: "ci.yml", path: ".github/workflows/ci.yml", type: "file", content: b64(CI_YAML), encoding: "base64" }), { status: 200 }),
+  },
+  {
+    match: "/contents/.github/workflows",
+    make: () => new Response(JSON.stringify([{ name: "ci.yml", path: ".github/workflows/ci.yml", type: "file", size }]), { status: 200 }),
+  },
+];
+
+describe("parseRepoUrl", () => {
+  test("rejects non-https", () => {
+    expect(() => parseRepoUrl("http://github.com/o/r")).toThrow(FetchError);
+  });
+  test("rejects non-allowlisted host", () => {
+    expect(() => parseRepoUrl("https://evil.example.com/o/r")).toThrow(/Host not allowed/);
+  });
+  test("parses owner/repo and strips .git", () => {
+    const p = parseRepoUrl("https://github.com/acme/widgets.git");
+    expect(p.owner).toBe("acme");
+    expect(p.repo).toBe("widgets");
+    expect(p.host.kind).toBe("github");
+  });
+});
+
+describe("fetchCiFiles", () => {
+  test("fetches and decodes github workflow files", async () => {
+    const { impl } = fakeFetch(githubRoutes());
+    const files = await fetchCiFiles("https://github.com/acme/widgets", { fetchImpl: impl });
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe(".github/workflows/ci.yml");
+    expect(files[0].lexicon).toBe("github");
+    expect(files[0].content).toContain("permissions: write-all");
+  });
+
+  test("sends an auth token when provided", async () => {
+    const { impl, calls } = fakeFetch(githubRoutes());
+    await fetchCiFiles("https://github.com/acme/widgets", { fetchImpl: impl, token: "secret" });
+    const auth = calls.map((c) => (c.init?.headers as Record<string, string>)?.Authorization);
+    expect(auth).toContain("Bearer secret");
+  });
+
+  test("skips a file over the per-file size cap", async () => {
+    const { impl } = fakeFetch(githubRoutes(10_000_000));
+    const files = await fetchCiFiles("https://github.com/acme/widgets", { fetchImpl: impl, maxBytesPerFile: 1024 });
+    expect(files).toHaveLength(0);
+  });
+
+  test("refuses to follow a redirect", async () => {
+    const { impl } = fakeFetch([{ match: "/contents/", make: () => new Response(null, { status: 302 }) }]);
+    await expect(fetchCiFiles("https://github.com/acme/widgets", { fetchImpl: impl })).rejects.toThrow(/redirect/i);
+  });
+
+  test("throws on a non-allowlisted host before any fetch", async () => {
+    await expect(fetchCiFiles("https://evil.example.com/o/r")).rejects.toThrow(/Host not allowed/);
+  });
+
+  test("returns the gitlab pipeline file", async () => {
+    const { impl } = fakeFetch([
+      { match: "/repository/files/", make: () => new Response("stages:\n  - build\n", { status: 200 }) },
+    ]);
+    const files = await fetchCiFiles("https://gitlab.com/acme/widgets", { fetchImpl: impl });
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe(".gitlab-ci.yml");
+    expect(files[0].lexicon).toBe("gitlab");
+  });
+
+  test("forgejo (codeberg) reads .forgejo/workflows", async () => {
+    const { impl } = fakeFetch([
+      {
+        match: "/contents/.forgejo/workflows/ci.yml",
+        make: () => new Response(JSON.stringify({ name: "ci.yml", path: ".forgejo/workflows/ci.yml", type: "file", content: b64(CI_YAML), encoding: "base64" }), { status: 200 }),
+      },
+      {
+        match: "/contents/.forgejo/workflows",
+        make: () => new Response(JSON.stringify([{ name: "ci.yml", path: ".forgejo/workflows/ci.yml", type: "file", size: 100 }]), { status: 200 }),
+      },
+    ]);
+    const files = await fetchCiFiles("https://codeberg.org/acme/widgets", { fetchImpl: impl });
+    expect(files).toHaveLength(1);
+    expect(files[0].lexicon).toBe("forgejo");
+    expect(files[0].path).toBe(".forgejo/workflows/ci.yml");
+  });
+
+  test("a repo with no CI files returns []", async () => {
+    const { impl } = fakeFetch([]); // everything 404s
+    const files = await fetchCiFiles("https://github.com/acme/empty", { fetchImpl: impl });
+    expect(files).toEqual([]);
+  });
+});

--- a/packages/core/src/audit/fetch.ts
+++ b/packages/core/src/audit/fetch.ts
@@ -1,0 +1,200 @@
+/**
+ * Remote fetch — pull a repo's CI files from a git host so the auditor can run
+ * on a URL, not just a local path. This is the ONLY audit module that touches
+ * the network; the core stays pure.
+ *
+ * SSRF posture: only an allowlisted set of hosts is accepted; request URLs are
+ * built from the parsed owner/repo (never a user-controlled host); redirects
+ * are refused; and file count / size / total bytes / time are all capped.
+ */
+
+import type { AuditInput, AuditLexicon } from "./core";
+
+export interface FetchOptions {
+  /** Branch/tag/sha; defaults to the repo's default branch. */
+  ref?: string;
+  /** Server-side token (lifts rate limits). Never surfaced to callers. */
+  token?: string;
+  /** Max number of CI files to fetch (default 50). */
+  maxFiles?: number;
+  /** Max bytes for a single file; larger files are skipped (default 256 KiB). */
+  maxBytesPerFile?: number;
+  /** Max total bytes across all files; exceeding throws (default 2 MiB). */
+  maxTotalBytes?: number;
+  /** Per-request timeout in ms (default 10000). */
+  timeoutMs?: number;
+  /** Injectable fetch for testing. Defaults to the global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+const DEFAULTS = {
+  maxFiles: 50,
+  maxBytesPerFile: 256 * 1024,
+  maxTotalBytes: 2 * 1024 * 1024,
+  timeoutMs: 10_000,
+};
+
+type HostKind = "github" | "forgejo" | "gitlab";
+
+interface HostConfig {
+  kind: HostKind;
+  api: string;
+  lexicon: AuditLexicon;
+}
+
+const ALLOWED_HOSTS: Record<string, HostConfig> = {
+  "github.com": { kind: "github", api: "https://api.github.com", lexicon: "github" },
+  "codeberg.org": { kind: "forgejo", api: "https://codeberg.org/api/v1", lexicon: "forgejo" },
+  "gitlab.com": { kind: "gitlab", api: "https://gitlab.com/api/v4", lexicon: "gitlab" },
+};
+
+export class FetchError extends Error {}
+
+interface ParsedRepo {
+  host: HostConfig;
+  owner: string;
+  repo: string;
+}
+
+/** Parse and validate a repo URL against the host allowlist (SSRF guard). */
+export function parseRepoUrl(url: string): ParsedRepo {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    throw new FetchError(`Invalid URL: ${url}`);
+  }
+  if (u.protocol !== "https:") {
+    throw new FetchError(`Only https:// URLs are allowed (got ${u.protocol}).`);
+  }
+  const host = ALLOWED_HOSTS[u.hostname];
+  if (!host) {
+    throw new FetchError(
+      `Host not allowed: ${u.hostname}. Allowed: ${Object.keys(ALLOWED_HOSTS).join(", ")}.`,
+    );
+  }
+  const parts = u.pathname.replace(/^\/+/, "").split("/");
+  if (parts.length < 2 || !parts[0] || !parts[1]) {
+    throw new FetchError(`URL must be https://${u.hostname}/<owner>/<repo>.`);
+  }
+  return { host, owner: parts[0], repo: parts[1].replace(/\.git$/, "") };
+}
+
+function authHeaders(kind: HostKind, token?: string): Record<string, string> {
+  if (!token) return {};
+  if (kind === "github") return { Authorization: `Bearer ${token}` };
+  if (kind === "forgejo") return { Authorization: `token ${token}` };
+  return { "PRIVATE-TOKEN": token };
+}
+
+function isYaml(name: string): boolean {
+  return name.endsWith(".yml") || name.endsWith(".yaml");
+}
+
+function timeoutSignal(ms: number): AbortSignal | undefined {
+  return typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function"
+    ? AbortSignal.timeout(ms)
+    : undefined;
+}
+
+/** Gitea/GitHub contents-API entry (directory listing or single file). */
+interface ContentsEntry {
+  name: string;
+  path: string;
+  type: string;
+  size?: number;
+  content?: string;
+  encoding?: string;
+}
+
+export async function fetchCiFiles(url: string, opts: FetchOptions = {}): Promise<AuditInput[]> {
+  const { host, owner, repo } = parseRepoUrl(url);
+  const doFetch = opts.fetchImpl ?? fetch;
+  const cfg = {
+    maxFiles: opts.maxFiles ?? DEFAULTS.maxFiles,
+    maxBytesPerFile: opts.maxBytesPerFile ?? DEFAULTS.maxBytesPerFile,
+    maxTotalBytes: opts.maxTotalBytes ?? DEFAULTS.maxTotalBytes,
+    timeoutMs: opts.timeoutMs ?? DEFAULTS.timeoutMs,
+  };
+  const headers = authHeaders(host.kind, opts.token);
+
+  async function getJson(apiUrl: string): Promise<{ status: number; body: unknown }> {
+    let res: Response;
+    try {
+      res = await doFetch(apiUrl, { headers, redirect: "error", signal: timeoutSignal(cfg.timeoutMs) });
+    } catch (err) {
+      throw new FetchError(`Request failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    if (res.status >= 300 && res.status < 400) {
+      throw new FetchError(`Refusing to follow redirect from ${apiUrl}`);
+    }
+    if (res.status === 404) return { status: 404, body: null };
+    if (!res.ok) throw new FetchError(`${apiUrl} returned ${res.status}`);
+    return { status: res.status, body: await res.json() };
+  }
+
+  if (host.kind === "gitlab") {
+    return fetchGitlab(host, owner, repo, opts.ref, cfg, doFetch, headers);
+  }
+
+  // GitHub / Forgejo share the Gitea-style contents API.
+  const dirs = host.kind === "forgejo" ? [".forgejo/workflows", ".github/workflows"] : [".github/workflows"];
+  const ref = opts.ref ? `?ref=${encodeURIComponent(opts.ref)}` : "";
+
+  const candidates: ContentsEntry[] = [];
+  const seen = new Set<string>();
+  for (const dir of dirs) {
+    const { body } = await getJson(`${host.api}/repos/${owner}/${repo}/contents/${dir}${ref}`);
+    if (!Array.isArray(body)) continue;
+    for (const entry of body as ContentsEntry[]) {
+      if (entry.type === "file" && isYaml(entry.name) && !seen.has(entry.path)) {
+        seen.add(entry.path);
+        candidates.push(entry);
+      }
+    }
+  }
+
+  const inputs: AuditInput[] = [];
+  let total = 0;
+  for (const entry of candidates) {
+    if (inputs.length >= cfg.maxFiles) break;
+    if ((entry.size ?? 0) > cfg.maxBytesPerFile) continue; // skip oversize
+    const { body } = await getJson(`${host.api}/repos/${owner}/${repo}/contents/${entry.path}${ref}`);
+    const file = body as ContentsEntry | null;
+    if (!file?.content) continue;
+    const content = Buffer.from(file.content, (file.encoding as BufferEncoding) ?? "base64").toString("utf-8");
+    if (content.length > cfg.maxBytesPerFile) continue;
+    total += content.length;
+    if (total > cfg.maxTotalBytes) throw new FetchError("Repository CI files exceed the total size cap.");
+    inputs.push({ path: entry.path, content, lexicon: host.lexicon });
+  }
+  return inputs;
+}
+
+async function fetchGitlab(
+  host: HostConfig,
+  owner: string,
+  repo: string,
+  ref: string | undefined,
+  cfg: { maxBytesPerFile: number; maxTotalBytes: number; timeoutMs: number },
+  doFetch: typeof fetch,
+  headers: Record<string, string>,
+): Promise<AuditInput[]> {
+  const projectId = encodeURIComponent(`${owner}/${repo}`);
+  const refQ = `?ref=${encodeURIComponent(ref ?? "HEAD")}`;
+  const apiUrl = `${host.api}/projects/${projectId}/repository/files/${encodeURIComponent(".gitlab-ci.yml")}/raw${refQ}`;
+  let res: Response;
+  try {
+    res = await doFetch(apiUrl, { headers, redirect: "error", signal: timeoutSignal(cfg.timeoutMs) });
+  } catch (err) {
+    throw new FetchError(`Request failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (res.status >= 300 && res.status < 400) throw new FetchError(`Refusing to follow redirect from ${apiUrl}`);
+  if (res.status === 404) return [];
+  if (!res.ok) throw new FetchError(`${apiUrl} returned ${res.status}`);
+  const content = await res.text();
+  if (content.length > cfg.maxBytesPerFile || content.length > cfg.maxTotalBytes) {
+    throw new FetchError("Pipeline file exceeds the size cap.");
+  }
+  return [{ path: ".gitlab-ci.yml", content, lexicon: "gitlab" }];
+}

--- a/packages/core/src/cli/commands/audit.test.ts
+++ b/packages/core/src/cli/commands/audit.test.ts
@@ -49,6 +49,32 @@ describe("auditCommand", () => {
     expect(result.output).toContain("No CI files found");
   });
 
+  test("audits a remote repo URL via injected fetch", async () => {
+    const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64");
+    const yaml = "name: CI\non:\n  push:\npermissions: write-all\njobs:\n  build:\n    runs-on: ubuntu-latest\n";
+    const impl = (async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("/contents/.github/workflows/ci.yml")) {
+        return new Response(JSON.stringify({ name: "ci.yml", path: ".github/workflows/ci.yml", type: "file", content: b64(yaml), encoding: "base64" }), { status: 200 });
+      }
+      if (u.includes("/contents/.github/workflows")) {
+        return new Response(JSON.stringify([{ name: "ci.yml", path: ".github/workflows/ci.yml", type: "file", size: 100 }]), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const result = await auditCommand({ path: "https://github.com/acme/widgets", fetchImpl: impl });
+    expect(result.success).toBe(true);
+    expect(result.scanned).toContain(".github/workflows/ci.yml");
+    expect(result.findings.some((f) => f.checkId === "GHA033")).toBe(true);
+  });
+
+  test("a non-allowlisted URL fails cleanly", async () => {
+    const result = await auditCommand({ path: "https://evil.example.com/o/r" });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Host not allowed/);
+  });
+
   test("sarif output is valid JSON with results", async () => {
     const result = await auditCommand({ path: REPO, format: "sarif" });
     const sarif = JSON.parse(result.output);

--- a/packages/core/src/cli/commands/audit.ts
+++ b/packages/core/src/cli/commands/audit.ts
@@ -10,6 +10,7 @@ import { join, relative } from "path";
 import { auditFiles, type AuditInput, type AuditFinding, type AuditLexicon } from "../../audit/core";
 import { RULE_CATALOG } from "../../audit/catalog";
 import { renderMarkdown } from "../../audit/report";
+import { fetchCiFiles, FetchError } from "../../audit/fetch";
 import type { Severity } from "../../lint/rule";
 
 export type AuditFormat = "stylish" | "json" | "sarif" | "markdown";
@@ -17,13 +18,17 @@ export type AuditTier = "merge-worthy" | "all";
 export type AuditFailOn = "merge-worthy" | "warning" | "none";
 
 export interface AuditCommandOptions {
-  /** Repo root (or any dir) to scan. */
+  /** Repo root/dir to scan, or an https:// repo URL to fetch and audit. */
   path: string;
   format?: AuditFormat;
   /** Restrict findings to a tier (default "all"). */
   tier?: AuditTier;
   /** Exit-code policy (default "none" — read-only friendly). */
   failOn?: AuditFailOn;
+  /** Server-side token for remote fetch (defaults to env). */
+  token?: string;
+  /** Injectable fetch for testing remote audits. */
+  fetchImpl?: typeof fetch;
 }
 
 export interface AuditCommandResult {
@@ -137,11 +142,26 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
   const tier = options.tier ?? "all";
   const failOn = options.failOn ?? "none";
 
-  if (!existsSync(options.path)) {
-    return { success: false, output: "", findings: [], scanned: [], exitCode: 1, error: `Path not found: ${options.path}` };
+  const isUrl = /^https?:\/\//.test(options.path);
+
+  let inputs: AuditInput[];
+  if (isUrl) {
+    try {
+      inputs = await fetchCiFiles(options.path, {
+        token: options.token ?? process.env.CHANT_AUDIT_TOKEN ?? process.env.GITHUB_TOKEN,
+        fetchImpl: options.fetchImpl,
+      });
+    } catch (err) {
+      const msg = err instanceof FetchError ? err.message : err instanceof Error ? err.message : String(err);
+      return { success: false, output: "", findings: [], scanned: [], exitCode: 1, error: msg };
+    }
+  } else {
+    if (!existsSync(options.path)) {
+      return { success: false, output: "", findings: [], scanned: [], exitCode: 1, error: `Path not found: ${options.path}` };
+    }
+    inputs = discoverCiFiles(options.path);
   }
 
-  const inputs = discoverCiFiles(options.path);
   const scanned = inputs.map((i) => i.path);
 
   if (inputs.length === 0) {

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -173,7 +173,7 @@ Commands:
   describe              Show the effective config for one component
   vendor                Pull pinned, checksummed patterns into your repo
   import                Import external template into TypeScript
-  audit [path]          Audit a repo's CI YAML for security issues
+  audit [path|url]      Audit a repo's CI YAML for security issues
                         (--format stylish|json|sarif|markdown,
                          --tier merge-worthy|all, --fail-on merge-worthy|warning|none)
   migrate <file>        Translate a workflow between lexicons


### PR DESCRIPTION
Part of #350. Closes #355.

Adds `packages/core/src/audit/fetch.ts` — `fetchCiFiles(url)` pulls a repo's CI files so the auditor (and the future hosted service) can run on a URL. The only audit module that touches the network; the core stays pure.

## SSRF posture
- https-only; host allowlist (github.com / codeberg.org / gitlab.com).
- Request URLs are built from the parsed owner/repo — never a user-controlled host. Content fetched via the contents API (base64) so it stays on the API host.
- Redirects refused (`redirect: "error"` + explicit 3xx rejection).
- Caps: max files (50), per-file bytes (256 KiB, oversize skipped), total bytes (2 MiB, exceeding throws), per-request timeout (10s).
- Optional server-side token (`Bearer`/`token`/`PRIVATE-TOKEN` per host); never surfaced to callers.

## CLI
`chant audit <https url>` now works (reuses the path positional; token from `CHANT_AUDIT_TOKEN`/`GITHUB_TOKEN`).

## Tests
20 tests total (11 fetch + 9 command). `fetch` is injected, so **no real HTTP in CI**: github/forgejo/gitlab happy paths, auth header, size-cap skip, redirect refusal, host/https rejection, empty repo, and an end-to-end remote `auditCommand` via a fake fetch. `just build`, `eslint` green.