### PR TITLE
feat(audit): docker — Dockerfile + Compose (#393)

### DIFF
--- a/docs/src/content/docs/cli/audit.mdx
+++ b/docs/src/content/docs/cli/audit.mdx
@@ -22,6 +22,7 @@ What it scans:
 - `.forgejo/workflows/*.{yml,yaml}` (Forgejo / Codeberg / Gitea)
 - `.gitlab-ci.yml` (GitLab CI)
 - Kubernetes manifests (any `*.{yml,yaml}` with `apiVersion` + `kind`), for a local path — runs the `WK8*`/`ARGO*` checks (privileged containers, host namespaces, hardcoded secrets, image pinning, …)
+- Docker — `Dockerfile`/`*.Dockerfile` and Compose files (`*.{yml,yaml}` with `services:`), for a local path — runs the `DKRD*` checks (root user, `:latest` images, exposed SSH, …)
 
 Every rule a finding cites links to its entry in the [audit rules reference](/chant/lint-rules/audit-rules/).
 

--- a/docs/src/content/docs/lint-rules/audit-rules.mdx
+++ b/docs/src/content/docs/lint-rules/audit-rules.mdx
@@ -816,3 +816,49 @@ Set spec.rayVersion so KubeRay picks the right autoscaler image.
 **rayVersion does not match the head image tag** — report-only · guidance
 
 Align spec.rayVersion with the Ray version in the head container image.
+
+## Docker (DKRD)
+
+Run against Dockerfiles and Compose files.
+
+### DKRD001
+
+**Service uses :latest or untagged image** — merge-worthy · guidance
+
+Pin the image to an explicit version tag (ideally a digest).
+
+Authority: [OSSF Scorecard — Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
+
+### DKRD002
+
+**Named volume declared but unused** — report-only · guidance
+
+Remove the unused volume or mount it in a service.
+
+### DKRD003
+
+**Service exposes SSH (port 22)** — merge-worthy · guidance
+
+Don't expose SSH from a container; use exec/ephemeral access instead.
+
+Authority: [Docker — Security best practices](https://docs.docker.com/develop/security-best-practices/)
+
+### DKRD010
+
+**apt-get install without --no-install-recommends** — report-only · guidance
+
+Add --no-install-recommends to keep images small.
+
+### DKRD011
+
+**ADD used where COPY would do** — report-only · guidance
+
+Prefer COPY unless fetching a URL or extracting an archive.
+
+### DKRD012
+
+**No USER instruction — container runs as root** — merge-worthy · guidance
+
+Add a non-root USER instruction.
+
+Authority: [Docker — Security best practices](https://docs.docker.com/develop/security-best-practices/)

--- a/packages/core/src/audit/catalog.test.ts
+++ b/packages/core/src/audit/catalog.test.ts
@@ -4,7 +4,7 @@ import { loadPlugins } from "../cli/plugins";
 
 /** All post-synth check ids the audit can actually surface, from the lexicons. */
 async function realCheckIds(): Promise<Set<string>> {
-  const plugins = await loadPlugins(["github", "gitlab", "forgejo", "k8s"]);
+  const plugins = await loadPlugins(["github", "gitlab", "forgejo", "k8s", "docker"]);
   const ids = new Set<string>();
   for (const plugin of plugins) {
     for (const check of plugin.postSynthChecks?.() ?? []) {

--- a/packages/core/src/audit/catalog.ts
+++ b/packages/core/src/audit/catalog.ts
@@ -82,6 +82,10 @@ const K8S_SECRETS: Authority = {
   name: "Kubernetes — Good practices for Secrets",
   url: "https://kubernetes.io/docs/concepts/security/secrets-good-practices/",
 };
+const DOCKER_SEC: Authority = {
+  name: "Docker — Security best practices",
+  url: "https://docs.docker.com/develop/security-best-practices/",
+};
 
 function meta(
   id: string,
@@ -223,6 +227,14 @@ export const RULE_CATALOG: Record<string, RuleMeta> = {
   WK8401: meta("WK8401", M, G, "shmSize exceeds the container memory limit", "Lower shmSize or raise the memory limit so the pod can schedule."),
   WK8402: meta("WK8402", R, G, "RayCluster missing spec.rayVersion", "Set spec.rayVersion so KubeRay picks the right autoscaler image."),
   WK8403: meta("WK8403", R, G, "rayVersion does not match the head image tag", "Align spec.rayVersion with the Ray version in the head container image."),
+
+  // ── Docker (DKRD) ──────────────────────────────────────────────────
+  DKRD001: meta("DKRD001", M, G, "Service uses :latest or untagged image", "Pin the image to an explicit version tag (ideally a digest).", [SCORECARD_PINNED]),
+  DKRD002: meta("DKRD002", R, G, "Named volume declared but unused", "Remove the unused volume or mount it in a service."),
+  DKRD003: meta("DKRD003", M, G, "Service exposes SSH (port 22)", "Don't expose SSH from a container; use exec/ephemeral access instead.", [DOCKER_SEC]),
+  DKRD010: meta("DKRD010", R, G, "apt-get install without --no-install-recommends", "Add --no-install-recommends to keep images small."),
+  DKRD011: meta("DKRD011", R, G, "ADD used where COPY would do", "Prefer COPY unless fetching a URL or extracting an archive."),
+  DKRD012: meta("DKRD012", M, G, "No USER instruction — container runs as root", "Add a non-root USER instruction.", [DOCKER_SEC]),
 };
 
 /** Look up catalog metadata for a check id, if known. */

--- a/packages/core/src/audit/core.ts
+++ b/packages/core/src/audit/core.ts
@@ -16,13 +16,14 @@
  * audited YAML — the security tier is YAML-based, so this is by design.
  */
 
+import { basename } from "path";
 import type { Severity } from "../lint/rule";
 import type { PostSynthCheck, PostSynthContext } from "../lint/post-synth";
 import type { SerializerResult } from "../serializer";
 import { loadPlugins } from "../cli/plugins";
 
 /** Lexicons whose post-synth checks the auditor knows how to run. */
-export type AuditLexicon = "github" | "gitlab" | "forgejo" | "k8s";
+export type AuditLexicon = "github" | "gitlab" | "forgejo" | "k8s" | "docker";
 
 /** A single CI file to audit. */
 export interface AuditInput {
@@ -128,7 +129,11 @@ export async function auditFiles(
     for (const file of files) {
       const output: SerializerResult = {
         primary: file.content,
-        files: { [file.path]: file.content },
+        // Key additional files by basename to match how the build pipeline
+        // emits them (e.g. "Dockerfile", "dependabot.yml") — some checks filter
+        // `files` by name (docker's extractDockerfiles wants names starting
+        // with "Dockerfile").
+        files: { [basename(file.path)]: file.content },
       };
       const buildResult: PostSynthContext["buildResult"] = {
         outputs: new Map<string, string | SerializerResult>([[lexicon, output]]),

--- a/packages/core/src/audit/rules-doc.ts
+++ b/packages/core/src/audit/rules-doc.ts
@@ -14,6 +14,7 @@ const GROUPS: Array<{ heading: string; prefixes: string[]; blurb: string }> = [
   { heading: "GitLab CI (WGL)", prefixes: ["WGL"], blurb: "" },
   { heading: "Forgejo (WFJ)", prefixes: ["WFJ"], blurb: "" },
   { heading: "Kubernetes (WK8 / ARGO)", prefixes: ["WK8", "ARGO"], blurb: "Run against Kubernetes manifests." },
+  { heading: "Docker (DKRD)", prefixes: ["DKRD"], blurb: "Run against Dockerfiles and Compose files." },
 ];
 
 function ruleBlock(m: RuleMeta): string {

--- a/packages/core/src/cli/commands/__fixtures__/audit-docker/app/Dockerfile
+++ b/packages/core/src/cli/commands/__fixtures__/audit-docker/app/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:20
+RUN apt-get update && apt-get install -y curl
+COPY . /app
+CMD ["node", "server.js"]

--- a/packages/core/src/cli/commands/__fixtures__/audit-docker/docker-compose.yml
+++ b/packages/core/src/cli/commands/__fixtures__/audit-docker/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  web:
+    image: myapp:latest
+    ports:
+      - "22:22"

--- a/packages/core/src/cli/commands/audit.test.ts
+++ b/packages/core/src/cli/commands/audit.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { fileURLToPath } from "url";
-import { auditCommand, discoverCiFiles, discoverManifests, tokenForHost, coverageNotes } from "./audit";
+import { auditCommand, discoverCiFiles, discoverManifests, discoverDocker, tokenForHost, coverageNotes } from "./audit";
 import { MissingLexiconError, type AuditInput } from "../../audit/core";
 import { readFileSync, existsSync, rmSync } from "fs";
 import { tmpdir } from "os";
@@ -41,6 +41,21 @@ describe("auditCommand", () => {
     const ids = new Set(result.findings.map((f) => f.checkId));
     expect(ids).toContain("WK8202"); // privileged container
     expect(ids).toContain("WK8006"); // :latest image
+  });
+
+  test("discovers and audits Docker artifacts (nested Dockerfile + compose)", async () => {
+    const repo = fileURLToPath(new URL("./__fixtures__/audit-docker", import.meta.url));
+    const files = discoverDocker(repo);
+    const paths = files.map((f) => f.path).sort();
+    expect(paths).toContain("app/Dockerfile");
+    expect(paths).toContain("docker-compose.yml");
+
+    const result = await auditCommand({ path: repo, format: "stylish" });
+    expect(result.success).toBe(true);
+    const ids = new Set(result.findings.map((f) => f.checkId));
+    expect(ids).toContain("DKRD012"); // Dockerfile has no USER (nested — basename-key fix)
+    expect(ids).toContain("DKRD010"); // apt-get without --no-install-recommends
+    expect(ids).toContain("DKRD003"); // compose exposes SSH port 22
   });
 
   test("discovers CI files under a repo root", () => {

--- a/packages/core/src/cli/commands/audit.ts
+++ b/packages/core/src/cli/commands/audit.ts
@@ -6,7 +6,7 @@
  */
 
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "fs";
-import { join, relative } from "path";
+import { join, relative, basename } from "path";
 import { parseYAML } from "../../yaml";
 import { auditFiles, type AuditInput, type AuditFinding, type AuditLexicon, type ChecksProvider } from "../../audit/core";
 import { RULE_CATALOG } from "../../audit/catalog";
@@ -117,11 +117,11 @@ export function discoverCiFiles(root: string): AuditInput[] {
 }
 
 const WALK_SKIP = new Set(["node_modules", ".git", "dist", ".github", ".forgejo"]);
-const MAX_MANIFEST_FILES = 500;
+const MAX_WALK_FILES = 1000;
 
-/** Recursively collect YAML file paths under a root, skipping noise dirs. */
-function walkYaml(dir: string, out: string[]): void {
-  if (out.length >= MAX_MANIFEST_FILES) return;
+/** Recursively collect file paths under a root, skipping noise/dot dirs. */
+function walkFiles(dir: string, out: string[]): void {
+  if (out.length >= MAX_WALK_FILES) return;
   let entries;
   try {
     entries = readdirSync(dir, { withFileTypes: true });
@@ -129,12 +129,20 @@ function walkYaml(dir: string, out: string[]): void {
     return;
   }
   for (const e of entries.sort((a, b) => (a.name < b.name ? -1 : 1))) {
-    if (out.length >= MAX_MANIFEST_FILES) return;
+    if (out.length >= MAX_WALK_FILES) return;
     if (e.name.startsWith(".") && e.isDirectory()) continue;
     if (WALK_SKIP.has(e.name)) continue;
     const full = join(dir, e.name);
-    if (e.isDirectory()) walkYaml(full, out);
-    else if (isYaml(e.name)) out.push(full);
+    if (e.isDirectory()) walkFiles(full, out);
+    else out.push(full);
+  }
+}
+
+function readSafe(full: string): string | undefined {
+  try {
+    return readFileSync(full, "utf-8");
+  } catch {
+    return undefined;
   }
 }
 
@@ -156,16 +164,43 @@ function looksLikeK8s(content: string): boolean {
 /** Discover Kubernetes manifest files under a repo root (content-detected). */
 export function discoverManifests(root: string): AuditInput[] {
   const files: string[] = [];
-  walkYaml(root, files);
+  walkFiles(root, files);
   const inputs: AuditInput[] = [];
   for (const full of files) {
-    let content: string;
-    try {
-      content = readFileSync(full, "utf-8");
-    } catch {
-      continue;
+    if (!isYaml(basename(full))) continue;
+    const content = readSafe(full);
+    if (content !== undefined && looksLikeK8s(content)) {
+      inputs.push({ path: relative(root, full), content, lexicon: "k8s" });
     }
-    if (looksLikeK8s(content)) inputs.push({ path: relative(root, full), content, lexicon: "k8s" });
+  }
+  return inputs;
+}
+
+function isDockerfileName(name: string): boolean {
+  return name === "Dockerfile" || name.startsWith("Dockerfile.") || name.endsWith(".Dockerfile") || name.endsWith(".dockerfile");
+}
+
+function looksLikeCompose(content: string): boolean {
+  try {
+    const obj = parseYAML(content) as Record<string, unknown>;
+    return Boolean(obj) && typeof obj === "object" && "services" in obj;
+  } catch {
+    return false;
+  }
+}
+
+/** Discover Docker artifacts: Dockerfiles (by name) and Compose files (by `services:`). */
+export function discoverDocker(root: string): AuditInput[] {
+  const files: string[] = [];
+  walkFiles(root, files);
+  const inputs: AuditInput[] = [];
+  for (const full of files) {
+    const name = basename(full);
+    const content = readSafe(full);
+    if (content === undefined) continue;
+    if (isDockerfileName(name) || (isYaml(name) && looksLikeCompose(content))) {
+      inputs.push({ path: relative(root, full), content, lexicon: "docker" });
+    }
   }
   return inputs;
 }
@@ -302,7 +337,7 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
     if (!existsSync(options.path)) {
       return { success: false, output: "", findings: [], scanned: [], exitCode: 1, error: `Path not found: ${options.path}` };
     }
-    inputs = [...discoverCiFiles(options.path), ...discoverManifests(options.path)];
+    inputs = [...discoverCiFiles(options.path), ...discoverManifests(options.path), ...discoverDocker(options.path)];
   }
 
   const scanned = inputs.map((i) => i.path);


### PR DESCRIPTION
Part of #389. Closes #393. Second non-CI lexicon.

- Discovers **Dockerfiles** (by name) and **Compose** files (YAML with `services:`); runs `DKRD*` via `auditFiles`.
- **Format match:** compose checks read `services:` from primary; Dockerfile checks read `output.files` filtered to names starting with `Dockerfile`. So the synthetic output's `files` map is now keyed by **basename** (matches the real pipeline) — also making **nested** Dockerfiles discoverable.
- 6 `DKRD` rules catalogued; `walkYaml`→`walkFiles` shared by k8s+docker; drift test, rules reference, docs extended.

Verified on a fixture (nested `app/Dockerfile` + compose): DKRD012/010/001/003. 81 audit tests; tsc, eslint, astro build green. Next: aws (#392).