### PR TITLE
fix(audit): use redirect: manual in fetch.ts for edge compatibility (#410)

### DIFF
--- a/packages/core/src/audit/fetch.test.ts
+++ b/packages/core/src/audit/fetch.test.ts
@@ -75,6 +75,11 @@ describe("fetchCiFiles", () => {
     await expect(fetchCiFiles("https://github.com/acme/widgets", { fetchImpl: impl })).rejects.toThrow(/redirect/i);
   });
 
+  test("refuses to follow a redirect on the gitlab path", async () => {
+    const { impl } = fakeFetch([{ match: "/repository/files/", make: () => new Response(null, { status: 301 }) }]);
+    await expect(fetchCiFiles("https://gitlab.com/acme/widgets", { fetchImpl: impl })).rejects.toThrow(/redirect/i);
+  });
+
   test("throws on a non-allowlisted host before any fetch", async () => {
     await expect(fetchCiFiles("https://evil.example.com/o/r")).rejects.toThrow(/Host not allowed/);
   });

--- a/packages/core/src/audit/fetch.ts
+++ b/packages/core/src/audit/fetch.ts
@@ -121,7 +121,10 @@ export async function fetchCiFiles(url: string, opts: FetchOptions = {}): Promis
   async function getJson(apiUrl: string): Promise<{ status: number; body: unknown }> {
     let res: Response;
     try {
-      res = await doFetch(apiUrl, { headers, redirect: "error", signal: timeoutSignal(cfg.timeoutMs) });
+      // `redirect: "manual"` (not "error") so we can refuse the redirect ourselves
+      // by inspecting the 3xx below. An off-host redirect is an SSRF vector, and
+      // "error" is unsupported on edge runtimes (Cloudflare Workers).
+      res = await doFetch(apiUrl, { headers, redirect: "manual", signal: timeoutSignal(cfg.timeoutMs) });
     } catch (err) {
       throw new FetchError(`Request failed: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -195,7 +198,7 @@ export async function resolveActionSha(
         Accept: "application/vnd.github+json",
         ...(opts.token ? { Authorization: `Bearer ${opts.token}` } : {}),
       },
-      redirect: "error",
+      redirect: "manual",
       signal: timeoutSignal(opts.timeoutMs ?? DEFAULTS.timeoutMs),
     });
     if (!res.ok) return undefined;
@@ -289,16 +292,16 @@ export async function resolveImageDigest(
   const manifestUrl = `https://${parsed.registry}/v2/${parsed.repository}/manifests/${encodeURIComponent(parsed.tag)}`;
 
   try {
-    let res = await doFetch(manifestUrl, { headers: { Accept: accept }, redirect: "error", signal: timeoutSignal(ms) });
+    let res = await doFetch(manifestUrl, { headers: { Accept: accept }, redirect: "manual", signal: timeoutSignal(ms) });
     if (res.status === 401) {
       const tokenUrl = tokenUrlFromChallenge(res.headers.get("www-authenticate") ?? "");
       if (!tokenUrl) return undefined;
-      const tokRes = await doFetch(tokenUrl, { redirect: "error", signal: timeoutSignal(ms) });
+      const tokRes = await doFetch(tokenUrl, { redirect: "manual", signal: timeoutSignal(ms) });
       if (!tokRes.ok) return undefined;
       const tok = (await tokRes.json()) as { token?: string; access_token?: string };
       const bearer = tok.token ?? tok.access_token;
       if (!bearer) return undefined;
-      res = await doFetch(manifestUrl, { headers: { Accept: accept, Authorization: `Bearer ${bearer}` }, redirect: "error", signal: timeoutSignal(ms) });
+      res = await doFetch(manifestUrl, { headers: { Accept: accept, Authorization: `Bearer ${bearer}` }, redirect: "manual", signal: timeoutSignal(ms) });
     }
     if (!res.ok) return undefined;
     const digest = res.headers.get("docker-content-digest");
@@ -331,7 +334,7 @@ export async function resolveRepoCommit(
       ? `${host.api}/projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/commits?per_page=1`
       : `${host.api}/repos/${owner}/${repo}/commits?per_page=1&limit=1`;
   try {
-    const res = await doFetch(apiUrl, { headers, redirect: "error", signal: timeoutSignal(opts.timeoutMs ?? DEFAULTS.timeoutMs) });
+    const res = await doFetch(apiUrl, { headers, redirect: "manual", signal: timeoutSignal(opts.timeoutMs ?? DEFAULTS.timeoutMs) });
     if (!res.ok) return undefined;
     const body = (await res.json()) as Array<{ sha?: string; id?: string }>;
     if (!Array.isArray(body) || body.length === 0) return undefined;
@@ -356,7 +359,7 @@ async function fetchGitlab(
   const apiUrl = `${host.api}/projects/${projectId}/repository/files/${encodeURIComponent(".gitlab-ci.yml")}/raw${refQ}`;
   let res: Response;
   try {
-    res = await doFetch(apiUrl, { headers, redirect: "error", signal: timeoutSignal(cfg.timeoutMs) });
+    res = await doFetch(apiUrl, { headers, redirect: "manual", signal: timeoutSignal(cfg.timeoutMs) });
   } catch (err) {
     throw new FetchError(`Request failed: ${err instanceof Error ? err.message : String(err)}`);
   }


### PR DESCRIPTION
Closes #410.

## Problem
`fetch.ts` used `redirect: "error"` at 7 sites. The Cloudflare Workers / `workerd` runtime doesn't implement it and throws:

> Invalid redirect value, must be one of "follow" or "manual" — "error" won't be implemented at the edge; use "manual" and check the status.

So remote audits can't run on Workers (a prerequisite for the #356 hosted service).

## Fix
Switch all 7 sites to `redirect: "manual"` + an explicit 3xx rejection — the same "never follow an off-host redirect" posture, made explicit (and what #357's SSRF hardening wants anyway).

This is behavior-preserving on Node: `"error"` already rejected redirects, and the two primary paths (`getJson`, `fetchGitlab`) already had `3xx → throw "Refusing to follow redirect"` guards that were **dead** under `"error"` (the redirect threw first) and are now **live**. Best-effort resolvers (action SHA, image digest, repo commit) reject a 3xx via `!res.ok → undefined`, unchanged.

## Verification
- `tsc` clean, `eslint` clean
- 21 fetch tests pass — existing github redirect-refusal test still green, plus a new gitlab-path redirect-refusal test
- Edge-compat proven in the #356 spike: after this exact swap, the pipeline reached `api.github.com` and ran end-to-end on `workerd`