### PR TITLE
feat(audit): export ./lint/post-synth from barrel lexicons (#417)

### DIFF
--- a/lexicons/aws/package.json
+++ b/lexicons/aws/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"

--- a/lexicons/azure/package.json
+++ b/lexicons/azure/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"

--- a/lexicons/docker/package.json
+++ b/lexicons/docker/package.json
@@ -32,6 +32,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"

--- a/lexicons/forgejo/package.json
+++ b/lexicons/forgejo/package.json
@@ -32,7 +32,8 @@
   },
   "exports": {
     ".": "./src/index.ts",
-    "./*": "./src/*.ts"
+    "./*": "./src/*.ts",
+    "./lint/post-synth": "./src/lint/post-synth/index.ts"
   },
   "devDependencies": {
     "@intentius/chant": "*",

--- a/lexicons/gcp/package.json
+++ b/lexicons/gcp/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"

--- a/lexicons/github/package.json
+++ b/lexicons/github/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"

--- a/lexicons/gitlab/package.json
+++ b/lexicons/gitlab/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"

--- a/lexicons/helm/package.json
+++ b/lexicons/helm/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"

--- a/lexicons/k8s/package.json
+++ b/lexicons/k8s/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"

--- a/lexicons/temporal/package.json
+++ b/lexicons/temporal/package.json
@@ -20,6 +20,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./op/activities": "./src/op/activities/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",

--- a/packages/core/src/codegen/post-synth-barrel-guards.test.ts
+++ b/packages/core/src/codegen/post-synth-barrel-guards.test.ts
@@ -20,6 +20,15 @@ describe("post-synth barrel freshness", () => {
   });
 });
 
+describe("post-synth barrel is exported", () => {
+  // A lexicon that ships a barrel must export it so consumers can import
+  // `@intentius/chant-lexicon-<lex>/lint/post-synth` without `/index` (#417).
+  test.each(lexiconDirs)("%s exports ./lint/post-synth", (lexicon) => {
+    const pkg = JSON.parse(readFileSync(join(lexiconsDir, lexicon, "package.json"), "utf-8"));
+    expect(pkg.exports?.["./lint/post-synth"]).toBe("./src/lint/post-synth/index.ts");
+  });
+});
+
 describe("post-synth barrel is edge-bundle clean", () => {
   // The barrel is the entry an edge/bundled deployment imports. It must not drag
   // in the TypeScript compiler or the fs/tsx runtime loader (#409).


### PR DESCRIPTION
Closes #417. Follow-up from the #356 spike re-validation.

The #409 barrels had to be imported with an explicit `/index` because each lexicon's exports map is `"./*": "./src/*.ts"` (literal substitution, no directory-index resolution). Add a `"./lint/post-synth": "./src/lint/post-synth/index.ts"` export entry to all 10 barrel-bearing lexicons so consumers can `import … from "@intentius/chant-lexicon-<lex>/lint/post-synth"` directly.

- 10 lexicon `package.json` exports updated (entry inserted after `"./*"`, key order preserved).
- Guard test asserts the export exists wherever a `lint/post-synth/index.ts` barrel does.

Verified: the spike worker imports the barrels without `/index` and bundles cleanly on `workerd` (1.87 MiB gzip).