### PR TITLE
feat(audit): stable, versioned JSON report contract (#385)

### DIFF
--- a/docs/src/content/docs/cli/audit.mdx
+++ b/docs/src/content/docs/cli/audit.mdx
@@ -59,6 +59,30 @@ Only the root `.gitlab-ci.yml` is fetched; `include:` files are not resolved, so
 
 - `--template my.html` replaces the whole document. Available slots: `{{title}}`, `{{accent}}`, `{{logo}}`, `{{styles}}`, `{{body}}`, `{{footer}}`. The findings render into `{{body}}`.
 
+## Machine-readable output
+
+For tooling, `--format json` emits a **versioned** envelope (stable contract). The same object is embedded in the HTML report inside `<script type="application/json" id="chant-audit-report">`, so the expanded report is both human- and machine-readable.
+
+```json
+{
+  "schemaVersion": "1.0",
+  "tool": { "name": "chant-audit", "version": "0.4.0" },
+  "snapshot": { "target": "...", "host": "github.com", "repo": "owner/repo", "commit": "…", "files": ["..."], "generatedAt": "…", "toolVersion": "0.4.0" },
+  "summary": { "total": 0, "quickWin": 0, "needsReview": 0, "reportOnly": 0, "errors": 0, "warnings": 0, "infos": 0 },
+  "findings": [
+    { "checkId": "GHA033", "severity": "warning", "message": "…", "file": "…", "entity": "…", "lexicon": "github",
+      "tier": "merge-worthy", "fixKind": "deterministic", "title": "…", "remediation": "…", "authority": [{ "name": "…", "url": "…" }] }
+  ]
+}
+```
+
+**Stability contract:**
+
+- Additive changes (new fields) keep the same `schemaVersion`; renamed or removed fields bump it.
+- Consumers should check the **major** version and **ignore unknown fields**.
+- The `snapshot` anchors findings to an exact commit for reproducibility.
+- For maximum stability, integrate via `--format sarif` — an industry-standard, independently-versioned format.
+
 ## Tokens
 
 Auditing a URL calls the host's API. Set a host-specific token to lift rate limits (and, for GitHub, to resolve action SHAs and image digests for the inline fix diffs):

--- a/packages/core/src/audit/report-html.test.ts
+++ b/packages/core/src/audit/report-html.test.ts
@@ -42,6 +42,18 @@ describe("renderHtml", () => {
     expect(html).toContain("chant 0.4.0");
   });
 
+  test("embeds the machine-readable JSON report (parseable, escaped)", () => {
+    const html = renderHtml(FINDINGS, { snapshot: SNAPSHOT });
+    const m = html.match(/<script type="application\/json" id="chant-audit-report">(.*?)<\/script>/s);
+    expect(m).not.toBeNull();
+    // No raw "<" can break out of the script element.
+    expect(m![1]).not.toContain("<");
+    const data = JSON.parse(m![1].replace(/\\u003c/g, "<"));
+    expect(data.schemaVersion).toBe("1.0");
+    expect(data.snapshot.commit).toBe(SNAPSHOT.commit);
+    expect(data.findings.length).toBe(3);
+  });
+
   test("escapes HTML in finding content (no injection)", () => {
     const evil: AuditFinding[] = [
       { checkId: "GHA036", severity: "error", message: "<script>alert(1)</script>", file: "a.yml", lexicon: "github" },

--- a/packages/core/src/audit/report-html.ts
+++ b/packages/core/src/audit/report-html.ts
@@ -9,19 +9,9 @@
  */
 
 import type { AuditFinding } from "./core";
-import { buildReportModel, type BuildModelOptions, type EnrichedFinding, type GuidanceCluster, type QuickWinFile, type ReportCounts } from "./report-model";
+import { buildReportModel, buildReportJson, type AuditSnapshot, type BuildModelOptions, type EnrichedFinding, type GuidanceCluster, type QuickWinFile, type ReportCounts } from "./report-model";
 
-/** A provenance snapshot of what was audited (anchors findings to a commit). */
-export interface AuditSnapshot {
-  target: string;
-  host?: string;
-  repo?: string;
-  ref?: string;
-  commit?: string;
-  files: string[];
-  generatedAt: string;
-  toolVersion: string;
-}
+export type { AuditSnapshot } from "./report-model";
 
 /** Customizable theme knobs filled into the template. */
 export interface ReportTheme {
@@ -177,14 +167,20 @@ export function renderHtml(findings: AuditFinding[], opts: RenderHtmlOptions = {
   const logo = theme.logo ? (/^https?:\/\//.test(theme.logo) ? `<img class="logo" src="${esc(theme.logo)}" alt="">` : theme.logo) : "";
   const footer = theme.footer ?? DEFAULT_FOOTER;
 
+  // Machine-readable data embedded so the HTML report is also parseable.
+  // `<` escaped so the JSON can't break out of the <script> element.
+  const dataJson = JSON.stringify(buildReportJson(findings, { snapshot: opts.snapshot }), null, 0).replace(/</g, "\\u003c");
+  const dataScript = `<script type="application/json" id="chant-audit-report">${dataJson}</script>`;
+
   let body: string;
   if (model.counts.total === 0) {
-    body = renderHeader(model.counts, opts.snapshot, opts.notes ?? []) + `<section><p>No issues found.</p></section>`;
+    body = renderHeader(model.counts, opts.snapshot, opts.notes ?? []) + `<section><p>No issues found.</p></section>` + dataScript;
   } else {
     const parts = [renderHeader(model.counts, opts.snapshot, opts.notes ?? [])];
     if (model.quickWins.length > 0) parts.push(renderQuickWins(model.quickWins));
     if (model.needsReview.length > 0) parts.push(renderNeedsReview(model.needsReview, model.counts.needsReview));
     if (model.reportOnly.length > 0) parts.push(renderReportOnly(model.reportOnly, model.counts.reportOnly));
+    parts.push(dataScript);
     body = parts.join("\n");
   }
 

--- a/packages/core/src/audit/report-model.ts
+++ b/packages/core/src/audit/report-model.ts
@@ -6,9 +6,17 @@
  */
 
 import type { AuditFinding } from "./core";
-import { RULE_CATALOG, type RuleMeta, type Tier } from "./catalog";
+import { RULE_CATALOG, type Authority, type FixKind, type RuleMeta, type Tier } from "./catalog";
 import { proveFix, unifiedDiff, type ProveOptions } from "./proof";
 import type { Severity } from "../lint/rule";
+
+/**
+ * Version of the machine-readable JSON report. Stability contract: additive
+ * changes (new fields) keep the same major; renamed/removed fields bump the
+ * major. Consumers should check the major and ignore unknown fields. See
+ * `docs/cli/audit`.
+ */
+export const REPORT_SCHEMA_VERSION = "1.0";
 
 export const SEVERITY_WEIGHT: Record<Severity, number> = { error: 0, warning: 1, info: 2 };
 
@@ -54,6 +62,44 @@ export interface ReportModel {
   quickWins: QuickWinFile[];
   needsReview: GuidanceCluster[];
   reportOnly: EnrichedFinding[];
+  /** All shown findings (after de-noise), flat and sorted — for serialization. */
+  findings: EnrichedFinding[];
+}
+
+/** Provenance snapshot of what was audited (anchors findings to a commit). */
+export interface AuditSnapshot {
+  target: string;
+  host?: string;
+  repo?: string;
+  ref?: string;
+  commit?: string;
+  files: string[];
+  generatedAt: string;
+  toolVersion: string;
+}
+
+/** A finding flattened for the machine-readable JSON report. */
+export interface SerializedFinding {
+  checkId: string;
+  severity: Severity;
+  message: string;
+  file: string;
+  entity?: string;
+  lexicon: string;
+  tier: Tier;
+  fixKind: FixKind;
+  title: string;
+  remediation: string;
+  authority: Authority[];
+}
+
+/** The versioned machine-readable audit report. */
+export interface AuditReportJson {
+  schemaVersion: string;
+  tool: { name: string; version: string };
+  snapshot?: AuditSnapshot;
+  summary: ReportCounts;
+  findings: SerializedFinding[];
 }
 
 export function metaFor(id: string): RuleMeta {
@@ -196,5 +242,31 @@ export function buildReportModel(findings: AuditFinding[], opts: BuildModelOptio
     quickWins: buildQuickWins(quickWinFindings, contents, { resolveSha: opts.resolveSha, resolveDigest: opts.resolveDigest }),
     needsReview: buildClusters(needsReviewFindings),
     reportOnly: [...reportOnly].sort(sortFindings),
+    findings: [...shown].sort(sortFindings),
+  };
+}
+
+/** Build the versioned, machine-readable JSON report (stable contract). */
+export function buildReportJson(findings: AuditFinding[], opts: { snapshot?: AuditSnapshot; toolVersion?: string } = {}): AuditReportJson {
+  const model = buildReportModel(findings);
+  const version = opts.toolVersion ?? opts.snapshot?.toolVersion ?? "0.0.0";
+  return {
+    schemaVersion: REPORT_SCHEMA_VERSION,
+    tool: { name: "chant-audit", version },
+    snapshot: opts.snapshot,
+    summary: model.counts,
+    findings: model.findings.map((f) => ({
+      checkId: f.checkId,
+      severity: f.severity,
+      message: f.message,
+      file: f.file,
+      entity: f.entity,
+      lexicon: f.lexicon,
+      tier: f.meta.tier,
+      fixKind: f.meta.fixKind,
+      title: f.meta.title,
+      remediation: f.meta.remediation,
+      authority: f.meta.authority ?? [],
+    })),
   };
 }

--- a/packages/core/src/cli/commands/audit.test.ts
+++ b/packages/core/src/cli/commands/audit.test.ts
@@ -45,11 +45,20 @@ describe("auditCommand", () => {
     expect(result.output).toContain("Merge-worthy:");
   });
 
-  test("--json emits parseable findings", async () => {
-    const result = await auditCommand({ path: REPO, format: "json" });
+  test("--json emits the versioned envelope with snapshot, summary, findings", async () => {
+    const result = await auditCommand({ path: REPO, format: "json", toolVersion: "0.4.0" });
     const parsed = JSON.parse(result.output);
+    expect(parsed.schemaVersion).toBe("1.0");
+    expect(parsed.tool).toEqual({ name: "chant-audit", version: "0.4.0" });
+    expect(parsed.snapshot.files).toContain(".github/workflows/ci.yml");
+    expect(parsed.snapshot.toolVersion).toBe("0.4.0");
+    expect(parsed.summary.total).toBeGreaterThan(0);
     expect(Array.isArray(parsed.findings)).toBe(true);
-    expect(parsed.scanned).toContain(".github/workflows/ci.yml");
+    // Each finding carries its classification, so consumers can filter.
+    const f = parsed.findings.find((x: { checkId: string }) => x.checkId === "GHA033");
+    expect(f.tier).toBe("merge-worthy");
+    expect(f.fixKind).toBe("deterministic");
+    expect(Array.isArray(f.authority)).toBe(true);
   });
 
   test("--fail-on merge-worthy exits nonzero when merge-worthy findings exist", async () => {

--- a/packages/core/src/cli/commands/audit.ts
+++ b/packages/core/src/cli/commands/audit.ts
@@ -10,7 +10,8 @@ import { join, relative } from "path";
 import { auditFiles, type AuditInput, type AuditFinding, type AuditLexicon, type ChecksProvider } from "../../audit/core";
 import { RULE_CATALOG } from "../../audit/catalog";
 import { renderMarkdown } from "../../audit/report";
-import { renderHtml, type AuditSnapshot, type ReportTheme } from "../../audit/report-html";
+import { renderHtml, type ReportTheme } from "../../audit/report-html";
+import { buildReportJson, type AuditSnapshot } from "../../audit/report-model";
 import { fetchCiFiles, resolveActionSha, resolveImageDigest, resolveRepoCommit, parseRepoUrl, FetchError } from "../../audit/fetch";
 import { extractUnpinnedActions, extractUnpinnedImages } from "../../audit/proof";
 import type { ProveOptions } from "../../audit/proof";
@@ -304,9 +305,11 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
   const files = inputs.map((i) => ({ path: i.path, content: i.content }));
   let output: string;
   switch (format) {
-    case "json":
-      output = JSON.stringify({ scanned, findings }, null, 2);
+    case "json": {
+      const snapshot = await buildSnapshot(options, scanned, isUrl);
+      output = JSON.stringify(buildReportJson(findings, { snapshot, toolVersion: options.toolVersion }), null, 2);
       break;
+    }
     case "sarif":
       output = renderSarif(findings);
       break;


### PR DESCRIPTION
Part of #350. Closes #385. Answers the "tools parsing this could break" concern, especially around the report metadata.

## What
- **Versioned JSON envelope** for `--format json`: `{ schemaVersion: "1.0", tool, snapshot, summary, findings[] }` (was the unversioned `{ scanned, findings }`).
- The **snapshot** (host/repo/commit/files/timestamp/version) is now part of the machine-readable contract, not just rendered into HTML.
- Each finding carries `tier`/`fixKind`/`title`/`remediation`/`authority` so consumers filter without re-deriving from the catalog.
- The same JSON is **embedded in the HTML** report (`<script type="application/json" id="chant-audit-report">`, `<`-escaped) — expanded report is human- *and* machine-readable.

## Stability policy (documented)
Additive fields keep the major; renames/removals bump `schemaVersion`; consumers check the major and ignore unknown fields. SARIF recommended for maximum stability. Shared `report-model.ts` builds both the JSON and the rendered reports, so they stay consistent.

Pre-release, so changing the json shape now to establish the contract is intentional.

77 audit tests (envelope shape, embedded-and-escaped HTML data, snapshot in JSON); tsc, eslint, astro build green.