### PR TITLE
feat(audit): --output flag + friendly missing-lexicon error (#379)

### DIFF
--- a/packages/core/src/audit/core.ts
+++ b/packages/core/src/audit/core.ts
@@ -68,19 +68,33 @@ function dedupeById(checks: PostSynthCheck[]): PostSynthCheck[] {
  * checks. Forgejo workflows are GitHub-dialect YAML, so the GitHub security
  * tier is run against them in addition to Forgejo's own checks.
  */
+/** Thrown when a lexicon package the audit needs isn't installed. */
+export class MissingLexiconError extends Error {}
+
+async function load(names: string[]): Promise<Awaited<ReturnType<typeof loadPlugins>>> {
+  try {
+    return await loadPlugins(names);
+  } catch (err) {
+    const pkgs = names.map((n) => `@intentius/chant-lexicon-${n}`).join(" ");
+    throw new MissingLexiconError(
+      `Missing lexicon package needed to audit ${names.join("/")} workflows. Install it with: npm i ${pkgs}\n(${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+}
+
 async function defaultChecksProvider(lexicon: AuditLexicon): Promise<PostSynthCheck[]> {
   const cached = checksCache.get(lexicon);
   if (cached) return cached;
 
   let checks: PostSynthCheck[];
   if (lexicon === "forgejo") {
-    const [forgejo, github] = await loadPlugins(["forgejo", "github"]);
+    const [forgejo, github] = await load(["forgejo", "github"]);
     checks = dedupeById([
       ...(forgejo?.postSynthChecks?.() ?? []),
       ...(github?.postSynthChecks?.() ?? []),
     ]);
   } else {
-    const [plugin] = await loadPlugins([lexicon]);
+    const [plugin] = await load([lexicon]);
     checks = plugin?.postSynthChecks?.() ?? [];
   }
 

--- a/packages/core/src/cli/commands/audit.test.ts
+++ b/packages/core/src/cli/commands/audit.test.ts
@@ -1,7 +1,10 @@
 import { describe, test, expect } from "vitest";
 import { fileURLToPath } from "url";
 import { auditCommand, discoverCiFiles, tokenForHost, coverageNotes } from "./audit";
-import type { AuditInput } from "../../audit/core";
+import { MissingLexiconError, type AuditInput } from "../../audit/core";
+import { readFileSync, existsSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 const REPO = fileURLToPath(new URL("./__fixtures__/audit-repo", import.meta.url));
 
@@ -61,6 +64,29 @@ describe("auditCommand", () => {
     const mw = await auditCommand({ path: REPO, tier: "merge-worthy" });
     expect(mw.findings.length).toBeLessThanOrEqual(all.findings.length);
     expect(mw.findings.some((f) => f.checkId === "GHA022")).toBe(false); // report-only
+  });
+
+  test("writes the report to --output instead of returning it for stdout", async () => {
+    const out = join(tmpdir(), `chant-audit-test-${process.pid}.md`);
+    if (existsSync(out)) rmSync(out);
+    const result = await auditCommand({ path: REPO, format: "markdown", output: out });
+    expect(result.success).toBe(true);
+    expect(result.wroteTo).toBe(out);
+    expect(existsSync(out)).toBe(true);
+    expect(readFileSync(out, "utf-8")).toContain("# CI security audit");
+    rmSync(out);
+  });
+
+  test("surfaces a friendly error when a lexicon package is missing", async () => {
+    const result = await auditCommand({
+      path: REPO,
+      checksProvider: async () => {
+        throw new MissingLexiconError("Missing lexicon package needed to audit github workflows. Install it with: npm i @intentius/chant-lexicon-github");
+      },
+    });
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toMatch(/npm i @intentius\/chant-lexicon-github/);
   });
 
   test("a path with no CI files succeeds with a clear message", async () => {

--- a/packages/core/src/cli/commands/audit.ts
+++ b/packages/core/src/cli/commands/audit.ts
@@ -5,9 +5,9 @@
  * directly and runs the real post-synth checks via the audit core.
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "fs";
 import { join, relative } from "path";
-import { auditFiles, type AuditInput, type AuditFinding, type AuditLexicon } from "../../audit/core";
+import { auditFiles, type AuditInput, type AuditFinding, type AuditLexicon, type ChecksProvider } from "../../audit/core";
 import { RULE_CATALOG } from "../../audit/catalog";
 import { renderMarkdown } from "../../audit/report";
 import { fetchCiFiles, resolveActionSha, resolveImageDigest, FetchError } from "../../audit/fetch";
@@ -31,6 +31,10 @@ export interface AuditCommandOptions {
   token?: string;
   /** Injectable fetch for testing remote audits. */
   fetchImpl?: typeof fetch;
+  /** Write the rendered report to this file instead of returning it for stdout. */
+  output?: string;
+  /** Injectable post-synth checks provider (testing). */
+  checksProvider?: ChecksProvider;
 }
 
 export interface AuditCommandResult {
@@ -42,6 +46,8 @@ export interface AuditCommandResult {
   scanned: string[];
   exitCode: number;
   error?: string;
+  /** Set when the report was written to a file (via `output`). */
+  wroteTo?: string;
 }
 
 /**
@@ -212,7 +218,13 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
     return { success: true, output: `No CI files found under ${options.path}.`, findings: [], scanned: [], exitCode: 0 };
   }
 
-  let findings = await auditFiles(inputs);
+  let findings: AuditFinding[];
+  try {
+    findings = await auditFiles(inputs, { checksProvider: options.checksProvider });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { success: false, output: "", findings: [], scanned, exitCode: 1, error: msg };
+  }
   if (tier === "merge-worthy") findings = findings.filter(isMergeWorthy);
   const notes = coverageNotes(inputs);
 
@@ -273,13 +285,27 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
       output = renderStylish(findings, scanned, notes);
   }
 
-  return { success: true, output, findings, scanned, exitCode: exitCodeFor(findings, failOn) };
+  const exitCode = exitCodeFor(findings, failOn);
+  if (options.output) {
+    try {
+      writeFileSync(options.output, output);
+    } catch (err) {
+      return { success: false, output, findings, scanned, exitCode: 1, error: `Failed to write ${options.output}: ${err instanceof Error ? err.message : String(err)}` };
+    }
+    return { success: true, output, findings, scanned, exitCode, wroteTo: options.output };
+  }
+
+  return { success: true, output, findings, scanned, exitCode };
 }
 
 /** Print an audit result to stdout. */
 export function printAuditResult(result: AuditCommandResult): void {
   if (!result.success) {
     console.error(result.error ?? "Audit failed");
+    return;
+  }
+  if (result.wroteTo) {
+    console.error(`Wrote report to ${result.wroteTo}`);
     return;
   }
   console.log(result.output);

--- a/packages/core/src/cli/handlers/misc.ts
+++ b/packages/core/src/cli/handlers/misc.ts
@@ -29,7 +29,7 @@ export async function runAudit(ctx: CommandContext): Promise<number> {
     return 1;
   }
 
-  const result = await auditCommand({ path: args.path, format, tier, failOn });
+  const result = await auditCommand({ path: args.path, format, tier, failOn, output: args.output });
   printAuditResult(result);
   return result.exitCode;
 }

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -174,7 +174,7 @@ Commands:
   vendor                Pull pinned, checksummed patterns into your repo
   import                Import external template into TypeScript
   audit [path|url]      Audit a repo's CI YAML for security issues
-                        (--format stylish|json|sarif|markdown,
+                        (--format stylish|json|sarif|markdown, -o <file>,
                          --tier merge-worthy|all, --fail-on merge-worthy|warning|none)
   migrate <file>        Translate a workflow between lexicons
                         (default: --from github --to gitlab)


### PR DESCRIPTION
Part of #379 (UX batch).

- **`chant audit -o <file>`** writes the report to a file (the report is the whole point — shell redirection shouldn't be the only way to save it). Implemented in `auditCommand` so it's testable; `printAuditResult` prints a 'Wrote report to …' confirmation.
- **Friendly missing-lexicon error** — `@intentius/chant` core doesn't depend on the CI lexicons, so a clean install previously threw a raw `Cannot find package` from deep in `loadPlugins`. Now `MissingLexiconError` says `npm i @intentius/chant-lexicon-<name>`, and `auditCommand` returns a clean failure.
- Added `output` + `checksProvider` to `AuditCommandOptions` (the latter makes the error path testable).

70 audit tests (incl. --output write + missing-lexicon surfacing); tsc + eslint green. Docs page is the follow-up PR.