### PR TITLE
feat(audit): k8s manifests pilot (#390)

### DIFF
--- a/docs/src/content/docs/cli/audit.mdx
+++ b/docs/src/content/docs/cli/audit.mdx
@@ -21,6 +21,7 @@ What it scans:
 - `.github/workflows/*.{yml,yaml}` (GitHub Actions / Forgejo)
 - `.forgejo/workflows/*.{yml,yaml}` (Forgejo / Codeberg / Gitea)
 - `.gitlab-ci.yml` (GitLab CI)
+- Kubernetes manifests (any `*.{yml,yaml}` with `apiVersion` + `kind`), for a local path — runs the `WK8*`/`ARGO*` checks (privileged containers, host namespaces, hardcoded secrets, image pinning, …)
 
 Every rule a finding cites links to its entry in the [audit rules reference](/chant/lint-rules/audit-rules/).
 

--- a/docs/src/content/docs/lint-rules/audit-rules.mdx
+++ b/docs/src/content/docs/lint-rules/audit-rules.mdx
@@ -616,3 +616,203 @@ Use an action reference Forgejo can resolve (full URL or a mirrored action).
 **GitHub-hosted runner label with no Forgejo equivalent** — merge-worthy · guidance
 
 Use a runner label your Forgejo instance provides.
+
+## Kubernetes (WK8 / ARGO)
+
+Run against Kubernetes manifests.
+
+### ARGO002
+
+**Argo Application references an undeclared AppProject** — merge-worthy · guidance
+
+Declare the named AppProject or reference an existing project.
+
+### ARGO003
+
+**Argo Application targets an unregistered cluster** — merge-worthy · guidance
+
+Point spec.destination at a registered cluster or the in-cluster target.
+
+### ARGO005
+
+**Argo source.path may not resolve** — report-only · guidance
+
+Ensure the source path exists under the build root.
+
+### WK8005
+
+**Hardcoded secret in env var** — merge-worthy · guidance
+
+Use a secretKeyRef instead of a literal value, and rotate the secret.
+
+Authority: [Kubernetes — Good practices for Secrets](https://kubernetes.io/docs/concepts/security/secrets-good-practices/)
+
+### WK8006
+
+**Image uses :latest or no tag** — merge-worthy · guidance
+
+Pin the image to an explicit version tag (ideally a digest).
+
+Authority: [OSSF Scorecard — Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
+
+### WK8041
+
+**Hardcoded API key in env var** — merge-worthy · guidance
+
+Move the key to a Secret and rotate it.
+
+Authority: [Kubernetes — Good practices for Secrets](https://kubernetes.io/docs/concepts/security/secrets-good-practices/)
+
+### WK8042
+
+**Private key stored in a ConfigMap** — merge-worthy · guidance
+
+Store private keys in a Secret, not a ConfigMap.
+
+Authority: [Kubernetes — Good practices for Secrets](https://kubernetes.io/docs/concepts/security/secrets-good-practices/)
+
+### WK8101
+
+**Deployment selector does not match template labels** — merge-worthy · guidance
+
+Align spec.selector with the pod template labels.
+
+### WK8102
+
+**Resource missing metadata labels** — report-only · guidance
+
+Add metadata labels for filtering and tooling.
+
+### WK8103
+
+**Container missing name** — merge-worthy · guidance
+
+Add the required container `name`.
+
+### WK8104
+
+**Container ports not named** — report-only · guidance
+
+Name ports for clearer Service/NetworkPolicy config.
+
+### WK8105
+
+**imagePullPolicy not explicit** — report-only · guidance
+
+Set imagePullPolicy explicitly to avoid surprising defaults.
+
+### WK8201
+
+**Container missing resource limits** — report-only · guidance
+
+Set CPU and memory limits.
+
+### WK8202
+
+**Privileged container** — merge-worthy · guidance
+
+Remove privileged: true; grant only the specific capabilities needed.
+
+Authority: [Kubernetes — Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+
+### WK8203
+
+**Root filesystem is writable** — merge-worthy · guidance
+
+Set readOnlyRootFilesystem: true.
+
+Authority: [Kubernetes — Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+
+### WK8204
+
+**Container may run as root** — merge-worthy · guidance
+
+Set runAsNonRoot: true (and a non-zero runAsUser).
+
+Authority: [Kubernetes — Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+
+### WK8205
+
+**Capabilities not dropped** — merge-worthy · guidance
+
+drop: [ALL] and add back only what is required.
+
+Authority: [Kubernetes — Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+
+### WK8207
+
+**Pod uses host network** — merge-worthy · guidance
+
+Remove hostNetwork; it bypasses network isolation.
+
+Authority: [Kubernetes — Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+
+### WK8208
+
+**Pod shares host PID namespace** — merge-worthy · guidance
+
+Remove hostPID.
+
+Authority: [Kubernetes — Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+
+### WK8209
+
+**Pod shares host IPC namespace** — merge-worthy · guidance
+
+Remove hostIPC.
+
+Authority: [Kubernetes — Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+
+### WK8301
+
+**Container missing probes** — report-only · guidance
+
+Add liveness and readiness probes.
+
+### WK8302
+
+**Deployment has a single replica** — report-only · guidance
+
+Use replicas >= 2 for availability.
+
+### WK8303
+
+**No PodDisruptionBudget for an HA Deployment** — report-only · guidance
+
+Add a PDB to protect availability during disruptions.
+
+### WK8304
+
+**SSL redirect without a certificate** — report-only · guidance
+
+Provide a certificate and HTTPS listen-ports for the ssl-redirect annotation.
+
+### WK8305
+
+**Ingress backend port does not match the Service** — merge-worthy · guidance
+
+Point the Ingress backend at a declared Service port.
+
+### WK8306
+
+**Container command starts with a flag** — merge-worthy · guidance
+
+The first command element should be a binary, not a flag.
+
+### WK8401
+
+**shmSize exceeds the container memory limit** — merge-worthy · guidance
+
+Lower shmSize or raise the memory limit so the pod can schedule.
+
+### WK8402
+
+**RayCluster missing spec.rayVersion** — report-only · guidance
+
+Set spec.rayVersion so KubeRay picks the right autoscaler image.
+
+### WK8403
+
+**rayVersion does not match the head image tag** — report-only · guidance
+
+Align spec.rayVersion with the Ray version in the head container image.

--- a/packages/core/src/audit/catalog.test.ts
+++ b/packages/core/src/audit/catalog.test.ts
@@ -4,7 +4,7 @@ import { loadPlugins } from "../cli/plugins";
 
 /** All post-synth check ids the audit can actually surface, from the lexicons. */
 async function realCheckIds(): Promise<Set<string>> {
-  const plugins = await loadPlugins(["github", "gitlab", "forgejo"]);
+  const plugins = await loadPlugins(["github", "gitlab", "forgejo", "k8s"]);
   const ids = new Set<string>();
   for (const plugin of plugins) {
     for (const check of plugin.postSynthChecks?.() ?? []) {

--- a/packages/core/src/audit/catalog.ts
+++ b/packages/core/src/audit/catalog.ts
@@ -74,6 +74,14 @@ const GH_OIDC: Authority = {
   name: "GitHub — Security hardening with OpenID Connect",
   url: "https://docs.github.com/en/actions/concepts/security/openid-connect",
 };
+const K8S_PSS: Authority = {
+  name: "Kubernetes — Pod Security Standards",
+  url: "https://kubernetes.io/docs/concepts/security/pod-security-standards/",
+};
+const K8S_SECRETS: Authority = {
+  name: "Kubernetes — Good practices for Secrets",
+  url: "https://kubernetes.io/docs/concepts/security/secrets-good-practices/",
+};
 
 function meta(
   id: string,
@@ -184,6 +192,37 @@ export const RULE_CATALOG: Record<string, RuleMeta> = {
   // ── Forgejo (WFJ) ──────────────────────────────────────────────────
   WFJ010: meta("WFJ010", M, G, "Unresolved action reference on Forgejo", "Use an action reference Forgejo can resolve (full URL or a mirrored action)."),
   WFJ011: meta("WFJ011", M, G, "GitHub-hosted runner label with no Forgejo equivalent", "Use a runner label your Forgejo instance provides."),
+
+  // ── Kubernetes (WK8 / ARGO) ────────────────────────────────────────
+  ARGO002: meta("ARGO002", M, G, "Argo Application references an undeclared AppProject", "Declare the named AppProject or reference an existing project."),
+  ARGO003: meta("ARGO003", M, G, "Argo Application targets an unregistered cluster", "Point spec.destination at a registered cluster or the in-cluster target."),
+  ARGO005: meta("ARGO005", R, G, "Argo source.path may not resolve", "Ensure the source path exists under the build root."),
+  WK8005: meta("WK8005", M, G, "Hardcoded secret in env var", "Use a secretKeyRef instead of a literal value, and rotate the secret.", [K8S_SECRETS]),
+  WK8006: meta("WK8006", M, G, "Image uses :latest or no tag", "Pin the image to an explicit version tag (ideally a digest).", [SCORECARD_PINNED]),
+  WK8041: meta("WK8041", M, G, "Hardcoded API key in env var", "Move the key to a Secret and rotate it.", [K8S_SECRETS]),
+  WK8042: meta("WK8042", M, G, "Private key stored in a ConfigMap", "Store private keys in a Secret, not a ConfigMap.", [K8S_SECRETS]),
+  WK8101: meta("WK8101", M, G, "Deployment selector does not match template labels", "Align spec.selector with the pod template labels."),
+  WK8102: meta("WK8102", R, G, "Resource missing metadata labels", "Add metadata labels for filtering and tooling."),
+  WK8103: meta("WK8103", M, G, "Container missing name", "Add the required container `name`."),
+  WK8104: meta("WK8104", R, G, "Container ports not named", "Name ports for clearer Service/NetworkPolicy config."),
+  WK8105: meta("WK8105", R, G, "imagePullPolicy not explicit", "Set imagePullPolicy explicitly to avoid surprising defaults."),
+  WK8201: meta("WK8201", R, G, "Container missing resource limits", "Set CPU and memory limits."),
+  WK8202: meta("WK8202", M, G, "Privileged container", "Remove privileged: true; grant only the specific capabilities needed.", [K8S_PSS]),
+  WK8203: meta("WK8203", M, G, "Root filesystem is writable", "Set readOnlyRootFilesystem: true.", [K8S_PSS]),
+  WK8204: meta("WK8204", M, G, "Container may run as root", "Set runAsNonRoot: true (and a non-zero runAsUser).", [K8S_PSS]),
+  WK8205: meta("WK8205", M, G, "Capabilities not dropped", "drop: [ALL] and add back only what is required.", [K8S_PSS]),
+  WK8207: meta("WK8207", M, G, "Pod uses host network", "Remove hostNetwork; it bypasses network isolation.", [K8S_PSS]),
+  WK8208: meta("WK8208", M, G, "Pod shares host PID namespace", "Remove hostPID.", [K8S_PSS]),
+  WK8209: meta("WK8209", M, G, "Pod shares host IPC namespace", "Remove hostIPC.", [K8S_PSS]),
+  WK8301: meta("WK8301", R, G, "Container missing probes", "Add liveness and readiness probes."),
+  WK8302: meta("WK8302", R, G, "Deployment has a single replica", "Use replicas >= 2 for availability."),
+  WK8303: meta("WK8303", R, G, "No PodDisruptionBudget for an HA Deployment", "Add a PDB to protect availability during disruptions."),
+  WK8304: meta("WK8304", R, G, "SSL redirect without a certificate", "Provide a certificate and HTTPS listen-ports for the ssl-redirect annotation."),
+  WK8305: meta("WK8305", M, G, "Ingress backend port does not match the Service", "Point the Ingress backend at a declared Service port."),
+  WK8306: meta("WK8306", M, G, "Container command starts with a flag", "The first command element should be a binary, not a flag."),
+  WK8401: meta("WK8401", M, G, "shmSize exceeds the container memory limit", "Lower shmSize or raise the memory limit so the pod can schedule."),
+  WK8402: meta("WK8402", R, G, "RayCluster missing spec.rayVersion", "Set spec.rayVersion so KubeRay picks the right autoscaler image."),
+  WK8403: meta("WK8403", R, G, "rayVersion does not match the head image tag", "Align spec.rayVersion with the Ray version in the head container image."),
 };
 
 /** Look up catalog metadata for a check id, if known. */

--- a/packages/core/src/audit/core.ts
+++ b/packages/core/src/audit/core.ts
@@ -22,7 +22,7 @@ import type { SerializerResult } from "../serializer";
 import { loadPlugins } from "../cli/plugins";
 
 /** Lexicons whose post-synth checks the auditor knows how to run. */
-export type AuditLexicon = "github" | "gitlab" | "forgejo";
+export type AuditLexicon = "github" | "gitlab" | "forgejo" | "k8s";
 
 /** A single CI file to audit. */
 export interface AuditInput {

--- a/packages/core/src/audit/rules-doc.ts
+++ b/packages/core/src/audit/rules-doc.ts
@@ -9,10 +9,11 @@
 
 import { RULE_CATALOG, type RuleMeta } from "./catalog";
 
-const GROUPS: Array<{ heading: string; prefix: string; blurb: string }> = [
-  { heading: "GitHub Actions (GHA)", prefix: "GHA", blurb: "Also applied to Forgejo workflows, which are GitHub-dialect." },
-  { heading: "GitLab CI (WGL)", prefix: "WGL", blurb: "" },
-  { heading: "Forgejo (WFJ)", prefix: "WFJ", blurb: "" },
+const GROUPS: Array<{ heading: string; prefixes: string[]; blurb: string }> = [
+  { heading: "GitHub Actions (GHA)", prefixes: ["GHA"], blurb: "Also applied to Forgejo workflows, which are GitHub-dialect." },
+  { heading: "GitLab CI (WGL)", prefixes: ["WGL"], blurb: "" },
+  { heading: "Forgejo (WFJ)", prefixes: ["WFJ"], blurb: "" },
+  { heading: "Kubernetes (WK8 / ARGO)", prefixes: ["WK8", "ARGO"], blurb: "Run against Kubernetes manifests." },
 ];
 
 function ruleBlock(m: RuleMeta): string {
@@ -26,8 +27,8 @@ function ruleBlock(m: RuleMeta): string {
 /** Render the full audit rules reference page (frontmatter + body). */
 export function renderRulesReference(): string {
   const ids = Object.keys(RULE_CATALOG).sort();
-  const sections = GROUPS.map(({ heading, prefix, blurb }) => {
-    const blocks = ids.filter((id) => id.startsWith(prefix)).map((id) => ruleBlock(RULE_CATALOG[id]));
+  const sections = GROUPS.map(({ heading, prefixes, blurb }) => {
+    const blocks = ids.filter((id) => prefixes.some((p) => id.startsWith(p))).map((id) => ruleBlock(RULE_CATALOG[id]));
     if (blocks.length === 0) return "";
     return `## ${heading}\n${blurb ? `\n${blurb}\n` : ""}\n${blocks.join("\n\n")}`;
   }).filter(Boolean);

--- a/packages/core/src/cli/commands/__fixtures__/audit-k8s/manifests/deploy.yaml
+++ b/packages/core/src/cli/commands/__fixtures__/audit-k8s/manifests/deploy.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx:latest
+          securityContext:
+            privileged: true

--- a/packages/core/src/cli/commands/audit.test.ts
+++ b/packages/core/src/cli/commands/audit.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { fileURLToPath } from "url";
-import { auditCommand, discoverCiFiles, tokenForHost, coverageNotes } from "./audit";
+import { auditCommand, discoverCiFiles, discoverManifests, tokenForHost, coverageNotes } from "./audit";
 import { MissingLexiconError, type AuditInput } from "../../audit/core";
 import { readFileSync, existsSync, rmSync } from "fs";
 import { tmpdir } from "os";
@@ -28,6 +28,19 @@ describe("auditCommand", () => {
     // github files never produce the gitlab include note
     const gh: AuditInput[] = [{ path: ".github/workflows/ci.yml", content: "on: push\n", lexicon: "github" }];
     expect(coverageNotes(gh)).toEqual([]);
+  });
+
+  test("discovers and audits Kubernetes manifests", async () => {
+    const repo = fileURLToPath(new URL("./__fixtures__/audit-k8s", import.meta.url));
+    const files = discoverManifests(repo);
+    expect(files.map((f) => f.path)).toContain("manifests/deploy.yaml");
+    expect(files.every((f) => f.lexicon === "k8s")).toBe(true);
+
+    const result = await auditCommand({ path: repo, format: "stylish" });
+    expect(result.success).toBe(true);
+    const ids = new Set(result.findings.map((f) => f.checkId));
+    expect(ids).toContain("WK8202"); // privileged container
+    expect(ids).toContain("WK8006"); // :latest image
   });
 
   test("discovers CI files under a repo root", () => {
@@ -99,11 +112,14 @@ describe("auditCommand", () => {
   });
 
   test("a path with no CI files succeeds with a clear message", async () => {
-    const tmp = fileURLToPath(new URL(".", import.meta.url)); // commands dir, no CI files
+    const tmp = join(tmpdir(), `chant-audit-empty-${process.pid}`);
+    const { mkdirSync } = await import("fs");
+    mkdirSync(tmp, { recursive: true });
     const result = await auditCommand({ path: tmp });
     expect(result.success).toBe(true);
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain("No CI files found");
+    rmSync(tmp, { recursive: true, force: true });
   });
 
   test("audits a remote repo URL via injected fetch", async () => {

--- a/packages/core/src/cli/commands/audit.ts
+++ b/packages/core/src/cli/commands/audit.ts
@@ -7,6 +7,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "fs";
 import { join, relative } from "path";
+import { parseYAML } from "../../yaml";
 import { auditFiles, type AuditInput, type AuditFinding, type AuditLexicon, type ChecksProvider } from "../../audit/core";
 import { RULE_CATALOG } from "../../audit/catalog";
 import { renderMarkdown } from "../../audit/report";
@@ -111,6 +112,60 @@ export function discoverCiFiles(root: string): AuditInput[] {
   const gitlab = join(root, ".gitlab-ci.yml");
   if (existsSync(gitlab) && statSync(gitlab).isFile()) {
     inputs.push({ path: ".gitlab-ci.yml", content: readFileSync(gitlab, "utf-8"), lexicon: "gitlab" });
+  }
+  return inputs;
+}
+
+const WALK_SKIP = new Set(["node_modules", ".git", "dist", ".github", ".forgejo"]);
+const MAX_MANIFEST_FILES = 500;
+
+/** Recursively collect YAML file paths under a root, skipping noise dirs. */
+function walkYaml(dir: string, out: string[]): void {
+  if (out.length >= MAX_MANIFEST_FILES) return;
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries.sort((a, b) => (a.name < b.name ? -1 : 1))) {
+    if (out.length >= MAX_MANIFEST_FILES) return;
+    if (e.name.startsWith(".") && e.isDirectory()) continue;
+    if (WALK_SKIP.has(e.name)) continue;
+    const full = join(dir, e.name);
+    if (e.isDirectory()) walkYaml(full, out);
+    else if (isYaml(e.name)) out.push(full);
+  }
+}
+
+/** True if any YAML document in the content is a Kubernetes manifest. */
+function looksLikeK8s(content: string): boolean {
+  for (const doc of content.split(/\n---\n/)) {
+    const t = doc.trim();
+    if (!t) continue;
+    try {
+      const obj = parseYAML(t) as Record<string, unknown>;
+      if (obj && typeof obj.apiVersion === "string" && typeof obj.kind === "string") return true;
+    } catch {
+      // not parseable as a single doc — skip
+    }
+  }
+  return false;
+}
+
+/** Discover Kubernetes manifest files under a repo root (content-detected). */
+export function discoverManifests(root: string): AuditInput[] {
+  const files: string[] = [];
+  walkYaml(root, files);
+  const inputs: AuditInput[] = [];
+  for (const full of files) {
+    let content: string;
+    try {
+      content = readFileSync(full, "utf-8");
+    } catch {
+      continue;
+    }
+    if (looksLikeK8s(content)) inputs.push({ path: relative(root, full), content, lexicon: "k8s" });
   }
   return inputs;
 }
@@ -247,7 +302,7 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
     if (!existsSync(options.path)) {
       return { success: false, output: "", findings: [], scanned: [], exitCode: 1, error: `Path not found: ${options.path}` };
     }
-    inputs = discoverCiFiles(options.path);
+    inputs = [...discoverCiFiles(options.path), ...discoverManifests(options.path)];
   }
 
   const scanned = inputs.map((i) => i.path);


### PR DESCRIPTION
Part of #389. Closes #390. The pilot proving `chant audit` generalizes beyond CI/CD.

## What
- **Discovers Kubernetes manifests** under a local path by content — any YAML doc with `apiVersion` + `kind`, multi-doc aware — via a capped recursive walk that skips `node_modules`/`.git`/`dist`/CI dirs.
- **Runs the k8s checks** (`WK8*`/`ARGO*`) through the existing lexicon-agnostic `auditFiles`. **Format match is clean**: the checks parse manifest YAML from `ctx.outputs` — exactly what users write (no JSON/YAML gap like aws/azure will have).
- **Catalog**: 29 k8s rules tiered — privileged containers, host namespaces, runAsNonRoot, drop-capabilities, hardcoded secrets → merge-worthy with **Pod Security Standards** / Secrets authority; labels/probes/replicas → report-only. Drift test and the rules reference page extended to k8s.
- `AuditLexicon` widened; docs updated.

## Verified
`chant audit <dir>` on a fixture Deployment (privileged + `:latest`) reports WK8202/WK8006/WK8203/204/205, clustered under Pod Security Standards, with rule links resolving to `#wk8202`. 80 audit tests; tsc, eslint, astro build green.

Folds in the minimal #391 foundation for k8s; full pluggable detection across all lexicons remains #391. Next: docker (#393).