### PR TITLE
feat(audit): round-trip proof of minimal change (#358)

### DIFF
--- a/packages/core/src/audit/proof.test.ts
+++ b/packages/core/src/audit/proof.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from "vitest";
+import { proveFix, unifiedDiff } from "./proof";
+
+const WF = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+`;
+
+const WF_WRITE_ALL = `name: CI
+on:
+  push:
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+`;
+
+describe("proveFix — pin action (GHA021/GHA029)", () => {
+  test("pins an unpinned action and the diff shows only that line", () => {
+    const sha = "11bd71901bbe5b1630ceea73d27597364c9af683";
+    const res = proveFix("GHA021", WF, { resolveSha: () => sha });
+    expect(res.applied).toBe(true);
+    expect(res.patched).toContain(`actions/checkout@${sha}  # v4`);
+    // Only the uses line changes: exactly one - and one + in the diff.
+    const removed = res.diff!.split("\n").filter((l) => l.startsWith("-") && !l.startsWith("---"));
+    const added = res.diff!.split("\n").filter((l) => l.startsWith("+") && !l.startsWith("+++"));
+    expect(removed).toEqual(["-      - uses: actions/checkout@v4"]);
+    expect(added).toEqual([`+      - uses: actions/checkout@${sha}  # v4`]);
+  });
+
+  test("needs a sha when none can be resolved", () => {
+    const res = proveFix("GHA021", WF, { resolveSha: () => undefined });
+    expect(res.applied).toBe(false);
+    expect(res.note).toMatch(/SHA is required/i);
+  });
+
+  test("no-op when the action is already pinned", () => {
+    const pinned = WF.replace("@v4", "@11bd71901bbe5b1630ceea73d27597364c9af683");
+    const res = proveFix("GHA021", pinned, { resolveSha: () => "x" });
+    expect(res.applied).toBe(false);
+    expect(res.note).toMatch(/no-op/i);
+  });
+});
+
+describe("proveFix — permissions", () => {
+  test("adds a least-privilege block additively (GHA017)", () => {
+    const res = proveFix("GHA017", WF);
+    expect(res.applied).toBe(true);
+    expect(res.patched).toContain("permissions:\n  contents: read");
+    // Purely additive: no removed lines.
+    const removed = res.diff!.split("\n").filter((l) => l.startsWith("-") && !l.startsWith("---"));
+    expect(removed).toEqual([]);
+    const added = res.diff!.split("\n").filter((l) => l.startsWith("+") && !l.startsWith("+++"));
+    expect(added).toEqual(["+permissions:", "+  contents: read"]);
+  });
+
+  test("no-op when a permissions block already exists", () => {
+    const withPerms = WF.replace("jobs:", "permissions:\n  contents: read\njobs:");
+    const res = proveFix("GHA017", withPerms);
+    expect(res.applied).toBe(false);
+  });
+
+  test("narrows write-all (GHA033)", () => {
+    const res = proveFix("GHA033", WF_WRITE_ALL);
+    expect(res.applied).toBe(true);
+    expect(res.patched).toContain("permissions:\n  contents: read");
+    expect(res.patched).not.toContain("write-all");
+  });
+});
+
+describe("proveFix — guidance findings are not auto-fixed", () => {
+  test("a guidance rule returns remediation, not a patch", () => {
+    const res = proveFix("GHA036", WF); // script injection — guidance
+    expect(res.applied).toBe(false);
+    expect(res.patched).toBeUndefined();
+    expect(res.note && res.note.length).toBeGreaterThan(0);
+  });
+});
+
+describe("unifiedDiff", () => {
+  test("identical input produces an empty diff", () => {
+    expect(unifiedDiff(WF, WF)).toBe("");
+  });
+
+  test("emits a hunk header and the changed lines", () => {
+    const a = "a\nb\nc\n";
+    const b = "a\nB\nc\n";
+    const diff = unifiedDiff(a, b);
+    expect(diff).toContain("@@");
+    expect(diff).toContain("-b");
+    expect(diff).toContain("+B");
+    expect(diff).toContain(" a");
+  });
+});

--- a/packages/core/src/audit/proof.ts
+++ b/packages/core/src/audit/proof.ts
@@ -1,0 +1,211 @@
+/**
+ * Proof of minimal change — for a deterministic (fixKind: "deterministic")
+ * finding, produce a minimal patched YAML + unified diff so a PR can show it
+ * changes exactly the flagged line and nothing else.
+ *
+ * No LLM, no API key — purely mechanical text edits. Findings that need
+ * judgment (fixKind: "guidance") are NOT auto-fixed here; they return
+ * `applied: false` with the catalog remediation as guidance. Any LLM-assisted
+ * apply of a guidance fix is a separate, optional, local concern.
+ *
+ * Edits are applied directly to the YAML text (not via a model round-trip), so
+ * the patched output differs only where intended — the diff proves it.
+ */
+
+import { RULE_CATALOG } from "./catalog";
+
+export interface ProveOptions {
+  /** Resolve an action ref (e.g. "actions/checkout@v4") to a 40-char SHA. */
+  resolveSha?: (action: string, ref: string) => string | undefined;
+}
+
+export interface ProofResult {
+  checkId: string;
+  /** True when a deterministic fix was produced. */
+  applied: boolean;
+  /** Full patched content (only when applied). */
+  patched?: string;
+  /** Unified diff of the change (only when applied). */
+  diff?: string;
+  /** Guidance/explanation when not applied (guidance fix, no-op, or needs-sha). */
+  note?: string;
+}
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+function notApplied(checkId: string, note: string): ProofResult {
+  return { checkId, applied: false, note };
+}
+
+/** Pin unpinned `uses: action@ref` lines to a SHA. */
+function pinActions(content: string, opts: ProveOptions): { patched: string; changed: boolean; needsSha: boolean } {
+  const lines = content.split("\n");
+  let changed = false;
+  let needsSha = false;
+  const usesRe = /^(\s*-?\s*uses:\s*)([^@\s'"]+)@([^\s'"#]+)(.*)$/;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(usesRe);
+    if (!m) continue;
+    const [, prefix, action, ref, rest] = m;
+    if (SHA_RE.test(ref)) continue; // already pinned
+    const sha = opts.resolveSha?.(action, ref);
+    if (!sha) {
+      needsSha = true;
+      continue;
+    }
+    lines[i] = `${prefix}${action}@${sha}  # ${ref}${rest.replace(/\s*#.*$/, "")}`;
+    changed = true;
+  }
+  return { patched: lines.join("\n"), changed, needsSha };
+}
+
+/** Insert a least-privilege top-level permissions block if absent. */
+function addPermissions(content: string): { patched: string; changed: boolean } {
+  if (/^permissions:/m.test(content)) return { patched: content, changed: false };
+  const lines = content.split("\n");
+  const jobsIdx = lines.findIndex((l) => /^jobs:\s*$/.test(l));
+  if (jobsIdx === -1) return { patched: content, changed: false };
+  lines.splice(jobsIdx, 0, "permissions:", "  contents: read");
+  return { patched: lines.join("\n"), changed: true };
+}
+
+/** Replace a top-level `permissions: write-all` with a least-privilege block. */
+function narrowWriteAll(content: string): { patched: string; changed: boolean } {
+  const re = /^permissions:[ \t]+write-all[ \t]*$/m;
+  if (!re.test(content)) return { patched: content, changed: false };
+  return { patched: content.replace(re, "permissions:\n  contents: read"), changed: true };
+}
+
+/**
+ * Produce a deterministic fix + diff for a finding, if one is mechanical.
+ * Returns `applied: false` with guidance for non-deterministic findings.
+ */
+export function proveFix(checkId: string, content: string, opts: ProveOptions = {}): ProofResult {
+  const cat = RULE_CATALOG[checkId];
+  if (cat && cat.fixKind !== "deterministic") {
+    return notApplied(checkId, cat.remediation || "Manual fix required.");
+  }
+
+  let result: { patched: string; changed: boolean; needsSha?: boolean };
+  switch (checkId) {
+    case "GHA021":
+    case "GHA029":
+      result = pinActions(content, opts);
+      if (!result.changed && (result as { needsSha?: boolean }).needsSha) {
+        return notApplied(checkId, "A commit SHA is required to pin; resolve it (e.g. via the fetch layer) and re-run.");
+      }
+      break;
+    case "GHA017":
+      result = addPermissions(content);
+      break;
+    case "GHA033":
+      result = narrowWriteAll(content);
+      break;
+    default:
+      return notApplied(checkId, cat?.remediation || "No deterministic fix implemented for this rule yet.");
+  }
+
+  if (!result.changed) {
+    return notApplied(checkId, "Nothing to fix — the issue is not present (no-op).");
+  }
+  return {
+    checkId,
+    applied: true,
+    patched: result.patched,
+    diff: unifiedDiff(content, result.patched),
+  };
+}
+
+// ── Minimal line-based unified diff ──────────────────────────────────
+
+type Op = { type: "eq" | "del" | "add"; line: string };
+
+/** LCS-based line diff. */
+function diffOps(a: string[], b: string[]): Op[] {
+  const n = a.length;
+  const m = b.length;
+  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] = a[i] === b[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+  const ops: Op[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      ops.push({ type: "eq", line: a[i] });
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      ops.push({ type: "del", line: a[i] });
+      i++;
+    } else {
+      ops.push({ type: "add", line: b[j] });
+      j++;
+    }
+  }
+  while (i < n) ops.push({ type: "del", line: a[i++] });
+  while (j < m) ops.push({ type: "add", line: b[j++] });
+  return ops;
+}
+
+/** Render a unified diff with up to `context` equal lines around changes. */
+export function unifiedDiff(oldStr: string, newStr: string, context = 3): string {
+  const a = oldStr.split("\n");
+  const b = newStr.split("\n");
+  const ops = diffOps(a, b);
+
+  // Mark which op indexes are within `context` of a change.
+  const keep = new Array(ops.length).fill(false);
+  for (let k = 0; k < ops.length; k++) {
+    if (ops[k].type !== "eq") {
+      for (let d = -context; d <= context; d++) {
+        const idx = k + d;
+        if (idx >= 0 && idx < ops.length) keep[idx] = true;
+      }
+    }
+  }
+
+  const lines: string[] = [];
+  let oldLine = 1;
+  let newLine = 1;
+  let k = 0;
+  while (k < ops.length) {
+    if (!keep[k]) {
+      if (ops[k].type !== "add") oldLine++;
+      if (ops[k].type !== "del") newLine++;
+      k++;
+      continue;
+    }
+    // Start of a hunk.
+    const hunk: string[] = [];
+    const oldStart = oldLine;
+    const newStart = newLine;
+    let oldCount = 0;
+    let newCount = 0;
+    while (k < ops.length && keep[k]) {
+      const op = ops[k];
+      if (op.type === "eq") {
+        hunk.push(` ${op.line}`);
+        oldCount++;
+        newCount++;
+        oldLine++;
+        newLine++;
+      } else if (op.type === "del") {
+        hunk.push(`-${op.line}`);
+        oldCount++;
+        oldLine++;
+      } else {
+        hunk.push(`+${op.line}`);
+        newCount++;
+        newLine++;
+      }
+      k++;
+    }
+    lines.push(`@@ -${oldStart},${oldCount} +${newStart},${newCount} @@`);
+    lines.push(...hunk);
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
Part of #350. Closes #358.

Adds `packages/core/src/audit/proof.ts` — `proveFix(checkId, content)` produces a deterministic minimal fix + unified diff so a PR can show it changes exactly the flagged line.

## Scope (deterministic only — no LLM)
- **pin-to-SHA** (GHA021/GHA029): `uses: x@v4` → `uses: x@<sha>  # v4`. SHA comes from an injected resolver (the git API lookup belongs to the fetch layer, #355), not a model.
- **additive permissions** (GHA017): inserts `permissions:\n  contents: read` before `jobs:`.
- **write-all narrowing** (GHA033): `permissions: write-all` → least-privilege block.
- Guidance-tier findings (injection, pwn-request, secrets) return remediation **text**, never a patch.

## Honesty guarantees
- Edits are applied directly to the YAML text, so the patched output differs only where intended — the included unified diff proves it (pin → exactly one `-`/`+`; permissions → purely additive, zero `-`).
- No-op when the issue isn't present (already pinned / block already exists) → `applied: false`.
- Identical input → empty diff. No network, no API key.

9 tests; `just build`, `eslint` green locally.