### PR TITLE
fix(github): GHA021/029 false-positive on SHA-pinned actions with a comment (#368)

### DIFF
--- a/lexicons/github/src/lint/post-synth/gha021.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha021.test.ts
@@ -50,6 +50,21 @@ jobs:
     expect(diags).toHaveLength(0);
   });
 
+  test("does not flag a SHA pin with a trailing version comment", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - run: echo test
+`;
+    const diags = gha021.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
   test("does not flag non-checkout actions", () => {
     const yaml = `name: CI
 on:

--- a/lexicons/github/src/lint/post-synth/gha029.test.ts
+++ b/lexicons/github/src/lint/post-synth/gha029.test.ts
@@ -64,6 +64,21 @@ jobs:
     expect(diags).toHaveLength(0);
   });
 
+  test("does not flag a SHA pin with a trailing version comment", () => {
+    const yaml = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b # v4.0.2
+      - run: echo build
+`;
+    const diags = gha029.check(makeCtx(yaml));
+    expect(diags).toHaveLength(0);
+  });
+
   test("does not flag actions/checkout (owned by GHA021)", () => {
     const yaml = `name: CI
 on:

--- a/lexicons/github/src/lint/post-synth/yaml-helpers.ts
+++ b/lexicons/github/src/lint/post-synth/yaml-helpers.ts
@@ -86,7 +86,7 @@ export function extractJobs(yaml: string): Map<string, ParsedJob> {
         const stepNameMatch = stepEntry.match(/name:\s+(.+)$/m);
         if (usesMatch || runMatch) {
           job.steps.push({
-            uses: usesMatch?.[1]?.trim().replace(/^'|'$/g, ""),
+            uses: usesMatch?.[1] ? stripUsesComment(usesMatch[1].trim().replace(/^'|'$/g, "")) : undefined,
             run: runMatch?.[1]?.trim(),
             name: stepNameMatch?.[1]?.trim().replace(/^'|'$/g, ""),
           });
@@ -453,7 +453,17 @@ export function grantsWrite(perms: PermissionsValue): boolean {
  * Returns undefined for local (`./`, `../`) and `docker://` references, which
  * are not GitHub action repository references.
  */
-export function parseActionUses(uses: string): { owner: string; repo: string; slug: string; gitRef: string } | undefined {
+/**
+ * Strip a trailing inline YAML comment from a `uses:` value. A `uses` ref
+ * cannot contain whitespace, so `<ref> # v1.2.3` (the recommended SHA-pin
+ * style) is safe to trim back to `<ref>`.
+ */
+export function stripUsesComment(uses: string): string {
+  return uses.replace(/\s+#.*$/, "").trim();
+}
+
+export function parseActionUses(rawUses: string): { owner: string; repo: string; slug: string; gitRef: string } | undefined {
+  const uses = stripUsesComment(rawUses);
   if (uses.startsWith("./") || uses.startsWith("../") || uses.startsWith("docker://")) return undefined;
   const at = uses.lastIndexOf("@");
   const path = at === -1 ? uses : uses.slice(0, at);


### PR DESCRIPTION
Closes #368. Found by running `chant audit` on a real, fully SHA-pinned repo (expressjs/express) — it was wrongly told to pin its already-pinned actions.

## Root cause
`uses: actions/checkout@<40-sha> # v6.0.2` (the recommended pin style Dependabot emits) was parsed keeping the trailing comment, so the git ref read as `<sha> # v6.0.2` and failed the 40-hex SHA test → GHA021 + GHA029 fired.

## Fix
Strip the inline YAML comment (`/\s+#.*$/`) from the `uses` value in `extractJobs` and `parseActionUses` (new `stripUsesComment` helper). A `uses` ref can't contain whitespace, so this is safe; also helps GHA031 and the migrate path which use `parseActionUses`.

## Verified
- Before: express → GHA021×5, GHA029×3 (all false). After: **0 pin findings** (just timeout hygiene).
- 2 regression tests added (`@<sha> # comment` must not trigger GHA021/029).
- All 455 github lexicon tests + 55 audit tests pass; eslint clean.