### PR TITLE
fix(audit): don't list an already-patched finding as needs-a-value (#370)

### DIFF
--- a/packages/core/src/audit/proof.ts
+++ b/packages/core/src/audit/proof.ts
@@ -29,13 +29,21 @@ export interface ProofResult {
   diff?: string;
   /** Guidance/explanation when not applied (guidance fix, no-op, or needs-sha). */
   note?: string;
+  /**
+   * Why the result is what it is:
+   *  - applied: a fix was produced
+   *  - noop: nothing to fix (issue absent, or already resolved by a prior fix)
+   *  - needs-input: deterministic but blocked on external input (e.g. a SHA)
+   *  - guidance: not auto-fixable; needs human judgement
+   */
+  reason: "applied" | "noop" | "needs-input" | "guidance";
 }
 
 const SHA_RE = /^[0-9a-f]{40}$/;
 const USES_RE = /^(\s*-?\s*uses:\s*)([^@\s'"]+)@([^\s'"#]+)(.*)$/;
 
-function notApplied(checkId: string, note: string): ProofResult {
-  return { checkId, applied: false, note };
+function notApplied(checkId: string, reason: "noop" | "needs-input" | "guidance", note: string): ProofResult {
+  return { checkId, applied: false, reason, note };
 }
 
 /** Extract unpinned `uses: action@ref` references (deduped) from workflow YAML. */
@@ -100,7 +108,7 @@ function narrowWriteAll(content: string): { patched: string; changed: boolean } 
 export function proveFix(checkId: string, content: string, opts: ProveOptions = {}): ProofResult {
   const cat = RULE_CATALOG[checkId];
   if (cat && cat.fixKind !== "deterministic") {
-    return notApplied(checkId, cat.remediation || "Manual fix required.");
+    return notApplied(checkId, "guidance", cat.remediation || "Manual fix required.");
   }
 
   let result: { patched: string; changed: boolean; needsSha?: boolean };
@@ -109,7 +117,7 @@ export function proveFix(checkId: string, content: string, opts: ProveOptions = 
     case "GHA029":
       result = pinActions(content, opts);
       if (!result.changed && (result as { needsSha?: boolean }).needsSha) {
-        return notApplied(checkId, "A commit SHA is required to pin; resolve it (e.g. via the fetch layer) and re-run.");
+        return notApplied(checkId, "needs-input", "A commit SHA is required to pin; resolve it (e.g. via the fetch layer) and re-run.");
       }
       break;
     case "GHA017":
@@ -119,15 +127,16 @@ export function proveFix(checkId: string, content: string, opts: ProveOptions = 
       result = narrowWriteAll(content);
       break;
     default:
-      return notApplied(checkId, cat?.remediation || "No deterministic fix implemented for this rule yet.");
+      return notApplied(checkId, "needs-input", cat?.remediation || "No deterministic fix implemented for this rule yet.");
   }
 
   if (!result.changed) {
-    return notApplied(checkId, "Nothing to fix — the issue is not present (no-op).");
+    return notApplied(checkId, "noop", "Nothing to fix — the issue is not present (no-op).");
   }
   return {
     checkId,
     applied: true,
+    reason: "applied",
     patched: result.patched,
     diff: unifiedDiff(content, result.patched),
   };

--- a/packages/core/src/audit/report.test.ts
+++ b/packages/core/src/audit/report.test.ts
@@ -53,6 +53,19 @@ describe("renderMarkdown — reworked structure", () => {
     expect(out).toContain(`actions/checkout@${sha}`);
   });
 
+  test("does not list a finding already resolved by the combined patch", () => {
+    const sha = "11bd71901bbe5b1630ceea73d27597364c9af683";
+    const content = "name: CI\non:\n  push:\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - uses: acme/deploy-action@v1\n";
+    const findings: AuditFinding[] = [
+      { checkId: "GHA021", severity: "warning", message: "unpinned checkout.", file: ".github/workflows/ci.yml", lexicon: "github", entity: "build" },
+      { checkId: "GHA029", severity: "warning", message: "unpinned acme.", file: ".github/workflows/ci.yml", lexicon: "github", entity: "build" },
+    ];
+    const out = renderMarkdown(findings, { files: [{ path: ".github/workflows/ci.yml", content }], resolveSha: () => sha });
+    // Both actions pinned in one combined diff; neither listed as "needs a value".
+    expect(out).toContain("```diff");
+    expect(out).not.toContain("Needs a value before it can be auto-patched");
+  });
+
   test("guidance findings cluster by authority", () => {
     const out = renderMarkdown(FINDINGS);
     expect(out).toContain("<summary>Needs review (guidance)");

--- a/packages/core/src/audit/report.ts
+++ b/packages/core/src/audit/report.ts
@@ -104,10 +104,12 @@ function renderQuickWins(
         if (res.applied && res.patched !== undefined) {
           patched = res.patched;
           addressed.push(id);
-        } else {
-          // Couldn't auto-patch (e.g. pin needs a SHA) — surface as guidance.
+        } else if (res.reason === "needs-input") {
+          // Deterministic but blocked on input (e.g. pin needs a SHA).
           needsInput.push(...group.filter((f) => f.checkId === id));
         }
+        // reason "noop" (already resolved by a prior fix in the combined patch)
+        // is intentionally dropped — not listed as needing attention.
       }
     }
 


### PR DESCRIPTION
Closes #370. Found demoing on chalk/chalk: the combined quick-win patch pinned all actions in the GHA021 pass, so GHA029 no-opped but was still listed under 'Needs a value'. `ProofResult` now carries a `reason` (applied/noop/needs-input/guidance); the report lists only `needs-input` and drops no-ops. Regression test added; audit suite + eslint green.