### PR TITLE
fix(audit): host-specific tokens, GitHub token no longer breaks GitLab/Codeberg (#372)

### DIFF
--- a/packages/core/src/cli/commands/audit.test.ts
+++ b/packages/core/src/cli/commands/audit.test.ts
@@ -1,10 +1,21 @@
 import { describe, test, expect } from "vitest";
 import { fileURLToPath } from "url";
-import { auditCommand, discoverCiFiles } from "./audit";
+import { auditCommand, discoverCiFiles, tokenForHost } from "./audit";
 
 const REPO = fileURLToPath(new URL("./__fixtures__/audit-repo", import.meta.url));
 
 describe("auditCommand", () => {
+  test("selects a host-specific token (no cross-host leakage)", () => {
+    const env = { GITHUB_TOKEN: "gh", GITLAB_TOKEN: "gl", CODEBERG_TOKEN: "cb" } as unknown as NodeJS.ProcessEnv;
+    expect(tokenForHost("https://github.com/o/r", env)).toBe("gh");
+    expect(tokenForHost("https://gitlab.com/o/r", env)).toBe("gl");
+    expect(tokenForHost("https://codeberg.org/o/r", env)).toBe("cb");
+    // A GitHub token is never offered to other hosts.
+    const onlyGh = { GITHUB_TOKEN: "gh" } as unknown as NodeJS.ProcessEnv;
+    expect(tokenForHost("https://gitlab.com/o/r", onlyGh)).toBeUndefined();
+    expect(tokenForHost("https://codeberg.org/o/r", onlyGh)).toBeUndefined();
+  });
+
   test("discovers CI files under a repo root", () => {
     const files = discoverCiFiles(REPO);
     expect(files.map((f) => f.path)).toContain(".github/workflows/ci.yml");

--- a/packages/core/src/cli/commands/audit.ts
+++ b/packages/core/src/cli/commands/audit.ts
@@ -44,6 +44,34 @@ export interface AuditCommandResult {
   error?: string;
 }
 
+/**
+ * Select the fetch token for a repo host. Tokens are host-specific — a GitHub
+ * PAT sent to GitLab/Codeberg is rejected (401) — so we never cross hosts.
+ */
+export function tokenForHost(url: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
+  let host: string;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
+  switch (host) {
+    case "gitlab.com":
+      return env.GITLAB_TOKEN ?? env.CHANT_AUDIT_GITLAB_TOKEN;
+    case "codeberg.org":
+      return env.CODEBERG_TOKEN ?? env.CHANT_AUDIT_CODEBERG_TOKEN;
+    case "github.com":
+      return env.GITHUB_TOKEN ?? env.CHANT_AUDIT_GITHUB_TOKEN;
+    default:
+      return undefined;
+  }
+}
+
+/** GitHub token used for action-SHA resolution (always queries api.github.com). */
+function githubToken(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return env.GITHUB_TOKEN ?? env.CHANT_AUDIT_GITHUB_TOKEN;
+}
+
 function isYaml(name: string): boolean {
   return name.endsWith(".yml") || name.endsWith(".yaml");
 }
@@ -150,7 +178,7 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
   if (isUrl) {
     try {
       inputs = await fetchCiFiles(options.path, {
-        token: options.token ?? process.env.CHANT_AUDIT_TOKEN ?? process.env.GITHUB_TOKEN,
+        token: options.token ?? tokenForHost(options.path),
         fetchImpl: options.fetchImpl,
       });
     } catch (err) {
@@ -186,7 +214,9 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
       // diffs. Pre-resolved into a sync map; render stays synchronous.
       let resolveSha: ProveOptions["resolveSha"];
       if (isUrl) {
-        const token = options.token ?? process.env.CHANT_AUDIT_TOKEN ?? process.env.GITHUB_TOKEN;
+        // Action SHAs always resolve against api.github.com, so use the GitHub
+        // token regardless of which host the repo lives on.
+        const token = githubToken();
         const refs = new Map<string, { action: string; ref: string }>();
         for (const inp of inputs) {
           for (const a of extractUnpinnedActions(inp.content)) refs.set(`${a.action}@${a.ref}`, a);


### PR DESCRIPTION
Closes #372. Found auditing real GitLab/Codeberg repos with `GITHUB_TOKEN` exported — the GitHub PAT was sent to those hosts and rejected (401).

Fix: `tokenForHost` selects the fetch token per host (`GITHUB_TOKEN`/`GITLAB_TOKEN`/`CODEBERG_TOKEN`), never crossing hosts. Action-SHA resolution still uses the GitHub token (always api.github.com). Dropped the cross-host `CHANT_AUDIT_TOKEN` fallback.

Verified live with `GITHUB_TOKEN` set: github (chalk), gitlab (gitlab-org/cli, 26 findings), codeberg (forgejo/forgejo, 64) all audit cleanly. Unit test asserts no cross-host token leakage; 57 audit tests + eslint green.