### PR TITLE
fix(k8s): MonitoredService emits real ServiceMonitor/PrometheusRule kinds (#400)

### DIFF
--- a/lexicons/k8s/src/composites/composites.test.ts
+++ b/lexicons/k8s/src/composites/composites.test.ts
@@ -1689,6 +1689,12 @@ describe("MonitoredService", () => {
     expect(spec.groups[0].rules[0].labels.severity).toBe("critical");
   });
 
+  test("serviceMonitor and prometheusRule emit the correct CRD kind (not Deployment)", () => {
+    const result = MonitoredService({ ...minProps, alertRules: [{ name: "A", expr: "1" }] });
+    expect((result.serviceMonitor as any).entityType).toBe("K8s::Monitoring::ServiceMonitor");
+    expect((result.prometheusRule as any).entityType).toBe("K8s::Monitoring::PrometheusRule");
+  });
+
   test("serviceMonitor has correct selector and endpoint", () => {
     const result = MonitoredService({ ...minProps, metricsPort: 9090, metricsPath: "/metrics", scrapeInterval: "15s" });
     const spec = p(result.serviceMonitor).spec as any;

--- a/lexicons/k8s/src/composites/monitored-service.ts
+++ b/lexicons/k8s/src/composites/monitored-service.ts
@@ -7,7 +7,7 @@
  */
 
 import { Composite, mergeDefaults } from "@intentius/chant";
-import { Deployment, Service } from "../generated";
+import { Deployment, Service, ServiceMonitor, PrometheusRule } from "../generated";
 import type { ContainerSecurityContext } from "./security-context";
 
 export interface AlertRule {
@@ -68,8 +68,8 @@ export interface MonitoredServiceProps {
 export interface MonitoredServiceResult {
   deployment: InstanceType<typeof Deployment>;
   service: InstanceType<typeof Service>;
-  serviceMonitor: InstanceType<typeof Deployment>; // CRD — use Deployment as proxy type
-  prometheusRule?: InstanceType<typeof Deployment>; // CRD — use Deployment as proxy type
+  serviceMonitor: InstanceType<typeof ServiceMonitor>;
+  prometheusRule?: InstanceType<typeof PrometheusRule>;
 }
 
 /**
@@ -175,8 +175,7 @@ export const MonitoredService = Composite<MonitoredServiceProps>((props) => {
     },
   }, defs?.service));
 
-  // ServiceMonitor is a CRD — use Deployment constructor as a generic Declarable wrapper
-  const serviceMonitor = new Deployment(mergeDefaults({
+  const serviceMonitor = new ServiceMonitor(mergeDefaults({
     metadata: {
       name,
       ...(namespace && { namespace }),
@@ -199,7 +198,7 @@ export const MonitoredService = Composite<MonitoredServiceProps>((props) => {
   const result: Record<string, any> = { deployment, service, serviceMonitor };
 
   if (alertRules && alertRules.length > 0) {
-    result.prometheusRule = new Deployment(mergeDefaults({
+    result.prometheusRule = new PrometheusRule(mergeDefaults({
       metadata: {
         name: `${name}-alerts`,
         ...(namespace && { namespace }),

--- a/lexicons/k8s/src/crd/crd-sources.ts
+++ b/lexicons/k8s/src/crd/crd-sources.ts
@@ -93,6 +93,20 @@ const COCKROACH_OPERATOR_CRD_BASE = `https://raw.githubusercontent.com/cockroach
 const CERT_MANAGER_VERSION = "v1.16.2";
 const CERT_MANAGER_CRD_BUNDLE = `https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.crds.yaml`;
 
+/**
+ * Prometheus Operator CRDs — monitoring.coreos.com/v1
+ *
+ * Produces (the `monitoring.coreos.com` group maps to the `Monitoring`
+ * namespace):
+ *   K8s::Monitoring::ServiceMonitor  → apiVersion: monitoring.coreos.com/v1, kind: ServiceMonitor
+ *   K8s::Monitoring::PrometheusRule  → apiVersion: monitoring.coreos.com/v1, kind: PrometheusRule
+ *
+ * Operator install: kube-prometheus-stack chart, or
+ *   https://github.com/prometheus-operator/prometheus-operator
+ */
+const PROM_OPERATOR_VERSION = "v0.79.2";
+const PROM_OPERATOR_CRD_BASE = `https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${PROM_OPERATOR_VERSION}/example/prometheus-operator-crd`;
+
 export const CRD_SOURCES: CRDSource[] = [
   { type: "url", url: `${KUBERAY_CRD_BASE}/ray.io_rayclusters.yaml` },
   { type: "url", url: `${KUBERAY_CRD_BASE}/ray.io_rayjobs.yaml` },
@@ -107,4 +121,6 @@ export const CRD_SOURCES: CRDSource[] = [
   { type: "url", url: `${GATEWAY_API_CRD_BASE}/gateway.networking.k8s.io_referencegrants.yaml` },
   { type: "url", url: `${COCKROACH_OPERATOR_CRD_BASE}/crdb.cockroachlabs.com_crdbclusters.yaml` },
   { type: "url", url: CERT_MANAGER_CRD_BUNDLE },
+  { type: "url", url: `${PROM_OPERATOR_CRD_BASE}/monitoring.coreos.com_servicemonitors.yaml` },
+  { type: "url", url: `${PROM_OPERATOR_CRD_BASE}/monitoring.coreos.com_prometheusrules.yaml` },
 ];


### PR DESCRIPTION
Closes #400.

`MonitoredService` built its ServiceMonitor/PrometheusRule with `new Deployment()` as a CRD proxy. The serializer derives `kind` from the resource **type**, so they emitted `kind: Deployment` with a ServiceMonitor-shaped spec — malformed manifests. The existing test only checked the spec, so it slipped through.

## Fix
- Add the Prometheus Operator CRDs (`monitoring.coreos.com/v1`, v0.79.2) to `crd-sources.ts` → codegen produces typed `K8s::Monitoring::ServiceMonitor` / `PrometheusRule`.
- Switch `MonitoredService` to the typed resources.
- Regression test asserts `entityType`.

## Verified (end-to-end serialize)
```
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
```
855 k8s + audit tests pass; `generated/` is regenerated by CI `prepack` from the new sources.