### PR TITLE
fix(audit): missing-lexicon hint on local audit + docs (#379)

### DIFF
--- a/docs/src/content/docs/cli/audit.mdx
+++ b/docs/src/content/docs/cli/audit.mdx
@@ -135,15 +135,24 @@ Without a token, unauthenticated GitHub is limited to 60 requests/hour and pin f
 
 ## Prerequisites
 
-`chant audit` needs the relevant CI lexicon packages installed alongside `@intentius/chant`:
+`chant audit` runs each lexicon's security checks, so it needs the lexicon packages for the file types you want audited installed alongside `@intentius/chant`:
 
 ```bash
-npm i @intentius/chant-lexicon-github   # GitHub / Forgejo
-npm i @intentius/chant-lexicon-gitlab   # GitLab
+# CI/CD pipelines
+npm i @intentius/chant-lexicon-github   # GitHub Actions (also Forgejo workflows)
+npm i @intentius/chant-lexicon-gitlab   # GitLab CI
 npm i @intentius/chant-lexicon-forgejo  # Forgejo dialect
+
+# Infrastructure & manifests
+npm i @intentius/chant-lexicon-k8s      # Kubernetes manifests
+npm i @intentius/chant-lexicon-helm     # Helm charts
+npm i @intentius/chant-lexicon-docker   # Dockerfiles / Compose
+npm i @intentius/chant-lexicon-aws      # CloudFormation
+npm i @intentius/chant-lexicon-azure    # ARM templates
+npm i @intentius/chant-lexicon-gcp      # Config Connector
 ```
 
-If a needed lexicon is missing, the command tells you which package to install.
+If a needed lexicon package is missing, the command tells you which package to install — either as a friendly error (CI files, detected by path) or, for content-detected file types, as a note when nothing was found.
 
 ## Usage
 

--- a/packages/core/src/audit/discover.test.ts
+++ b/packages/core/src/audit/discover.test.ts
@@ -64,4 +64,9 @@ describe("discoverByDetection (unified, detectTemplate-driven)", () => {
     const plugins = await loadAuditPlugins(["github", "gitlab", "forgejo", "docker", "aws", "azure", "gcp", "helm"]);
     expect(discoverByDetection(fixture("audit-k8s"), plugins).some((i) => i.lexicon === "k8s")).toBe(false);
   });
+
+  test("loadAuditPlugins skips an uninstalled lexicon instead of throwing", async () => {
+    const plugins = await loadAuditPlugins(["github", "definitely-not-a-real-lexicon"]);
+    expect(plugins.map((p) => p.name)).toEqual(["github"]);
+  });
 });

--- a/packages/core/src/cli/commands/audit.ts
+++ b/packages/core/src/cli/commands/audit.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, statSync, writeFileSync } from "fs";
 import { auditFiles, type AuditInput, type AuditFinding, type ChecksProvider } from "../../audit/core";
-import { discoverByDetection, loadAuditPlugins } from "../../audit/discover";
+import { discoverByDetection, loadAuditPlugins, AUDIT_LEXICONS } from "../../audit/discover";
 import { RULE_CATALOG } from "../../audit/catalog";
 import { renderMarkdown } from "../../audit/report";
 import { renderHtml, type ReportTheme } from "../../audit/report-html";
@@ -206,6 +206,10 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
   const isUrl = /^https?:\/\//.test(options.path);
 
   let inputs: AuditInput[];
+  // Content-detected lexicons whose package isn't installed can't be detected
+  // (detection needs the plugin's `detectTemplate`), so a local audit would
+  // silently find nothing. Track the missing packages to turn that into a hint.
+  let missingHint = "";
   if (isUrl) {
     try {
       inputs = await fetchCiFiles(options.path, {
@@ -225,13 +229,20 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
     // (name), and Helm charts (bundle) are handled by discoverByDetection's
     // special-cases since content shape alone can't disambiguate them.
     const plugins = await loadAuditPlugins();
+    const loaded = new Set(plugins.map((p) => p.name));
+    const missing = AUDIT_LEXICONS.filter((n) => !loaded.has(n));
+    if (missing.length > 0) {
+      missingHint =
+        ` Some lexicon packages are not installed, so files of those types were not detected: ${missing.join(", ")}.` +
+        ` Install what you need, e.g. npm i ${missing.map((n) => `@intentius/chant-lexicon-${n}`).join(" ")}`;
+    }
     inputs = discoverByDetection(options.path, plugins);
   }
 
   const scanned = inputs.map((i) => i.path);
 
   if (inputs.length === 0) {
-    return { success: true, output: `No auditable files found under ${options.path}.`, findings: [], scanned: [], exitCode: 0 };
+    return { success: true, output: `No auditable files found under ${options.path}.${missingHint}`, findings: [], scanned: [], exitCode: 0 };
   }
 
   let findings: AuditFinding[];


### PR DESCRIPTION
Addresses the remaining gap in #379.

Auditing the user path showed #379's three original items — docs/discoverability, friendly missing-lexicon error, and `--output` — were **already shipped** by the audit-expansion epic after the issue was filed:
- `docs/src/content/docs/cli/audit.mdx` exists (synopsis, flags, tokens, exit codes), in the sidebar, overview table, and README.
- `MissingLexiconError` with an install hint is thrown by `auditFiles` and surfaced by `auditCommand` (tested).
- `-o, --output <file>` is parsed (`main.ts`), wired, documented, and tested.

What was left is a gap the **unified discovery refactor (#406)** introduced: content-detected lexicons (k8s/aws/azure/gcp/docker/helm) need their plugin installed to be detected at all, so a local audit on a clean standalone install silently reported "No auditable files found" instead of telling the user to install a package. (CI files are path-detected, so they still surface the friendly `MissingLexiconError`.)

## Changes
- **`commands/audit.ts`** — when a local audit finds nothing, append the not-installed audit lexicon packages and an `npm i` command to the empty-result message. The hint only appears when packages are genuinely missing (a full install shows nothing extra).
- **`audit/discover.test.ts`** — test that `loadAuditPlugins` skips an uninstalled lexicon instead of throwing.
- **`cli/audit.mdx`** — widen Prerequisites to list every auditable lexicon (CI + infra/manifests), not just the CI three.

## Verification
- `tsc --noEmit` clean, `eslint` clean
- 30/30 discover + audit tests pass