### PR TITLE
feat(audit): deterministic image-digest pinning GHA030/WGL031 (#375)

### DIFF
--- a/packages/core/src/audit/fetch.test.ts
+++ b/packages/core/src/audit/fetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { fetchCiFiles, parseRepoUrl, resolveActionSha, FetchError } from "./fetch";
+import { fetchCiFiles, parseRepoUrl, resolveActionSha, resolveImageDigest, parseImageRef, FetchError } from "./fetch";
 
 const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64");
 const CI_YAML = "name: CI\non:\n  push:\npermissions: write-all\njobs:\n  build:\n    runs-on: ubuntu-latest\n";
@@ -133,5 +133,50 @@ describe("resolveActionSha", () => {
   test("rejects a non-SHA response", async () => {
     const { impl } = fakeFetch([{ match: "/commits/", make: () => new Response(JSON.stringify({ sha: "not-a-sha" }), { status: 200 }) }]);
     expect(await resolveActionSha("acme/action", "v1", { fetchImpl: impl })).toBeUndefined();
+  });
+});
+
+describe("parseImageRef", () => {
+  test("bare Docker Hub official image", () => {
+    expect(parseImageRef("node:20")).toEqual({ registry: "registry-1.docker.io", repository: "library/node", tag: "20" });
+  });
+  test("Docker Hub org image, default tag", () => {
+    expect(parseImageRef("acme/app")).toEqual({ registry: "registry-1.docker.io", repository: "acme/app", tag: "latest" });
+  });
+  test("ghcr image with registry host", () => {
+    expect(parseImageRef("ghcr.io/owner/img:1.2")).toEqual({ registry: "ghcr.io", repository: "owner/img", tag: "1.2" });
+  });
+  test("already-digested ref returns undefined", () => {
+    expect(parseImageRef("node@sha256:" + "a".repeat(64))).toBeUndefined();
+  });
+});
+
+describe("resolveImageDigest", () => {
+  const DIGEST = "sha256:" + "c".repeat(64);
+
+  test("resolves via the registry v2 bearer-token challenge", async () => {
+    const challenge = 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/node:pull"';
+    const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("auth.docker.io/token")) return new Response(JSON.stringify({ token: "t" }), { status: 200 });
+      if (u.includes("/v2/library/node/manifests/20")) {
+        const hasAuth = Boolean((init?.headers as Record<string, string>)?.Authorization);
+        return hasAuth
+          ? new Response(null, { status: 200, headers: { "docker-content-digest": DIGEST } })
+          : new Response(null, { status: 401, headers: { "www-authenticate": challenge } });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    expect(await resolveImageDigest("node:20", { fetchImpl: impl })).toBe(DIGEST);
+  });
+
+  test("skips a non-allowlisted registry (SSRF guard)", async () => {
+    let called = false;
+    const impl = (async () => {
+      called = true;
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+    expect(await resolveImageDigest("evil.internal/x:1", { fetchImpl: impl })).toBeUndefined();
+    expect(called).toBe(false);
   });
 });

--- a/packages/core/src/audit/fetch.ts
+++ b/packages/core/src/audit/fetch.ts
@@ -206,6 +206,108 @@ export async function resolveActionSha(
   }
 }
 
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+
+/** Public registries we'll talk to. The image ref is untrusted (SSRF guard). */
+const ALLOWED_REGISTRIES = new Set([
+  "registry-1.docker.io",
+  "ghcr.io",
+  "quay.io",
+  "gcr.io",
+  "public.ecr.aws",
+  "mcr.microsoft.com",
+  "registry.gitlab.com",
+]);
+
+interface ImageRef {
+  registry: string;
+  repository: string;
+  tag: string;
+}
+
+/** Parse a Docker/OCI image reference. Returns undefined if already digested. */
+export function parseImageRef(ref: string): ImageRef | undefined {
+  if (ref.includes("@")) return undefined; // already digest-pinned
+  let registry = "registry-1.docker.io";
+  let rest = ref;
+  let repoPrefix = "";
+  const firstSlash = ref.indexOf("/");
+  const firstPart = firstSlash === -1 ? "" : ref.slice(0, firstSlash);
+  if (firstPart && (firstPart.includes(".") || firstPart.includes(":") || firstPart === "localhost")) {
+    registry = firstPart;
+    rest = ref.slice(firstSlash + 1);
+  } else if (firstSlash === -1) {
+    repoPrefix = "library/"; // bare Docker Hub official image
+  }
+  let tag = "latest";
+  const lastColon = rest.lastIndexOf(":");
+  const lastSlash = rest.lastIndexOf("/");
+  if (lastColon > lastSlash) {
+    tag = rest.slice(lastColon + 1);
+    rest = rest.slice(0, lastColon);
+  }
+  if (!rest) return undefined;
+  return { registry, repository: repoPrefix + rest, tag };
+}
+
+/** Parse a `Bearer realm=...,service=...,scope=...` challenge into a token URL. */
+function tokenUrlFromChallenge(header: string): string | undefined {
+  const m = /Bearer\s+(.*)/i.exec(header);
+  if (!m) return undefined;
+  const params: Record<string, string> = {};
+  for (const part of m[1].split(",")) {
+    const kv = /(\w+)="([^"]*)"/.exec(part.trim());
+    if (kv) params[kv[1]] = kv[2];
+  }
+  if (!params.realm) return undefined;
+  const url = new URL(params.realm);
+  if (params.service) url.searchParams.set("service", params.service);
+  if (params.scope) url.searchParams.set("scope", params.scope);
+  return url.toString();
+}
+
+/**
+ * Resolve a container image `name:tag` to its `sha256:...` digest via the OCI
+ * registry v2 API (anonymous bearer-token challenge). Returns undefined on any
+ * failure or for a non-allowlisted registry. The image ref is untrusted, so we
+ * only ever contact allowlisted public registries (SSRF guard).
+ */
+export async function resolveImageDigest(
+  image: string,
+  opts: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<string | undefined> {
+  const parsed = parseImageRef(image);
+  if (!parsed || !ALLOWED_REGISTRIES.has(parsed.registry)) return undefined;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const ms = opts.timeoutMs ?? DEFAULTS.timeoutMs;
+  const accept = [
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+  ].join(", ");
+  const manifestUrl = `https://${parsed.registry}/v2/${parsed.repository}/manifests/${encodeURIComponent(parsed.tag)}`;
+
+  try {
+    let res = await doFetch(manifestUrl, { headers: { Accept: accept }, redirect: "error", signal: timeoutSignal(ms) });
+    if (res.status === 401) {
+      const tokenUrl = tokenUrlFromChallenge(res.headers.get("www-authenticate") ?? "");
+      if (!tokenUrl) return undefined;
+      const tokRes = await doFetch(tokenUrl, { redirect: "error", signal: timeoutSignal(ms) });
+      if (!tokRes.ok) return undefined;
+      const tok = (await tokRes.json()) as { token?: string; access_token?: string };
+      const bearer = tok.token ?? tok.access_token;
+      if (!bearer) return undefined;
+      res = await doFetch(manifestUrl, { headers: { Accept: accept, Authorization: `Bearer ${bearer}` }, redirect: "error", signal: timeoutSignal(ms) });
+    }
+    if (!res.ok) return undefined;
+    const digest = res.headers.get("docker-content-digest");
+    return digest && DIGEST_RE.test(digest) ? digest : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function fetchGitlab(
   host: HostConfig,
   owner: string,

--- a/packages/core/src/audit/proof.test.ts
+++ b/packages/core/src/audit/proof.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { proveFix, unifiedDiff } from "./proof";
+import { proveFix, unifiedDiff, extractUnpinnedImages } from "./proof";
 
 const WF = `name: CI
 on:
@@ -71,6 +71,47 @@ describe("proveFix — permissions", () => {
     expect(res.applied).toBe(true);
     expect(res.patched).toContain("permissions:\n  contents: read");
     expect(res.patched).not.toContain("write-all");
+  });
+});
+
+describe("proveFix — pin image digest (GHA030/WGL031)", () => {
+  const WF_IMG = `name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:20
+`;
+  const digest = "sha256:" + "a".repeat(64);
+
+  test("pins an image to a digest and the diff shows only that line", () => {
+    const res = proveFix("GHA030", WF_IMG, { resolveDigest: () => digest });
+    expect(res.applied).toBe(true);
+    expect(res.patched).toContain(`image: node:20@${digest}`);
+    const removed = res.diff!.split("\n").filter((l) => l.startsWith("-") && !l.startsWith("---"));
+    const added = res.diff!.split("\n").filter((l) => l.startsWith("+") && !l.startsWith("+++"));
+    expect(removed).toEqual(["-      image: node:20"]);
+    expect(added).toEqual([`+      image: node:20@${digest}`]);
+  });
+
+  test("needs a value when no digest can be resolved", () => {
+    const res = proveFix("GHA030", WF_IMG, { resolveDigest: () => undefined });
+    expect(res.applied).toBe(false);
+    expect(res.reason).toBe("needs-input");
+  });
+
+  test("WGL031 uses the same image-pin fix", () => {
+    const gl = "build:\n  image: python:3.12\n  script:\n    - echo hi\n";
+    const res = proveFix("WGL031", gl, { resolveDigest: () => digest });
+    expect(res.applied).toBe(true);
+    expect(res.patched).toContain(`image: python:3.12@${digest}`);
+  });
+
+  test("extractUnpinnedImages finds pinnable images, skips digested/variable", () => {
+    const content = "image: node:20\nimage: foo@sha256:" + "b".repeat(64) + "\nimage: $REG/x:1\n";
+    expect(extractUnpinnedImages(content)).toEqual(["node:20"]);
   });
 });
 

--- a/packages/core/src/audit/proof.ts
+++ b/packages/core/src/audit/proof.ts
@@ -17,6 +17,8 @@ import { RULE_CATALOG } from "./catalog";
 export interface ProveOptions {
   /** Resolve an action ref (e.g. "actions/checkout@v4") to a 40-char SHA. */
   resolveSha?: (action: string, ref: string) => string | undefined;
+  /** Resolve a container image (e.g. "node:20") to a "sha256:..." digest. */
+  resolveDigest?: (image: string) => string | undefined;
 }
 
 export interface ProofResult {
@@ -41,6 +43,7 @@ export interface ProofResult {
 
 const SHA_RE = /^[0-9a-f]{40}$/;
 const USES_RE = /^(\s*-?\s*uses:\s*)([^@\s'"]+)@([^\s'"#]+)(.*)$/;
+const IMAGE_RE = /^(\s*image:\s*)(["']?)([^\s"'#]+)\2(.*)$/;
 
 function notApplied(checkId: string, reason: "noop" | "needs-input" | "guidance", note: string): ProofResult {
   return { checkId, applied: false, reason, note };
@@ -84,6 +87,47 @@ function pinActions(content: string, opts: ProveOptions): { patched: string; cha
   return { patched: lines.join("\n"), changed, needsSha };
 }
 
+/** A container image is unpinnable here if it lacks a digest and isn't a variable. */
+function isPinnableImage(ref: string): boolean {
+  return !ref.includes("@sha256:") && !ref.includes("$");
+}
+
+/** Extract unpinned `image:` references (deduped) from CI YAML. */
+export function extractUnpinnedImages(content: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const line of content.split("\n")) {
+    const m = line.match(IMAGE_RE);
+    if (!m) continue;
+    const ref = m[3];
+    if (!isPinnableImage(ref) || seen.has(ref)) continue;
+    seen.add(ref);
+    out.push(ref);
+  }
+  return out;
+}
+
+/** Pin unpinned `image:` references to a digest via the resolver. */
+function pinImages(content: string, opts: ProveOptions): { patched: string; changed: boolean; needsValue: boolean } {
+  const lines = content.split("\n");
+  let changed = false;
+  let needsValue = false;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(IMAGE_RE);
+    if (!m) continue;
+    const [, prefix, , ref, rest] = m;
+    if (!isPinnableImage(ref)) continue;
+    const digest = opts.resolveDigest?.(ref);
+    if (!digest) {
+      needsValue = true;
+      continue;
+    }
+    lines[i] = `${prefix}${ref}@${digest}${rest.replace(/\s*#.*$/, "")}`;
+    changed = true;
+  }
+  return { patched: lines.join("\n"), changed, needsValue };
+}
+
 /** Insert a least-privilege top-level permissions block if absent. */
 function addPermissions(content: string): { patched: string; changed: boolean } {
   if (/^permissions:/m.test(content)) return { patched: content, changed: false };
@@ -120,6 +164,15 @@ export function proveFix(checkId: string, content: string, opts: ProveOptions = 
         return notApplied(checkId, "needs-input", "A commit SHA is required to pin; resolve it (e.g. via the fetch layer) and re-run.");
       }
       break;
+    case "GHA030":
+    case "WGL031": {
+      const r = pinImages(content, opts);
+      if (!r.changed && r.needsValue) {
+        return notApplied(checkId, "needs-input", "A registry digest is required to pin the image; resolve it (e.g. via the fetch layer) and re-run.");
+      }
+      result = r;
+      break;
+    }
     case "GHA017":
       result = addPermissions(content);
       break;

--- a/packages/core/src/audit/report.ts
+++ b/packages/core/src/audit/report.ts
@@ -26,6 +26,8 @@ export interface RenderOptions {
   files?: Array<{ path: string; content: string }>;
   /** Resolve an action ref to a SHA so pin fixes can be diffed. */
   resolveSha?: ProveOptions["resolveSha"];
+  /** Resolve a container image to a digest so image-pin fixes can be diffed. */
+  resolveDigest?: ProveOptions["resolveDigest"];
 }
 
 const SEVERITY_WEIGHT: Record<Severity, number> = { error: 0, warning: 1, info: 2 };
@@ -85,7 +87,7 @@ function byFile<T extends { file: string }>(items: T[]): Map<string, T[]> {
 function renderQuickWins(
   findings: EnrichedFinding[],
   contents: Map<string, string>,
-  resolveSha: ProveOptions["resolveSha"],
+  proveOpts: ProveOptions,
 ): string[] {
   const lines: string[] = ["## Quick wins (deterministic)", "", "Safe mechanical fixes — the diff changes only the flagged lines.", ""];
 
@@ -100,7 +102,7 @@ function renderQuickWins(
 
     if (original !== undefined) {
       for (const id of ids) {
-        const res = proveFix(id, patched ?? original, { resolveSha });
+        const res = proveFix(id, patched ?? original, proveOpts);
         if (res.applied && res.patched !== undefined) {
           patched = res.patched;
           addressed.push(id);
@@ -234,7 +236,9 @@ export function renderMarkdown(findings: AuditFinding[], opts: RenderOptions = {
 
   // Quick wins lead, expanded. Needs-review and hygiene collapse so a pasted
   // report opens on the actionable fix.
-  if (quickWins.length > 0) lines.push(...renderQuickWins(quickWins, contents, opts.resolveSha));
+  if (quickWins.length > 0) {
+    lines.push(...renderQuickWins(quickWins, contents, { resolveSha: opts.resolveSha, resolveDigest: opts.resolveDigest }));
+  }
   if (needsReview.length > 0) {
     lines.push("<details>", `<summary>Needs review (guidance) — ${needsReview.length}</summary>`, "");
     lines.push(...renderNeedsReview(needsReview));

--- a/packages/core/src/cli/commands/audit.ts
+++ b/packages/core/src/cli/commands/audit.ts
@@ -10,8 +10,8 @@ import { join, relative } from "path";
 import { auditFiles, type AuditInput, type AuditFinding, type AuditLexicon } from "../../audit/core";
 import { RULE_CATALOG } from "../../audit/catalog";
 import { renderMarkdown } from "../../audit/report";
-import { fetchCiFiles, resolveActionSha, FetchError } from "../../audit/fetch";
-import { extractUnpinnedActions } from "../../audit/proof";
+import { fetchCiFiles, resolveActionSha, resolveImageDigest, FetchError } from "../../audit/fetch";
+import { extractUnpinnedActions, extractUnpinnedImages } from "../../audit/proof";
 import type { ProveOptions } from "../../audit/proof";
 import type { Severity } from "../../lint/rule";
 
@@ -210,32 +210,46 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
       output = renderSarif(findings);
       break;
     case "markdown": {
-      // For remote audits, resolve action SHAs so pin fixes render as inline
-      // diffs. Pre-resolved into a sync map; render stays synchronous.
+      // For remote audits, resolve action SHAs and image digests so pin fixes
+      // render as inline diffs. Pre-resolved into sync maps; render stays sync.
       let resolveSha: ProveOptions["resolveSha"];
+      let resolveDigest: ProveOptions["resolveDigest"];
       if (isUrl) {
         // Action SHAs always resolve against api.github.com, so use the GitHub
         // token regardless of which host the repo lives on.
         const token = githubToken();
         const refs = new Map<string, { action: string; ref: string }>();
+        const images = new Set<string>();
         for (const inp of inputs) {
           for (const a of extractUnpinnedActions(inp.content)) refs.set(`${a.action}@${a.ref}`, a);
+          for (const img of extractUnpinnedImages(inp.content)) images.add(img);
         }
-        const resolved = await Promise.all(
-          [...refs.values()].map(async (a) => {
-            const key = `${a.action}@${a.ref}`;
-            const sha = await resolveActionSha(a.action, a.ref, { token, fetchImpl: options.fetchImpl });
-            return [key, sha] as [string, string | undefined];
-          }),
-        );
+        const [resolvedShas, resolvedDigests] = await Promise.all([
+          Promise.all(
+            [...refs.values()].map(async (a) => {
+              const sha = await resolveActionSha(a.action, a.ref, { token, fetchImpl: options.fetchImpl });
+              return [`${a.action}@${a.ref}`, sha] as [string, string | undefined];
+            }),
+          ),
+          Promise.all(
+            [...images].map(async (img) => {
+              const digest = await resolveImageDigest(img, { fetchImpl: options.fetchImpl });
+              return [img, digest] as [string, string | undefined];
+            }),
+          ),
+        ]);
         const shaMap = new Map<string, string>();
-        for (const [key, sha] of resolved) if (sha) shaMap.set(key, sha);
+        for (const [key, sha] of resolvedShas) if (sha) shaMap.set(key, sha);
         if (shaMap.size > 0) resolveSha = (action, ref) => shaMap.get(`${action}@${ref}`);
+        const digestMap = new Map<string, string>();
+        for (const [img, digest] of resolvedDigests) if (digest) digestMap.set(img, digest);
+        if (digestMap.size > 0) resolveDigest = (img) => digestMap.get(img);
       }
       output = renderMarkdown(findings, {
         target: options.path,
         files: inputs.map((i) => ({ path: i.path, content: i.content })),
         resolveSha,
+        resolveDigest,
       });
       break;
     }


### PR DESCRIPTION
Part of #350. Closes #375. Closes the last deterministic-fix gap.

## What
- `fetch.resolveImageDigest(image)` — resolves `name:tag` → `sha256:...` via the OCI registry v2 API (generic `WWW-Authenticate` bearer-token challenge). Works for Docker Hub, ghcr.io, quay.io, gcr.io, registry.gitlab.com.
- **SSRF guard**: the image ref is untrusted, so only an allowlist of public registries is contacted; unknown/private registries are skipped (→ "needs a value").
- `proof.pinImages` rewrites `image: foo:tag` → `image: foo:tag@sha256:...`; GHA030/WGL031 route through it. `resolveDigest` threaded through the report quick-wins and pre-resolved in the `audit` command for URL audits (sync map, like action SHAs).

## Verified live
- Resolver: `node:20`, `python:3.12`, `ghcr.io/astral-sh/uv` all resolve.
- Real audit — **fdroid/fdroidclient** WGL031 quick-win pins `debian:trixie-slim` (Docker Hub) and `registry.gitlab.com/...` images to real digests in one diff, stripping a trailing `# TODO` comment.
- **forgejo/website** uses a private `data.forgejo.org` registry → correctly falls back to "needs a value" (not allowlisted).

## Tests
67 audit tests: `parseImageRef`, mocked registry challenge flow, SSRF skip, `pinImages` diff, `extractUnpinnedImages`. `just build` + eslint green.