### PR TITLE
feat(audit): report rework — inline diffs, quick-wins split, clustering (#366)

### DIFF
--- a/packages/core/src/audit/fetch.test.ts
+++ b/packages/core/src/audit/fetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { fetchCiFiles, parseRepoUrl, FetchError } from "./fetch";
+import { fetchCiFiles, parseRepoUrl, resolveActionSha, FetchError } from "./fetch";
 
 const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64");
 const CI_YAML = "name: CI\non:\n  push:\npermissions: write-all\njobs:\n  build:\n    runs-on: ubuntu-latest\n";
@@ -110,5 +110,28 @@ describe("fetchCiFiles", () => {
     const { impl } = fakeFetch([]); // everything 404s
     const files = await fetchCiFiles("https://github.com/acme/empty", { fetchImpl: impl });
     expect(files).toEqual([]);
+  });
+});
+
+describe("resolveActionSha", () => {
+  const SHA = "11bd71901bbe5b1630ceea73d27597364c9af683";
+
+  test("resolves an action ref to a commit SHA via the GitHub API", async () => {
+    const { impl, calls } = fakeFetch([
+      { match: "/repos/actions/checkout/commits/v4", make: () => new Response(JSON.stringify({ sha: SHA }), { status: 200 }) },
+    ]);
+    const sha = await resolveActionSha("actions/checkout", "v4", { fetchImpl: impl });
+    expect(sha).toBe(SHA);
+    expect(calls[0].url).toContain("api.github.com/repos/actions/checkout/commits/v4");
+  });
+
+  test("returns undefined on a failed lookup", async () => {
+    const { impl } = fakeFetch([]); // 404
+    expect(await resolveActionSha("acme/missing", "v1", { fetchImpl: impl })).toBeUndefined();
+  });
+
+  test("rejects a non-SHA response", async () => {
+    const { impl } = fakeFetch([{ match: "/commits/", make: () => new Response(JSON.stringify({ sha: "not-a-sha" }), { status: 200 }) }]);
+    expect(await resolveActionSha("acme/action", "v1", { fetchImpl: impl })).toBeUndefined();
   });
 });

--- a/packages/core/src/audit/fetch.ts
+++ b/packages/core/src/audit/fetch.ts
@@ -171,6 +171,41 @@ export async function fetchCiFiles(url: string, opts: FetchOptions = {}): Promis
   return inputs;
 }
 
+const SHA40 = /^[0-9a-f]{40}$/;
+
+/**
+ * Resolve an action ref (e.g. action="actions/checkout", ref="v4") to its
+ * commit SHA via the GitHub API. Returns undefined on any failure — pinning
+ * degrades gracefully to guidance. Actions are GitHub-hosted slugs, so this
+ * queries api.github.com regardless of the audited repo's host.
+ */
+export async function resolveActionSha(
+  action: string,
+  ref: string,
+  opts: { token?: string; fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<string | undefined> {
+  const parts = action.split("/");
+  if (parts.length < 2 || !parts[0] || !parts[1]) return undefined;
+  const [owner, repo] = parts;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const url = `https://api.github.com/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}`;
+  try {
+    const res = await doFetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        ...(opts.token ? { Authorization: `Bearer ${opts.token}` } : {}),
+      },
+      redirect: "error",
+      signal: timeoutSignal(opts.timeoutMs ?? DEFAULTS.timeoutMs),
+    });
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as { sha?: string };
+    return body.sha && SHA40.test(body.sha) ? body.sha : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function fetchGitlab(
   host: HostConfig,
   owner: string,

--- a/packages/core/src/audit/proof.ts
+++ b/packages/core/src/audit/proof.ts
@@ -32,9 +32,27 @@ export interface ProofResult {
 }
 
 const SHA_RE = /^[0-9a-f]{40}$/;
+const USES_RE = /^(\s*-?\s*uses:\s*)([^@\s'"]+)@([^\s'"#]+)(.*)$/;
 
 function notApplied(checkId: string, note: string): ProofResult {
   return { checkId, applied: false, note };
+}
+
+/** Extract unpinned `uses: action@ref` references (deduped) from workflow YAML. */
+export function extractUnpinnedActions(content: string): Array<{ action: string; ref: string }> {
+  const seen = new Set<string>();
+  const out: Array<{ action: string; ref: string }> = [];
+  for (const line of content.split("\n")) {
+    const m = line.match(USES_RE);
+    if (!m) continue;
+    const [, , action, ref] = m;
+    if (SHA_RE.test(ref)) continue;
+    const key = `${action}@${ref}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ action, ref });
+  }
+  return out;
 }
 
 /** Pin unpinned `uses: action@ref` lines to a SHA. */
@@ -42,9 +60,8 @@ function pinActions(content: string, opts: ProveOptions): { patched: string; cha
   const lines = content.split("\n");
   let changed = false;
   let needsSha = false;
-  const usesRe = /^(\s*-?\s*uses:\s*)([^@\s'"]+)@([^\s'"#]+)(.*)$/;
   for (let i = 0; i < lines.length; i++) {
-    const m = lines[i].match(usesRe);
+    const m = lines[i].match(USES_RE);
     if (!m) continue;
     const [, prefix, action, ref, rest] = m;
     if (SHA_RE.test(ref)) continue; // already pinned

--- a/packages/core/src/audit/report.test.ts
+++ b/packages/core/src/audit/report.test.ts
@@ -2,96 +2,105 @@ import { describe, test, expect } from "vitest";
 import { renderMarkdown } from "./report";
 import type { AuditFinding } from "./core";
 
+const CI = `name: CI
+on:
+  pull_request_target:
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`;
+
 const FINDINGS: AuditFinding[] = [
-  {
-    checkId: "GHA033",
-    severity: "warning",
-    message: "Workflow declares permissions: write-all — replace it with specific scopes.",
-    file: ".github/workflows/ci.yml",
-    lexicon: "github",
-  },
-  {
-    checkId: "GHA021",
-    severity: "warning",
-    message: 'Job "build" uses actions/checkout@v4 — pin to a full commit SHA.',
-    file: ".github/workflows/ci.yml",
-    lexicon: "github",
-    entity: "build",
-  },
-  {
-    checkId: "GHA036",
-    severity: "error",
-    message: "Untrusted input interpolated into a run: shell command.",
-    file: ".github/workflows/pr.yml",
-    lexicon: "github",
-    entity: "comment",
-  },
-  {
-    checkId: "GHA022",
-    severity: "info",
-    message: 'Job "build" has no timeout-minutes.',
-    file: ".github/workflows/ci.yml",
-    lexicon: "github",
-  },
+  { checkId: "GHA033", severity: "warning", message: "write-all permissions.", file: ".github/workflows/ci.yml", lexicon: "github" },
+  { checkId: "GHA021", severity: "warning", message: "unpinned checkout.", file: ".github/workflows/ci.yml", lexicon: "github", entity: "build" },
+  { checkId: "GHA035", severity: "error", message: "elevated token on pull_request_target.", file: ".github/workflows/ci.yml", lexicon: "github" },
+  { checkId: "GHA018", severity: "warning", message: "pull_request_target checks out PR code.", file: ".github/workflows/ci.yml", lexicon: "github", entity: "build" },
+  { checkId: "GHA022", severity: "info", message: "no timeout.", file: ".github/workflows/ci.yml", lexicon: "github" },
 ];
 
-describe("renderMarkdown", () => {
-  test("renders a stable tiered report", () => {
-    expect(renderMarkdown(FINDINGS, { target: "owner/repo" })).toMatchInlineSnapshot(`
-      "# CI security audit
+describe("renderMarkdown — reworked structure", () => {
+  test("summary counts by tier and severity", () => {
+    const out = renderMarkdown(FINDINGS, { target: "owner/repo" });
+    expect(out).toContain("Target: owner/repo");
+    expect(out).toContain("5 findings — 2 quick-win, 2 needs-review, 1 report-only (1 error, 3 warning, 1 info).");
+  });
 
-      Target: owner/repo
+  test("quick wins show a real combined diff when file content is provided", () => {
+    const out = renderMarkdown(FINDINGS, { files: [{ path: ".github/workflows/ci.yml", content: CI }] });
+    expect(out).toContain("## Quick wins (deterministic)");
+    expect(out).toContain("Addresses GHA033 (Blanket write-all permissions):");
+    expect(out).toContain("```diff");
+    expect(out).toContain("-permissions: write-all");
+    expect(out).toContain("+permissions:");
+    expect(out).toContain("+  contents: read");
+  });
 
-      4 findings — 3 merge-worthy, 1 report-only (1 error, 2 warning, 1 info).
+  test("pin findings without a SHA resolver are listed, not diffed", () => {
+    const out = renderMarkdown(FINDINGS, { files: [{ path: ".github/workflows/ci.yml", content: CI }] });
+    expect(out).toContain("Needs a value before it can be auto-patched:");
+    expect(out).toContain("**GHA021**");
+  });
 
-      ## Merge-worthy findings
+  test("pin findings are diffed when a SHA resolver is supplied", () => {
+    const sha = "11bd71901bbe5b1630ceea73d27597364c9af683";
+    const out = renderMarkdown(FINDINGS, {
+      files: [{ path: ".github/workflows/ci.yml", content: CI }],
+      resolveSha: () => sha,
+    });
+    expect(out).toContain(`actions/checkout@${sha}`);
+  });
 
-      ### GHA036 — Untrusted input interpolated into run: (error)
+  test("guidance findings cluster by authority", () => {
+    const out = renderMarkdown(FINDINGS);
+    expect(out).toContain("<summary>Needs review (guidance)");
+    // GHA035 and GHA018 both share the pwn-request authority → one cluster.
+    expect(out).toContain("Preventing pwn requests");
+    const clusterIdx = out.indexOf("Preventing pwn requests");
+    const after = out.slice(clusterIdx);
+    expect(after).toContain("**GHA035**");
+    expect(after).toContain("**GHA018**");
+  });
 
-      Pass untrusted \`\${{ }}\` values via an \`env:\` var and reference \`"$VAR"\`, never inline in the script.
+  test("report-only hygiene goes in a collapsible table", () => {
+    const out = renderMarkdown(FINDINGS);
+    expect(out).toContain("<details>");
+    expect(out).toContain("<summary>Report-only (hygiene)");
+    expect(out).toContain("| GHA022 |");
+  });
 
-      Authority: [GitHub — Understanding the risk of script injections](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)
+  test("suppresses a report-only finding on an entity already flagged merge-worthy", () => {
+    const findings: AuditFinding[] = [
+      { checkId: "WGL016", severity: "error", message: "hardcoded secret.", file: ".gitlab-ci.yml", lexicon: "gitlab", entity: "DB_PASSWORD" },
+      { checkId: "WGL021", severity: "warning", message: "unused variable.", file: ".gitlab-ci.yml", lexicon: "gitlab", entity: "DB_PASSWORD" },
+    ];
+    const out = renderMarkdown(findings);
+    expect(out).toContain("WGL016");
+    expect(out).not.toContain("WGL021"); // suppressed — same entity already flagged
+    expect(out).toContain("1 finding — ");
+  });
 
-      - \`.github/workflows/pr.yml\` (\`comment\`) — Untrusted input interpolated into a run: shell command.
-
-      ### GHA021 — actions/checkout not pinned to a SHA (warning)
-
-      Pin \`actions/checkout\` to a full 40-char commit SHA.
-
-      Authority: [OSSF Scorecard — Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) · [GitHub — Using third-party actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
-
-      - \`.github/workflows/ci.yml\` (\`build\`) — Job "build" uses actions/checkout@v4 — pin to a full commit SHA.
-
-      ### GHA033 — Blanket write-all permissions (warning)
-
-      Replace \`write-all\` with the specific scopes the jobs need (default \`contents: read\`).
-
-      Authority: [OSSF Scorecard — Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) · [GitHub — Automatic token authentication](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication)
-
-      - \`.github/workflows/ci.yml\` — Workflow declares permissions: write-all — replace it with specific scopes.
-
-      ## Report-only (hygiene)
-
-      | Rule | Title | File | Detail |
-      | --- | --- | --- | --- |
-      | GHA022 | Job without timeout-minutes | \`.github/workflows/ci.yml\` | Job "build" has no timeout-minutes. |
-
-      ---
-      Generated by [chant audit](https://intentius.io/chant/).
-      "
-    `);
+  test("does not suppress unrelated hygiene sharing a job entity", () => {
+    const findings: AuditFinding[] = [
+      { checkId: "GHA021", severity: "warning", message: "unpinned.", file: ".github/workflows/ci.yml", lexicon: "github", entity: "build" },
+      { checkId: "GHA022", severity: "info", message: "no timeout.", file: ".github/workflows/ci.yml", lexicon: "github", entity: "build" },
+    ];
+    const out = renderMarkdown(findings);
+    expect(out).toContain("GHA022"); // unrelated hygiene on the same job is kept
   });
 
   test("clean report when there are no findings", () => {
     const out = renderMarkdown([]);
     expect(out).toContain("No issues found.");
-    expect(out).toContain("chant audit");
-    expect(out).not.toContain("Merge-worthy");
+    expect(out).not.toContain("Quick wins");
   });
 
-  test("omits a tier section when it has no findings", () => {
-    const out = renderMarkdown([FINDINGS[2]]); // one merge-worthy error only
-    expect(out).toContain("## Merge-worthy findings");
-    expect(out).not.toContain("## Report-only");
+  test("omits empty sections", () => {
+    const onlyGuidance = renderMarkdown([FINDINGS[2]]); // GHA035 only
+    expect(onlyGuidance).toContain("<summary>Needs review (guidance)");
+    expect(onlyGuidance).not.toContain("## Quick wins");
+    expect(onlyGuidance).not.toContain("Report-only");
   });
 });

--- a/packages/core/src/audit/report.ts
+++ b/packages/core/src/audit/report.ts
@@ -1,24 +1,43 @@
 /**
  * Markdown report generator for audit findings.
  *
- * Renders a shareable report: a header with counts, a **merge-worthy** section
- * (security/correctness findings worth a PR, with remediation and authority
- * citations) and a compact **report-only** hygiene table. Deterministic
- * ordering keeps snapshots stable. Pure string output — no I/O.
+ * Structure:
+ *  - **Quick wins (deterministic)** — merge-worthy findings with a safe
+ *    mechanical fix, grouped per file with one combined unified diff (from
+ *    proof.ts) so the report doubles as a ready-to-apply patch. Pin fixes that
+ *    need a SHA (no resolver) are listed instead of diffed.
+ *  - **Needs review (guidance)** — merge-worthy findings that need judgment,
+ *    clustered by their primary authority so related rules (e.g. all
+ *    pull_request_target / pwn-request checks) read as one concern.
+ *  - **Report-only (hygiene)** — a compact table.
+ *
+ * Deterministic ordering keeps snapshots stable. Pure string output.
  */
 
 import type { AuditFinding } from "./core";
 import { RULE_CATALOG, type RuleMeta, type Tier } from "./catalog";
+import { proveFix, unifiedDiff, type ProveOptions } from "./proof";
 import type { Severity } from "../lint/rule";
 
 export interface RenderOptions {
   /** Repo URL or path shown in the header. */
   target?: string;
+  /** Audited file contents (path → YAML), enabling inline fix diffs. */
+  files?: Array<{ path: string; content: string }>;
+  /** Resolve an action ref to a SHA so pin fixes can be diffed. */
+  resolveSha?: ProveOptions["resolveSha"];
 }
 
 const SEVERITY_WEIGHT: Record<Severity, number> = { error: 0, warning: 1, info: 2 };
 
-/** Catalog lookup with a safe fallback for any uncatalogued id. */
+/**
+ * Report-only rules made redundant by a specific merge-worthy rule on the same
+ * entity. Narrow by design — only genuinely duplicative pairs.
+ */
+const SUPERSEDED_BY: Record<string, string[]> = {
+  WGL021: ["WGL016"], // "unused variable" is noise when the var is a flagged hardcoded secret
+};
+
 function metaFor(id: string): RuleMeta {
   return (
     RULE_CATALOG[id] ?? {
@@ -40,7 +59,6 @@ function enrich(findings: AuditFinding[]): EnrichedFinding[] {
   return findings.map((f) => ({ ...f, meta: metaFor(f.checkId) }));
 }
 
-/** Sort findings by severity, then check id, then file — stable for snapshots. */
 function sortFindings(a: EnrichedFinding, b: EnrichedFinding): number {
   const sev = SEVERITY_WEIGHT[a.severity] - SEVERITY_WEIGHT[b.severity];
   if (sev !== 0) return sev;
@@ -52,29 +70,108 @@ function escapeCell(s: string): string {
   return s.replace(/\|/g, "\\|").replace(/\n/g, " ").trim();
 }
 
-function renderMergeWorthy(findings: EnrichedFinding[]): string[] {
-  const lines: string[] = ["## Merge-worthy findings", ""];
-
-  // Group by check id, preserving severity/id order.
-  const byRule = new Map<string, EnrichedFinding[]>();
-  for (const f of [...findings].sort(sortFindings)) {
-    const list = byRule.get(f.checkId) ?? [];
-    list.push(f);
-    byRule.set(f.checkId, list);
+function byFile<T extends { file: string }>(items: T[]): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const it of [...items].sort((a, b) => (a.file < b.file ? -1 : a.file > b.file ? 1 : 0))) {
+    const list = map.get(it.file) ?? [];
+    list.push(it);
+    map.set(it.file, list);
   }
+  return map;
+}
 
-  for (const [checkId, group] of byRule) {
-    const m = group[0].meta;
-    lines.push(`### ${checkId} — ${m.title} (${group[0].severity})`);
-    if (m.remediation) lines.push("", m.remediation);
-    if (m.authority?.length) {
-      const links = m.authority.map((a) => `[${a.name}](${a.url})`).join(" · ");
-      lines.push("", `Authority: ${links}`);
+// ── Quick wins (deterministic) ───────────────────────────────────────
+
+function renderQuickWins(
+  findings: EnrichedFinding[],
+  contents: Map<string, string>,
+  resolveSha: ProveOptions["resolveSha"],
+): string[] {
+  const lines: string[] = ["## Quick wins (deterministic)", "", "Safe mechanical fixes — the diff changes only the flagged lines.", ""];
+
+  for (const [file, group] of byFile(findings)) {
+    lines.push(`### \`${file}\``);
+    const ids = [...new Set(group.map((f) => f.checkId))].sort();
+    const original = contents.get(file);
+
+    const addressed: string[] = [];
+    const needsInput: EnrichedFinding[] = [];
+    let patched = original;
+
+    if (original !== undefined) {
+      for (const id of ids) {
+        const res = proveFix(id, patched ?? original, { resolveSha });
+        if (res.applied && res.patched !== undefined) {
+          patched = res.patched;
+          addressed.push(id);
+        } else {
+          // Couldn't auto-patch (e.g. pin needs a SHA) — surface as guidance.
+          needsInput.push(...group.filter((f) => f.checkId === id));
+        }
+      }
+    }
+
+    if (original !== undefined && patched !== undefined && patched !== original) {
+      const labels = addressed.map((id) => `${id} (${metaFor(id).title})`).join(", ");
+      lines.push("", `Addresses ${labels}:`, "", "```diff", unifiedDiff(original, patched), "```");
+    } else if (original === undefined) {
+      // No content available — list the findings with remediation.
+      for (const f of group) needsInput.push(f);
+    }
+
+    const seen = new Set<string>();
+    const leftover = needsInput.filter((f) => {
+      const k = `${f.checkId}:${f.entity ?? ""}`;
+      if (seen.has(k)) return false;
+      seen.add(k);
+      return true;
+    });
+    if (leftover.length > 0) {
+      lines.push("", "Needs a value before it can be auto-patched:");
+      for (const f of leftover) {
+        const where = f.entity ? ` (\`${f.entity}\`)` : "";
+        lines.push(`- **${f.checkId}**${where} — ${f.meta.remediation}`);
+      }
     }
     lines.push("");
-    for (const f of [...group].sort((x, y) => (x.file < y.file ? -1 : x.file > y.file ? 1 : 0))) {
-      const where = f.entity ? `\`${f.file}\` (\`${f.entity}\`)` : `\`${f.file}\``;
-      lines.push(`- ${where} — ${escapeCell(f.message)}`);
+  }
+
+  return lines;
+}
+
+// ── Needs review (guidance), clustered by authority ──────────────────
+
+function clusterKey(m: RuleMeta): string {
+  return m.authority?.[0]?.name ?? "General hardening";
+}
+
+function renderNeedsReview(findings: EnrichedFinding[]): string[] {
+  const lines: string[] = ["These need a judgement call — remediation guidance, not an auto-fix.", ""];
+
+  const clusters = new Map<string, EnrichedFinding[]>();
+  for (const f of [...findings].sort(sortFindings)) {
+    const key = clusterKey(f.meta);
+    const list = clusters.get(key) ?? [];
+    list.push(f);
+    clusters.set(key, list);
+  }
+
+  for (const [cluster, group] of [...clusters.entries()].sort((a, b) => (a[0] < b[0] ? -1 : 1))) {
+    const authority = group[0].meta.authority?.[0];
+    const heading = authority ? `[${cluster}](${authority.url})` : cluster;
+    lines.push(`### ${heading}`, "");
+    const byRule = new Map<string, EnrichedFinding[]>();
+    for (const f of group) {
+      const list = byRule.get(f.checkId) ?? [];
+      list.push(f);
+      byRule.set(f.checkId, list);
+    }
+    for (const [id, rule] of byRule) {
+      lines.push(`- **${id}** — ${rule[0].meta.title} (${rule[0].severity}). ${rule[0].meta.remediation}`);
+      for (const f of rule) {
+        const where = f.entity ? `\`${f.file}\` (\`${f.entity}\`)` : `\`${f.file}\``;
+        lines.push(`  - ${where} — ${escapeCell(f.message)}`);
+      }
     }
     lines.push("");
   }
@@ -83,7 +180,7 @@ function renderMergeWorthy(findings: EnrichedFinding[]): string[] {
 }
 
 function renderReportOnly(findings: EnrichedFinding[]): string[] {
-  const lines: string[] = ["## Report-only (hygiene)", "", "| Rule | Title | File | Detail |", "| --- | --- | --- | --- |"];
+  const lines: string[] = ["", "| Rule | Title | File | Detail |", "| --- | --- | --- | --- |"];
   for (const f of [...findings].sort(sortFindings)) {
     lines.push(`| ${f.checkId} | ${escapeCell(f.meta.title)} | \`${f.file}\` | ${escapeCell(f.message)} |`);
   }
@@ -94,32 +191,58 @@ function renderReportOnly(findings: EnrichedFinding[]): string[] {
 /** Render an audit report as Markdown. */
 export function renderMarkdown(findings: AuditFinding[], opts: RenderOptions = {}): string {
   const enriched = enrich(findings);
-  const mergeWorthy = enriched.filter((f) => f.meta.tier === "merge-worthy");
-  const reportOnly = enriched.filter((f) => f.meta.tier === "report-only");
+  const contents = new Map((opts.files ?? []).map((f) => [f.path, f.content]));
 
-  const errors = enriched.filter((f) => f.severity === "error").length;
-  const warnings = enriched.filter((f) => f.severity === "warning").length;
-  const infos = enriched.filter((f) => f.severity === "info").length;
+  const mergeWorthy = enriched.filter((f) => f.meta.tier === "merge-worthy");
+  const quickWins = mergeWorthy.filter((f) => f.meta.fixKind === "deterministic");
+  const needsReview = mergeWorthy.filter((f) => f.meta.fixKind === "guidance");
+
+  // De-noise: drop a report-only finding only when a specific merge-worthy
+  // finding supersedes it on the *same* entity (e.g. "unused variable" is noise
+  // when that variable is already flagged as a hardcoded secret). Kept narrow
+  // so unrelated hygiene on a shared job entity is not lost.
+  const mwOnEntity = new Set(mergeWorthy.filter((f) => f.entity).map((f) => `${f.file}:${f.entity}:${f.checkId}`));
+  const isSuperseded = (f: EnrichedFinding): boolean => {
+    const supers = SUPERSEDED_BY[f.checkId];
+    if (!supers || !f.entity) return false;
+    return supers.some((id) => mwOnEntity.has(`${f.file}:${f.entity}:${id}`));
+  };
+  const reportOnly = enriched.filter((f) => f.meta.tier === "report-only" && !isSuperseded(f));
+
+  const shown = [...quickWins, ...needsReview, ...reportOnly];
+  const errors = shown.filter((f) => f.severity === "error").length;
+  const warnings = shown.filter((f) => f.severity === "warning").length;
+  const infos = shown.filter((f) => f.severity === "info").length;
 
   const lines: string[] = ["# CI security audit"];
   if (opts.target) lines.push("", `Target: ${opts.target}`);
   lines.push("");
 
-  if (enriched.length === 0) {
-    lines.push("No issues found.", "");
-    lines.push("---", "Generated by [chant audit](https://intentius.io/chant/).", "");
+  if (shown.length === 0) {
+    lines.push("No issues found.", "", "---", "Generated by [chant audit](https://intentius.io/chant/).", "");
     return lines.join("\n");
   }
 
   lines.push(
-    `${enriched.length} finding${enriched.length === 1 ? "" : "s"} — ` +
-      `${mergeWorthy.length} merge-worthy, ${reportOnly.length} report-only ` +
+    `${shown.length} finding${shown.length === 1 ? "" : "s"} — ` +
+      `${quickWins.length} quick-win, ${needsReview.length} needs-review, ${reportOnly.length} report-only ` +
       `(${errors} error, ${warnings} warning, ${infos} info).`,
     "",
   );
 
-  if (mergeWorthy.length > 0) lines.push(...renderMergeWorthy(mergeWorthy));
-  if (reportOnly.length > 0) lines.push(...renderReportOnly(reportOnly));
+  // Quick wins lead, expanded. Needs-review and hygiene collapse so a pasted
+  // report opens on the actionable fix.
+  if (quickWins.length > 0) lines.push(...renderQuickWins(quickWins, contents, opts.resolveSha));
+  if (needsReview.length > 0) {
+    lines.push("<details>", `<summary>Needs review (guidance) — ${needsReview.length}</summary>`, "");
+    lines.push(...renderNeedsReview(needsReview));
+    lines.push("</details>", "");
+  }
+  if (reportOnly.length > 0) {
+    lines.push("<details>", `<summary>Report-only (hygiene) — ${reportOnly.length}</summary>`, "");
+    lines.push(...renderReportOnly(reportOnly));
+    lines.push("</details>", "");
+  }
 
   lines.push("---", "Generated by [chant audit](https://intentius.io/chant/).", "");
   return lines.join("\n");

--- a/packages/core/src/cli/commands/audit.test.ts
+++ b/packages/core/src/cli/commands/audit.test.ts
@@ -69,6 +69,27 @@ describe("auditCommand", () => {
     expect(result.findings.some((f) => f.checkId === "GHA033")).toBe(true);
   });
 
+  test("remote markdown audit inlines a pin diff using resolved SHAs", async () => {
+    const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64");
+    const sha = "11bd71901bbe5b1630ceea73d27597364c9af683";
+    const yaml = "name: CI\non:\n  push:\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n";
+    const impl = (async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("/commits/v4")) return new Response(JSON.stringify({ sha }), { status: 200 });
+      if (u.includes("/contents/.github/workflows/ci.yml")) {
+        return new Response(JSON.stringify({ name: "ci.yml", path: ".github/workflows/ci.yml", type: "file", content: b64(yaml), encoding: "base64" }), { status: 200 });
+      }
+      if (u.includes("/contents/.github/workflows")) {
+        return new Response(JSON.stringify([{ name: "ci.yml", path: ".github/workflows/ci.yml", type: "file", size: 100 }]), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const result = await auditCommand({ path: "https://github.com/acme/widgets", format: "markdown", fetchImpl: impl });
+    expect(result.output).toContain(`actions/checkout@${sha}`);
+    expect(result.output).toContain("```diff");
+  });
+
   test("a non-allowlisted URL fails cleanly", async () => {
     const result = await auditCommand({ path: "https://evil.example.com/o/r" });
     expect(result.success).toBe(false);

--- a/packages/core/src/cli/commands/audit.ts
+++ b/packages/core/src/cli/commands/audit.ts
@@ -10,7 +10,9 @@ import { join, relative } from "path";
 import { auditFiles, type AuditInput, type AuditFinding, type AuditLexicon } from "../../audit/core";
 import { RULE_CATALOG } from "../../audit/catalog";
 import { renderMarkdown } from "../../audit/report";
-import { fetchCiFiles, FetchError } from "../../audit/fetch";
+import { fetchCiFiles, resolveActionSha, FetchError } from "../../audit/fetch";
+import { extractUnpinnedActions } from "../../audit/proof";
+import type { ProveOptions } from "../../audit/proof";
 import type { Severity } from "../../lint/rule";
 
 export type AuditFormat = "stylish" | "json" | "sarif" | "markdown";
@@ -179,9 +181,34 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
     case "sarif":
       output = renderSarif(findings);
       break;
-    case "markdown":
-      output = renderMarkdown(findings, { target: options.path });
+    case "markdown": {
+      // For remote audits, resolve action SHAs so pin fixes render as inline
+      // diffs. Pre-resolved into a sync map; render stays synchronous.
+      let resolveSha: ProveOptions["resolveSha"];
+      if (isUrl) {
+        const token = options.token ?? process.env.CHANT_AUDIT_TOKEN ?? process.env.GITHUB_TOKEN;
+        const refs = new Map<string, { action: string; ref: string }>();
+        for (const inp of inputs) {
+          for (const a of extractUnpinnedActions(inp.content)) refs.set(`${a.action}@${a.ref}`, a);
+        }
+        const resolved = await Promise.all(
+          [...refs.values()].map(async (a) => {
+            const key = `${a.action}@${a.ref}`;
+            const sha = await resolveActionSha(a.action, a.ref, { token, fetchImpl: options.fetchImpl });
+            return [key, sha] as [string, string | undefined];
+          }),
+        );
+        const shaMap = new Map<string, string>();
+        for (const [key, sha] of resolved) if (sha) shaMap.set(key, sha);
+        if (shaMap.size > 0) resolveSha = (action, ref) => shaMap.get(`${action}@${ref}`);
+      }
+      output = renderMarkdown(findings, {
+        target: options.path,
+        files: inputs.map((i) => ({ path: i.path, content: i.content })),
+        resolveSha,
+      });
       break;
+    }
     default:
       output = renderStylish(findings, scanned);
   }


### PR DESCRIPTION
Part of #350. Closes #366. Follow-up to #352.

Turns the flat finding list into an actionable artifact.

## Changes
- **Quick wins (deterministic)** lead the report: one combined unified `diff` per file (from `proof.ts`), so it's a ready-to-apply patch. Pin fixes show inline diffs when a SHA is available, else list as "needs a value".
- **Split merge-worthy by fixKind** — quick-wins vs needs-review.
- **Cluster guidance findings** by primary authority — the three `pull_request_target` rules now read as one "Preventing pwn requests" concern.
- **Collapsibles** — needs-review + report-only wrap in `<details>` so a pasted report opens on the actionable fix.
- **SHA resolution for URL audits** — `fetch.resolveActionSha` queries the GitHub API; the command pre-resolves into a sync map so pin fixes render as inline diffs remotely (render stays synchronous).
- **Precise de-noise** — a report-only finding superseded by a specific merge-worthy rule on the *same entity* (WGL021 unused-var ⊃ WGL016 secret) is dropped; unrelated hygiene on a shared job entity is kept.

## Verified
Local audit leads with the `write-all → contents: read` diff; WGL021 suppressed, GHA022 kept; pwn findings clustered. 55 audit tests (incl. remote markdown audit inlining a pin diff via resolved SHA). `just build`, `eslint` green.