### PR TITLE
feat(audit): remote (URL) audit covers all lexicons, not just CI (#420)

### DIFF
--- a/packages/core/src/audit/discover.ts
+++ b/packages/core/src/audit/discover.ts
@@ -27,7 +27,7 @@
  *     normalized to a JSON string here.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { readdirSync, readFileSync, statSync } from "fs";
 import { basename, join, relative } from "path";
 import { parseYAML } from "../yaml";
 import { loadPlugin } from "../cli/plugins";
@@ -56,12 +56,14 @@ export async function loadAuditPlugins(names: readonly string[] = AUDIT_LEXICONS
   return plugins;
 }
 
-const WALK_SKIP = new Set(["node_modules", ".git", "dist", ".github", ".forgejo"]);
+const WALK_SKIP = new Set(["node_modules", ".git", "dist"]);
+/** Dot-directories the walk descends into anyway (CI lives here). */
+const WALK_DOT_DIRS = new Set([".github", ".forgejo"]);
 const MAX_WALK_FILES = 1000;
 /** Skip absurdly large files before parsing — mirrors the fetch layer's caps. */
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
 
-/** Recursively collect file paths under a root, skipping noise/dot dirs. */
+/** Recursively collect file paths under a root, skipping noise dirs. */
 function walkFiles(dir: string, out: string[]): void {
   if (out.length >= MAX_WALK_FILES) return;
   let entries;
@@ -72,7 +74,7 @@ function walkFiles(dir: string, out: string[]): void {
   }
   for (const e of entries.sort((a, b) => (a.name < b.name ? -1 : 1))) {
     if (out.length >= MAX_WALK_FILES) return;
-    if (e.name.startsWith(".") && e.isDirectory()) continue;
+    if (e.name.startsWith(".") && e.isDirectory() && !WALK_DOT_DIRS.has(e.name)) continue;
     if (WALK_SKIP.has(e.name)) continue;
     const full = join(dir, e.name);
     if (e.isDirectory()) walkFiles(full, out);
@@ -200,99 +202,113 @@ const CONTENT_DETECTORS: ContentDetector[] = [
   },
 ];
 
-/** Discover CI files by PATH (github/forgejo/gitlab — content can't disambiguate). */
-function discoverCi(root: string): AuditInput[] {
-  const inputs: AuditInput[] = [];
-  const collectDir = (dir: string, lexicon: AuditLexicon) => {
-    const abs = join(root, dir);
-    if (!existsSync(abs) || !statSync(abs).isDirectory()) return;
-    for (const name of readdirSync(abs).sort()) {
-      if (!isYaml(name)) continue;
-      const full = join(abs, name);
-      if (!statSync(full).isFile()) continue;
-      inputs.push({ path: relative(root, full), content: readFileSync(full, "utf-8"), lexicon });
-    }
-  };
-  collectDir(".github/workflows", "github");
-  collectDir(".forgejo/workflows", "forgejo");
-  const gitlab = join(root, ".gitlab-ci.yml");
-  if (existsSync(gitlab) && statSync(gitlab).isFile()) {
-    inputs.push({ path: ".gitlab-ci.yml", content: readFileSync(gitlab, "utf-8"), lexicon: "gitlab" });
-  }
-  return inputs;
+/** A repo file (relative POSIX path + content) — the unit both local and remote feed the classifier. */
+export interface RepoFile {
+  path: string;
+  content: string;
 }
 
-/** Collect Helm charts as bundles, returning [inputs, set of chart path-prefixes]. */
-function discoverHelm(root: string, all: string[], plugin: LexiconPlugin | undefined): { inputs: AuditInput[]; prefixes: string[] } {
+/** Which CI lexicon a path belongs to (by location — content can't disambiguate github vs forgejo). */
+function ciLexiconForPath(path: string): AuditLexicon | undefined {
+  if (/^\.github\/workflows\/[^/]+\.ya?ml$/.test(path)) return "github";
+  if (/^\.forgejo\/workflows\/[^/]+\.ya?ml$/.test(path)) return "forgejo";
+  if (path === ".gitlab-ci.yml") return "gitlab";
+  return undefined;
+}
+
+/**
+ * Whether a path is worth reading/fetching at all. Bounds the local walk and,
+ * crucially, the remote fetch (so we never pull a whole repo's contents).
+ */
+export function isCandidatePath(path: string): boolean {
+  const name = basename(path);
+  if (ciLexiconForPath(path)) return true;
+  if (isDockerfileName(name)) return true;
+  if (name === "Chart.yaml") return true;
+  return /\.(ya?ml|json|template)$/i.test(name);
+}
+
+/** Collect Helm charts as bundles from an in-memory file set; returns inputs + chart path-prefixes. */
+function classifyHelm(files: RepoFile[], plugin: LexiconPlugin | undefined): { inputs: AuditInput[]; prefixes: string[] } {
   const inputs: AuditInput[] = [];
   const prefixes: string[] = [];
   if (!plugin) return { inputs, prefixes };
-  const chartDirs = all.filter((f) => basename(f) === "Chart.yaml").map((f) => f.slice(0, -("/Chart.yaml".length)));
-  for (const dir of chartDirs) {
-    const prefix = dir + "/";
-    const files: Record<string, string> = {};
-    for (const f of all) {
-      if (!f.startsWith(prefix)) continue;
-      const content = readSafe(f);
-      if (content !== undefined) files[f.slice(prefix.length)] = content;
+  const charts = files.filter((f) => f.path === "Chart.yaml" || f.path.endsWith("/Chart.yaml"));
+  for (const chartFile of charts) {
+    const dir = chartFile.path === "Chart.yaml" ? "" : chartFile.path.slice(0, -"/Chart.yaml".length);
+    const prefix = dir === "" ? "" : `${dir}/`;
+    const bundle: Record<string, string> = {};
+    for (const f of files) {
+      if (prefix !== "" && !f.path.startsWith(prefix)) continue;
+      bundle[prefix === "" ? f.path : f.path.slice(prefix.length)] = f.content;
     }
-    const chart = files["Chart.yaml"];
+    const chart = bundle["Chart.yaml"];
     if (chart === undefined) continue;
     const parsed = parseStructured(chart);
     if (!parsed || !plugin.detectTemplate?.(parsed)) continue;
-    const chartPath = relative(root, dir) || ".";
-    inputs.push({ path: chartPath, content: chart, lexicon: "helm", files });
-    prefixes.push(chartPath === "." ? "" : `${chartPath}/`);
+    inputs.push({ path: dir || ".", content: chart, lexicon: "helm", files: bundle });
+    prefixes.push(prefix);
   }
   return { inputs, prefixes };
 }
 
 /**
- * Unified discovery: one walk, plugin-delegated content detection, plus the
- * path/filename/bundle special-cases content shape can't express.
- *
- * `plugins` is the set of loaded lexicon plugins (by name); detection is skipped
- * for any lexicon whose plugin isn't provided, so a caller can scope discovery.
+ * Classify an in-memory set of repo files into per-lexicon audit inputs. Pure
+ * (no fs, no network) so the local walk and the remote tree-fetch share exactly
+ * one detection path. Each file maps to at most one lexicon: CI by path,
+ * Dockerfiles by name, Helm charts as a bundle, everything else by the
+ * precedence-ordered content detectors (delegating to each plugin's
+ * `detectTemplate`). Lexicons whose plugin isn't provided are skipped.
  */
-export function discoverByDetection(root: string, plugins: LexiconPlugin[]): AuditInput[] {
+export function classifyFiles(files: RepoFile[], plugins: LexiconPlugin[]): AuditInput[] {
   const byName = new Map(plugins.map((p) => [p.name, p]));
-  const all: string[] = [];
-  walkFiles(root, all);
 
-  // Helm claims whole chart directories first; everything under a chart is
-  // excluded from the loose-file pass so templates aren't double-audited.
-  const helm = discoverHelm(root, all, byName.get("helm"));
-  const underChart = (rel: string): boolean => helm.prefixes.some((pre) => (pre === "" ? true : rel.startsWith(pre)));
+  // Helm claims whole chart directories first; chart-internal files are excluded
+  // from the loose-file pass so templates aren't double-audited.
+  const helm = classifyHelm(files, byName.get("helm"));
+  const underChart = (p: string): boolean => helm.prefixes.some((pre) => (pre === "" ? true : p.startsWith(pre)));
 
-  const inputs: AuditInput[] = [...discoverCi(root), ...helm.inputs];
+  const inputs: AuditInput[] = [...helm.inputs];
+  for (const { path, content } of files) {
+    if (underChart(path)) continue;
+    const name = basename(path);
 
-  for (const full of all) {
-    const name = basename(full);
-    const rel = relative(root, full);
-    if (underChart(rel)) continue;
-
-    // Dockerfiles: filename-detected (not YAML/JSON, so no detectTemplate).
-    if (isDockerfileName(name) && byName.has("docker")) {
-      const content = readSafe(full);
-      if (content !== undefined) inputs.push({ path: rel, content, lexicon: "docker" });
+    const ci = ciLexiconForPath(path);
+    if (ci) {
+      if (byName.has(ci)) inputs.push({ path, content, lexicon: ci });
       continue;
     }
-
-    let content: string | undefined;
+    if (isDockerfileName(name)) {
+      if (byName.has("docker")) inputs.push({ path, content, lexicon: "docker" });
+      continue;
+    }
     for (const det of CONTENT_DETECTORS) {
       const plugin = byName.get(det.lexicon);
       if (!plugin || !det.accepts(name)) continue;
-      if (content === undefined) {
-        content = readSafe(full);
-        if (content === undefined) break;
-      }
       const normalized = det.detect(plugin, name, content);
       if (normalized !== null) {
-        inputs.push({ path: rel, content: normalized, lexicon: det.lexicon });
+        inputs.push({ path, content: normalized, lexicon: det.lexicon });
         break; // first detector in precedence wins — one lexicon per file
       }
     }
   }
-
   return inputs;
+}
+
+/**
+ * Local discovery: one filesystem walk, candidate-filtered, read into memory,
+ * then handed to the shared `classifyFiles`. Detection is skipped for any
+ * lexicon whose plugin isn't provided, so a caller can scope discovery.
+ */
+export function discoverByDetection(root: string, plugins: LexiconPlugin[]): AuditInput[] {
+  const all: string[] = [];
+  walkFiles(root, all);
+  const files: RepoFile[] = [];
+  for (const full of all) {
+    const path = relative(root, full);
+    if (!isCandidatePath(path)) continue;
+    const content = readSafe(full);
+    if (content !== undefined) files.push({ path, content });
+  }
+  return classifyFiles(files, plugins);
 }

--- a/packages/core/src/audit/fetch.ts
+++ b/packages/core/src/audit/fetch.ts
@@ -174,6 +174,132 @@ export async function fetchCiFiles(url: string, opts: FetchOptions = {}): Promis
   return inputs;
 }
 
+// ── Whole-repo fetch (all lexicons, not just CI) ─────────────────────────────
+// Mirrors the local walk: list the repo tree, keep candidate paths, fetch their
+// contents (capped), and hand the raw {path, content} set to the shared
+// classifier in discover.ts. SSRF posture is unchanged — allowlisted host,
+// URLs built from parsed owner/repo, redirects refused, counts/bytes capped.
+
+/** Module-level JSON GET that refuses redirects (reused by the tree-walk). */
+async function getJsonAt(
+  url: string,
+  headers: Record<string, string>,
+  doFetch: typeof fetch,
+  timeoutMs: number,
+): Promise<{ status: number; body: unknown }> {
+  let res: Response;
+  try {
+    res = await doFetch(url, { headers, redirect: "manual", signal: timeoutSignal(timeoutMs) });
+  } catch (err) {
+    throw new FetchError(`Request failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (res.status >= 300 && res.status < 400) throw new FetchError(`Refusing to follow redirect from ${url}`);
+  if (res.status === 404) return { status: 404, body: null };
+  if (!res.ok) throw new FetchError(`${url} returned ${res.status}`);
+  return { status: res.status, body: await res.json() };
+}
+
+function projectId(owner: string, repo: string): string {
+  return encodeURIComponent(`${owner}/${repo}`);
+}
+
+/** The repo's default branch, so the tree request has a concrete ref. */
+async function defaultBranch(host: HostConfig, owner: string, repo: string, doFetch: typeof fetch, headers: Record<string, string>, ms: number): Promise<string> {
+  const url =
+    host.kind === "gitlab"
+      ? `${host.api}/projects/${projectId(owner, repo)}`
+      : `${host.api}/repos/${owner}/${repo}`;
+  const { body } = await getJsonAt(url, headers, doFetch, ms);
+  const branch = (body as { default_branch?: string } | null)?.default_branch;
+  return branch && typeof branch === "string" ? branch : "HEAD";
+}
+
+interface TreeEntry {
+  path: string;
+  type: string;
+  size?: number;
+}
+
+/** List every blob path in the repo (recursive), with size where the host reports it. */
+async function listTree(host: HostConfig, owner: string, repo: string, ref: string, doFetch: typeof fetch, headers: Record<string, string>, ms: number): Promise<TreeEntry[]> {
+  if (host.kind === "gitlab") {
+    const out: TreeEntry[] = [];
+    const MAX_PAGES = 20; // 20 * 100 = 2000 entries — bounded; candidate filter + caps trim further
+    for (let page = 1; page <= MAX_PAGES; page++) {
+      const url = `${host.api}/projects/${projectId(owner, repo)}/repository/tree?recursive=true&per_page=100&page=${page}&ref=${encodeURIComponent(ref)}`;
+      const { body } = await getJsonAt(url, headers, doFetch, ms);
+      if (!Array.isArray(body) || body.length === 0) break;
+      for (const e of body as Array<{ path: string; type: string }>) {
+        if (e.type === "blob") out.push({ path: e.path, type: "blob" });
+      }
+      if (body.length < 100) break;
+    }
+    return out;
+  }
+  // GitHub / Forgejo (Gitea) share the git/trees recursive API.
+  const url = `${host.api}/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ref)}?recursive=1`;
+  const { body } = await getJsonAt(url, headers, doFetch, ms);
+  const tree = (body as { tree?: TreeEntry[] } | null)?.tree;
+  if (!Array.isArray(tree)) return [];
+  return tree.filter((e) => e.type === "blob").map((e) => ({ path: e.path, type: "blob", size: e.size }));
+}
+
+/** Fetch one file's content per host (base64 contents API, or GitLab raw). */
+async function fetchFileContent(host: HostConfig, owner: string, repo: string, path: string, ref: string, doFetch: typeof fetch, headers: Record<string, string>, ms: number): Promise<string | undefined> {
+  if (host.kind === "gitlab") {
+    const url = `${host.api}/projects/${projectId(owner, repo)}/repository/files/${encodeURIComponent(path)}/raw?ref=${encodeURIComponent(ref)}`;
+    let res: Response;
+    try {
+      res = await doFetch(url, { headers, redirect: "manual", signal: timeoutSignal(ms) });
+    } catch {
+      return undefined;
+    }
+    if (!res.ok) return undefined;
+    return await res.text();
+  }
+  const url = `${host.api}/repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`;
+  const { body } = await getJsonAt(url, headers, doFetch, ms);
+  const file = body as ContentsEntry | null;
+  if (!file?.content) return undefined;
+  return Buffer.from(file.content, (file.encoding as BufferEncoding) ?? "base64").toString("utf-8");
+}
+
+/**
+ * Fetch every candidate file in a repo (all lexicons), so a URL audit covers the
+ * same ground as a local one. Returns raw {path, content}; classification (which
+ * needs the lexicon plugins) is the caller's job via `classifyFiles`.
+ */
+export async function fetchRepoFiles(url: string, opts: FetchOptions = {}): Promise<Array<{ path: string; content: string }>> {
+  const { isCandidatePath } = await import("./discover");
+  const { host, owner, repo } = parseRepoUrl(url);
+  const doFetch = opts.fetchImpl ?? fetch;
+  const cfg = {
+    maxFiles: opts.maxFiles ?? DEFAULTS.maxFiles,
+    maxBytesPerFile: opts.maxBytesPerFile ?? DEFAULTS.maxBytesPerFile,
+    maxTotalBytes: opts.maxTotalBytes ?? DEFAULTS.maxTotalBytes,
+    timeoutMs: opts.timeoutMs ?? DEFAULTS.timeoutMs,
+  };
+  const headers = authHeaders(host.kind, opts.token);
+  const ref = opts.ref ?? (await defaultBranch(host, owner, repo, doFetch, headers, cfg.timeoutMs));
+
+  const tree = await listTree(host, owner, repo, ref, doFetch, headers, cfg.timeoutMs);
+  const candidates = tree.filter((e) => isCandidatePath(e.path));
+
+  const files: Array<{ path: string; content: string }> = [];
+  let total = 0;
+  for (const entry of candidates) {
+    if (files.length >= cfg.maxFiles) break;
+    if ((entry.size ?? 0) > cfg.maxBytesPerFile) continue; // skip oversize when the host reports size
+    const content = await fetchFileContent(host, owner, repo, entry.path, ref, doFetch, headers, cfg.timeoutMs);
+    if (content === undefined) continue;
+    if (content.length > cfg.maxBytesPerFile) continue;
+    total += content.length;
+    if (total > cfg.maxTotalBytes) throw new FetchError("Repository files exceed the total size cap.");
+    files.push({ path: entry.path, content });
+  }
+  return files;
+}
+
 const SHA40 = /^[0-9a-f]{40}$/;
 
 /**

--- a/packages/core/src/audit/remote-discovery.test.ts
+++ b/packages/core/src/audit/remote-discovery.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from "vitest";
+import { fileURLToPath } from "url";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative } from "path";
+import { fetchRepoFiles, FetchError } from "./fetch";
+import { discoverByDetection, classifyFiles } from "./discover";
+import { loadAuditPlugins } from "./discover";
+
+const MIXED = fileURLToPath(new URL("../cli/commands/__fixtures__/audit-mixed", import.meta.url));
+
+/** Read a dir into relative-path → content (the "repo" a mock will serve). */
+function readDir(root: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const walk = (dir: string) => {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, e.name);
+      if (e.isDirectory()) walk(full);
+      else out[relative(root, full)] = readFileSync(full, "utf-8");
+    }
+  };
+  walk(root);
+  return out;
+}
+
+/** A GitHub-shaped mock: repo-info default_branch, recursive git/trees, base64 contents. */
+function mockGithub(files: Record<string, string>): typeof fetch {
+  const b64 = (s: string) => Buffer.from(s, "utf-8").toString("base64");
+  return (async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("/git/trees/")) {
+      const tree = Object.keys(files).map((path) => ({ path, type: "blob", size: files[path].length }));
+      return new Response(JSON.stringify({ tree }), { status: 200 });
+    }
+    const cm = u.match(/\/contents\/(.+?)\?/);
+    if (cm) {
+      const path = decodeURIComponent(cm[1]);
+      const content = files[path];
+      if (content === undefined) return new Response("not found", { status: 404 });
+      return new Response(JSON.stringify({ path, type: "file", content: b64(content), encoding: "base64" }), { status: 200 });
+    }
+    if (/\/repos\/[^/]+\/[^/]+(\?|$)/.test(u)) return new Response(JSON.stringify({ default_branch: "main" }), { status: 200 });
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+const targets = (inputs: { lexicon: string; path: string }[]) => inputs.map((i) => `${i.lexicon}:${i.path}`).sort();
+
+describe("remote audit covers all lexicons (not just CI)", () => {
+  test("a URL audit detects github + k8s + docker + aws in one repo", async () => {
+    const plugins = await loadAuditPlugins();
+    const files = await fetchRepoFiles("https://github.com/acme/widgets", { fetchImpl: mockGithub(readDir(MIXED)) });
+    const lexicons = new Set(classifyFiles(files, plugins).map((i) => i.lexicon));
+    expect([...lexicons].sort()).toEqual(["aws", "docker", "github", "k8s"]);
+  });
+
+  test("remote classification matches a local audit of the same repo (parity)", async () => {
+    const plugins = await loadAuditPlugins();
+    const local = discoverByDetection(MIXED, plugins);
+    const remote = classifyFiles(await fetchRepoFiles("https://github.com/acme/widgets", { fetchImpl: mockGithub(readDir(MIXED)) }), plugins);
+    expect(targets(remote)).toEqual(targets(local));
+  });
+
+  test("caps the number of files fetched", async () => {
+    const files = await fetchRepoFiles("https://github.com/acme/widgets", { fetchImpl: mockGithub(readDir(MIXED)), maxFiles: 1 });
+    expect(files.length).toBe(1);
+  });
+
+  test("rejects a non-allowlisted host before any fetch", async () => {
+    await expect(fetchRepoFiles("https://evil.example.com/o/r")).rejects.toThrow(/Host not allowed/);
+  });
+
+  test("refuses to follow a redirect on the tree request", async () => {
+    const impl = (async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("/git/trees/")) return new Response(null, { status: 302 });
+      return new Response(JSON.stringify({ default_branch: "main" }), { status: 200 });
+    }) as unknown as typeof fetch;
+    await expect(fetchRepoFiles("https://github.com/acme/widgets", { fetchImpl: impl })).rejects.toThrow(/redirect/i);
+  });
+});

--- a/packages/core/src/cli/commands/__fixtures__/audit-mixed/.github/workflows/ci.yml
+++ b/packages/core/src/cli/commands/__fixtures__/audit-mixed/.github/workflows/ci.yml
@@ -1,0 +1,5 @@
+on: push
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest

--- a/packages/core/src/cli/commands/__fixtures__/audit-mixed/Dockerfile
+++ b/packages/core/src/cli/commands/__fixtures__/audit-mixed/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu
+RUN apt-get update

--- a/packages/core/src/cli/commands/__fixtures__/audit-mixed/cfn/template.json
+++ b/packages/core/src/cli/commands/__fixtures__/audit-mixed/cfn/template.json
@@ -1,0 +1,1 @@
+{"AWSTemplateFormatVersion":"2010-09-09","Resources":{"B":{"Type":"AWS::S3::Bucket"}}}

--- a/packages/core/src/cli/commands/__fixtures__/audit-mixed/k8s/deploy.yaml
+++ b/packages/core/src/cli/commands/__fixtures__/audit-mixed/k8s/deploy.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: x
+spec:
+  template:
+    spec:
+      containers:
+        - name: c
+          image: nginx:latest
+          securityContext:
+            privileged: true

--- a/packages/core/src/cli/commands/audit.test.ts
+++ b/packages/core/src/cli/commands/audit.test.ts
@@ -206,12 +206,13 @@ describe("auditCommand", () => {
     const yaml = "name: CI\non:\n  push:\npermissions: write-all\njobs:\n  build:\n    runs-on: ubuntu-latest\n";
     const impl = (async (url: string | URL | Request) => {
       const u = String(url);
+      if (u.includes("/git/trees/")) {
+        return new Response(JSON.stringify({ tree: [{ path: ".github/workflows/ci.yml", type: "blob", size: 100 }] }), { status: 200 });
+      }
       if (u.includes("/contents/.github/workflows/ci.yml")) {
         return new Response(JSON.stringify({ name: "ci.yml", path: ".github/workflows/ci.yml", type: "file", content: b64(yaml), encoding: "base64" }), { status: 200 });
       }
-      if (u.includes("/contents/.github/workflows")) {
-        return new Response(JSON.stringify([{ name: "ci.yml", path: ".github/workflows/ci.yml", type: "file", size: 100 }]), { status: 200 });
-      }
+      if (/\/repos\/acme\/widgets(\?|$)/.test(u)) return new Response(JSON.stringify({ default_branch: "main" }), { status: 200 });
       return new Response("not found", { status: 404 });
     }) as unknown as typeof fetch;
 
@@ -228,12 +229,13 @@ describe("auditCommand", () => {
     const impl = (async (url: string | URL | Request) => {
       const u = String(url);
       if (u.includes("/commits/v4")) return new Response(JSON.stringify({ sha }), { status: 200 });
+      if (u.includes("/git/trees/")) {
+        return new Response(JSON.stringify({ tree: [{ path: ".github/workflows/ci.yml", type: "blob", size: 100 }] }), { status: 200 });
+      }
       if (u.includes("/contents/.github/workflows/ci.yml")) {
         return new Response(JSON.stringify({ name: "ci.yml", path: ".github/workflows/ci.yml", type: "file", content: b64(yaml), encoding: "base64" }), { status: 200 });
       }
-      if (u.includes("/contents/.github/workflows")) {
-        return new Response(JSON.stringify([{ name: "ci.yml", path: ".github/workflows/ci.yml", type: "file", size: 100 }]), { status: 200 });
-      }
+      if (/\/repos\/acme\/widgets(\?|$)/.test(u)) return new Response(JSON.stringify({ default_branch: "main" }), { status: 200 });
       return new Response("not found", { status: 404 });
     }) as unknown as typeof fetch;
 

--- a/packages/core/src/cli/commands/audit.ts
+++ b/packages/core/src/cli/commands/audit.ts
@@ -7,12 +7,12 @@
 
 import { existsSync, statSync, writeFileSync } from "fs";
 import { auditFiles, type AuditInput, type AuditFinding, type ChecksProvider } from "../../audit/core";
-import { discoverByDetection, loadAuditPlugins, AUDIT_LEXICONS } from "../../audit/discover";
+import { discoverByDetection, classifyFiles, loadAuditPlugins, AUDIT_LEXICONS } from "../../audit/discover";
 import { RULE_CATALOG } from "../../audit/catalog";
 import { renderMarkdown } from "../../audit/report";
 import { renderHtml, type ReportTheme } from "../../audit/report-html";
 import { buildReportJson, type AuditSnapshot } from "../../audit/report-model";
-import { fetchCiFiles, resolveActionSha, resolveImageDigest, resolveRepoCommit, parseRepoUrl, FetchError } from "../../audit/fetch";
+import { fetchRepoFiles, resolveActionSha, resolveImageDigest, resolveRepoCommit, parseRepoUrl, FetchError } from "../../audit/fetch";
 import { extractUnpinnedActions, extractUnpinnedImages } from "../../audit/proof";
 import type { ProveOptions } from "../../audit/proof";
 import type { Severity } from "../../lint/rule";
@@ -212,10 +212,13 @@ export async function auditCommand(options: AuditCommandOptions): Promise<AuditC
   let missingHint = "";
   if (isUrl) {
     try {
-      inputs = await fetchCiFiles(options.path, {
+      // Fetch the whole repo's candidate files (all lexicons, not just CI) and
+      // run them through the same classifier the local path uses (#420).
+      const files = await fetchRepoFiles(options.path, {
         token: options.token ?? tokenForHost(options.path),
         fetchImpl: options.fetchImpl,
       });
+      inputs = classifyFiles(files, await loadAuditPlugins());
     } catch (err) {
       const msg = err instanceof FetchError ? err.message : err instanceof Error ? err.message : String(err);
       return { success: false, output: "", findings: [], scanned: [], exitCode: 1, error: msg };


### PR DESCRIPTION
Closes #420. Unblocks the #356 hosted service (URL-driven), which would otherwise ship CI-only by accident.

## Problem
Local and remote audits didn't cover the same ground: local walked the tree and content-detected **all** lexicons, but remote (`fetchCiFiles`) fetched only known CI paths. So `chant audit <url>` on a repo with CloudFormation + a GitLab pipeline surfaced the pipeline but **missed the CloudFormation**.

## Fix
Remote discovery now enumerates the repo tree and content-detects through the **same classifier** as local, so the two can't drift.

- **`discover.ts`** — extracted a pure `classifyFiles(files, plugins)` (CI by path, Dockerfile by name, Helm bundle, content detectors). Local `discoverByDetection` now walks (incl. `.github`/`.forgejo`), candidate-filters, reads, and calls it. Behavior preserved (all existing discover/audit tests green).
- **`fetch.ts`** — `fetchRepoFiles(url)` lists the repo tree recursively per host (GitHub/Forgejo `git/trees?recursive`, GitLab `repository/tree?recursive` paginated), filters to candidate paths (`isCandidatePath`), and fetches contents — keeping the **host allowlist, redirect refusal, and file-count / per-file / total-byte caps**. Returns raw `{path,content}`; classification stays with the caller so `fetch.ts` keeps no static fs/plugin dependency.
- **`auditCommand`** URL branch → `fetchRepoFiles` + `classifyFiles`.

## Testing (no network)
`remote-discovery.test.ts` serves a local fixture through a mock tree+contents API:
- **multi-lexicon over a URL** — one repo yields github + k8s + docker + aws.
- **parity** — `classifyFiles(fetchRepoFiles(mock))` == `discoverByDetection(localdir)` on the same files.
- **caps** — `maxFiles` honored.
- **SSRF** — non-allowlisted host rejected; a 302 on the tree request refused.

## Verification
- `tsc` + `eslint` clean
- Full suite: 6219 passed, 5 skipped

Note: `fetchCiFiles` is retained (still tested) but no longer used by `auditCommand`; it can be removed in a follow-up.