### PR TITLE
fix(packaging): track @intentius/* peer ranges with the release line (#411)

### DIFF
--- a/justfile
+++ b/justfile
@@ -109,8 +109,14 @@ release bump="patch":
     esac
     next="$major.$minor.$patch"
     echo "Bumping $current → $next"
+    # Bump .version everywhere, and keep the @intentius/* peerDependencies ranges
+    # in lockstep (they were frozen at ^0.1.0, which breaks clean installs — #411).
     for f in packages/core/package.json lexicons/*/package.json; do
-      jq --arg v "$next" '.version = $v' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+      jq --arg v "$next" '
+        .version = $v
+        | if .peerDependencies["@intentius/chant"] then .peerDependencies["@intentius/chant"] = "^" + $v else . end
+        | if .peerDependencies["@intentius/chant-lexicon-github"] then .peerDependencies["@intentius/chant-lexicon-github"] = "^" + $v else . end
+      ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
     done
     git add packages/core/package.json lexicons/*/package.json
     git commit -m "chant-v$next"

--- a/lexicons/aws/package.json
+++ b/lexicons/aws/package.json
@@ -51,6 +51,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.1.0"
+    "@intentius/chant": "^0.7.0"
   }
 }

--- a/lexicons/azure/package.json
+++ b/lexicons/azure/package.json
@@ -50,6 +50,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.1.0"
+    "@intentius/chant": "^0.7.0"
   }
 }

--- a/lexicons/docker/package.json
+++ b/lexicons/docker/package.json
@@ -48,6 +48,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.1.0"
+    "@intentius/chant": "^0.7.0"
   }
 }

--- a/lexicons/forgejo/package.json
+++ b/lexicons/forgejo/package.json
@@ -40,7 +40,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.1.0",
-    "@intentius/chant-lexicon-github": "^0.1.0"
+    "@intentius/chant": "^0.7.0",
+    "@intentius/chant-lexicon-github": "^0.7.0"
   }
 }

--- a/lexicons/gcp/package.json
+++ b/lexicons/gcp/package.json
@@ -52,6 +52,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.1.0"
+    "@intentius/chant": "^0.7.0"
   }
 }

--- a/lexicons/github/package.json
+++ b/lexicons/github/package.json
@@ -47,6 +47,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.1.0"
+    "@intentius/chant": "^0.7.0"
   }
 }

--- a/lexicons/gitlab/package.json
+++ b/lexicons/gitlab/package.json
@@ -48,8 +48,8 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.1.0",
-    "@intentius/chant-lexicon-github": "^0.1.0"
+    "@intentius/chant": "^0.7.0",
+    "@intentius/chant-lexicon-github": "^0.7.0"
   },
   "peerDependenciesMeta": {
     "@intentius/chant-lexicon-github": {

--- a/lexicons/helm/package.json
+++ b/lexicons/helm/package.json
@@ -50,6 +50,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.1.0"
+    "@intentius/chant": "^0.7.0"
   }
 }

--- a/lexicons/k8s/package.json
+++ b/lexicons/k8s/package.json
@@ -51,6 +51,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.1.0"
+    "@intentius/chant": "^0.7.0"
   }
 }

--- a/lexicons/temporal/package.json
+++ b/lexicons/temporal/package.json
@@ -33,7 +33,7 @@
     "prepack": "npm run generate && npm run bundle && npm run validate"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.1.0"
+    "@intentius/chant": "^0.7.0"
   },
   "devDependencies": {
     "@intentius/chant": "*",

--- a/packages/core/src/meta/peer-deps.test.ts
+++ b/packages/core/src/meta/peer-deps.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "vitest";
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { fileURLToPath } from "url";
+import { join } from "path";
+
+/**
+ * The lexicon packages are published in lockstep with core, so their
+ * `@intentius/*` peerDependencies must track the current core version. They were
+ * once frozen at `^0.1.0` while shipping at 0.7.0, which made a clean
+ * `npm install` fail (#411). This locks the invariant so it can't drift again.
+ */
+const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url));
+const coreVersion = JSON.parse(readFileSync(join(repoRoot, "packages/core/package.json"), "utf-8")).version as string;
+const expected = `^${coreVersion}`;
+
+const lexiconsDir = join(repoRoot, "lexicons");
+const lexicons = readdirSync(lexiconsDir).filter((name) => existsSync(join(lexiconsDir, name, "package.json")));
+
+describe("lexicon peerDependencies track the core version", () => {
+  test.each(lexicons)("%s pins @intentius/* peers to the current version", (lexicon) => {
+    const pkg = JSON.parse(readFileSync(join(lexiconsDir, lexicon, "package.json"), "utf-8"));
+    const peers: Record<string, string> = pkg.peerDependencies ?? {};
+    for (const [dep, range] of Object.entries(peers)) {
+      if (dep.startsWith("@intentius/")) {
+        expect(range, `${lexicon}: peer ${dep} should be ${expected}`).toBe(expected);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #411.

## Problem
The lexicon packages declared `peerDependencies: { "@intentius/chant": "^0.1.0" }` (gitlab/forgejo also `@intentius/chant-lexicon-github: ^0.1.0`) but are published at `0.7.0`. A clean install fails:

```
peer @intentius/chant@"^0.1.0" from @intentius/chant-lexicon-github@0.7.0
Could not resolve dependency ... (found @intentius/chant@0.7.0)
```

Root cause: `just release` bumped `.version` everywhere but never touched the peer ranges, so they froze at the initial `^0.1.0`. Found while standing up the #356 hosted service against the published packages.

## Fix
- Bump all 10 lexicons' `@intentius/*` peer ranges to `^0.7.0`.
- `just release` now rewrites the `@intentius/chant` and `@intentius/chant-lexicon-github` peer ranges to `^<next>` on every bump, in lockstep with `.version` — so they can't drift again.
- New meta test (`packages/core/src/meta/peer-deps.test.ts`) asserts every lexicon's `@intentius/*` peers equal `^<core version>` — CI guard against the exact regression.

## Verification
- 10/10 peer-deps meta tests pass.
- Release jq dry-run confirmed: core (no peerDeps) bumps version only; lexicons bump version + peers together.
- Note: `npm i` succeeding without `--legacy-peer-deps` takes effect on the **next publish** (the fix is in source; npm still serves the old `^0.1.0` metadata until then).