### PR TITLE
feat(audit): extract detectTemplate into edge-safe modules (#426)

### DIFF
--- a/lexicons/aws/package.json
+++ b/lexicons/aws/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./detect": "./src/detect.ts",
     "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",

--- a/lexicons/aws/src/detect.ts
+++ b/lexicons/aws/src/detect.ts
@@ -1,0 +1,19 @@
+/** Edge-safe template detection for aws (CloudFormation) — see #426. */
+export function detectTemplate(data: unknown): boolean {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  // CloudFormation has AWSTemplateFormatVersion
+  if (obj.AWSTemplateFormatVersion !== undefined) return true;
+  // Or Resources with AWS::* types
+  if (typeof obj.Resources === "object" && obj.Resources !== null) {
+    for (const resource of Object.values(obj.Resources as Record<string, unknown>)) {
+      if (typeof resource === "object" && resource !== null) {
+        const type = (resource as Record<string, unknown>).Type;
+        if (typeof type === "string" && type.startsWith("AWS::")) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}

--- a/lexicons/aws/src/plugin.ts
+++ b/lexicons/aws/src/plugin.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "module";
+import { detectTemplate } from "./detect";
 import type { LexiconPlugin, IntrinsicDef, ResourceMetadata, ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
 const require = createRequire(import.meta.url);
 import type { LintRule } from "@intentius/chant/lint/rule";
@@ -235,27 +236,7 @@ export const logsBucket = new Bucket({
     } };
   },
 
-  detectTemplate(data: unknown): boolean {
-    if (typeof data !== "object" || data === null) return false;
-    const obj = data as Record<string, unknown>;
-
-    // CloudFormation has AWSTemplateFormatVersion
-    if (obj.AWSTemplateFormatVersion !== undefined) return true;
-
-    // Or Resources with AWS::* types
-    if (typeof obj.Resources === "object" && obj.Resources !== null) {
-      for (const resource of Object.values(obj.Resources as Record<string, unknown>)) {
-        if (typeof resource === "object" && resource !== null) {
-          const type = (resource as Record<string, unknown>).Type;
-          if (typeof type === "string" && type.startsWith("AWS::")) {
-            return true;
-          }
-        }
-      }
-    }
-
-    return false;
-  },
+  detectTemplate,
 
   templateParser(): TemplateParser {
     return new CFParser();

--- a/lexicons/azure/package.json
+++ b/lexicons/azure/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./detect": "./src/detect.ts",
     "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",

--- a/lexicons/azure/src/detect.ts
+++ b/lexicons/azure/src/detect.ts
@@ -1,0 +1,17 @@
+/** Edge-safe template detection for azure (ARM) — see #426. */
+export function detectTemplate(content: unknown): boolean {
+  if (typeof content !== "string") return false;
+  try {
+    const parsed = JSON.parse(content);
+    return (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "$schema" in parsed &&
+      typeof parsed.$schema === "string" &&
+      parsed.$schema.includes("deploymentTemplate") &&
+      Array.isArray(parsed.resources)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/lexicons/azure/src/plugin.ts
+++ b/lexicons/azure/src/plugin.ts
@@ -1,4 +1,5 @@
 import type { LexiconPlugin, IntrinsicDef } from "@intentius/chant/lexicon";
+import { detectTemplate } from "./detect";
 import type { LintRule } from "@intentius/chant/lint/rule";
 import type { TemplateParser } from "@intentius/chant/import/parser";
 import type { TypeScriptGenerator } from "@intentius/chant/import/generator";
@@ -238,21 +239,7 @@ export const tags = defaultTags([
     };
   },
 
-  detectTemplate(content: string): boolean {
-    try {
-      const parsed = JSON.parse(content);
-      return (
-        typeof parsed === "object" &&
-        parsed !== null &&
-        "$schema" in parsed &&
-        typeof parsed.$schema === "string" &&
-        parsed.$schema.includes("deploymentTemplate") &&
-        Array.isArray(parsed.resources)
-      );
-    } catch {
-      return false;
-    }
-  },
+  detectTemplate,
 
   templateParser(): TemplateParser {
     return new ArmParser();

--- a/lexicons/docker/package.json
+++ b/lexicons/docker/package.json
@@ -32,6 +32,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./detect": "./src/detect.ts",
     "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",

--- a/lexicons/docker/src/detect.ts
+++ b/lexicons/docker/src/detect.ts
@@ -1,0 +1,7 @@
+/** Edge-safe template detection for docker (Compose) — see #426. */
+export function detectTemplate(data: unknown): boolean {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  // Docker Compose files have a services: key
+  return "services" in obj;
+}

--- a/lexicons/docker/src/plugin.ts
+++ b/lexicons/docker/src/plugin.ts
@@ -6,6 +6,7 @@
  */
 
 import type { LexiconPlugin, IntrinsicDef, InitTemplateSet } from "@intentius/chant/lexicon";
+import { detectTemplate } from "./detect";
 import type { LintRule } from "@intentius/chant/lint/rule";
 import { postSynthChecks as postSynthCheckList } from "./lint/post-synth";
 import { createSkillsLoader, createDiffTool, createCatalogResource } from "@intentius/chant/lexicon-plugin-helpers";
@@ -87,12 +88,7 @@ export const api = new Service({
     };
   },
 
-  detectTemplate(data: unknown): boolean {
-    if (typeof data !== "object" || data === null) return false;
-    const obj = data as Record<string, unknown>;
-    // Docker Compose files have a services: key
-    return "services" in obj;
-  },
+  detectTemplate,
 
   completionProvider(ctx: import("@intentius/chant/lsp/types").CompletionContext) {
     return dockerCompletions(ctx);

--- a/lexicons/gcp/package.json
+++ b/lexicons/gcp/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./detect": "./src/detect.ts",
     "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",

--- a/lexicons/gcp/src/detect.ts
+++ b/lexicons/gcp/src/detect.ts
@@ -1,0 +1,15 @@
+/** Edge-safe template detection for gcp (Config Connector) — see #426. */
+export function detectTemplate(data: unknown): boolean {
+  // Handle raw string input (unparsed YAML)
+  if (typeof data === "string") {
+    return data.includes("cnrm.cloud.google.com");
+  }
+  // Handle parsed YAML objects
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  const apiVersion = obj.apiVersion;
+  if (typeof apiVersion === "string" && apiVersion.includes("cnrm.cloud.google.com")) {
+    return true;
+  }
+  return false;
+}

--- a/lexicons/gcp/src/plugin.ts
+++ b/lexicons/gcp/src/plugin.ts
@@ -6,6 +6,7 @@
  */
 
 import type { LexiconPlugin, InitTemplateSet, ResourceMetadata } from "@intentius/chant/lexicon";
+import { detectTemplate } from "./detect";
 import type { LintRule } from "@intentius/chant/lint/rule";
 import type { TemplateParser } from "@intentius/chant/import/parser";
 import type { TypeScriptGenerator } from "@intentius/chant/import/generator";
@@ -172,22 +173,7 @@ export const bucketReader = new IAMPolicyMember({
     };
   },
 
-  detectTemplate(data: unknown): boolean {
-    // Handle raw string input (unparsed YAML)
-    if (typeof data === "string") {
-      return data.includes("cnrm.cloud.google.com");
-    }
-
-    // Handle parsed YAML objects
-    if (typeof data !== "object" || data === null) return false;
-    const obj = data as Record<string, unknown>;
-    const apiVersion = obj.apiVersion;
-    if (typeof apiVersion === "string" && apiVersion.includes("cnrm.cloud.google.com")) {
-      return true;
-    }
-
-    return false;
-  },
+  detectTemplate,
 
   templateParser(): TemplateParser {
     return new GcpParser();

--- a/lexicons/helm/package.json
+++ b/lexicons/helm/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./detect": "./src/detect.ts",
     "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",

--- a/lexicons/helm/src/detect.ts
+++ b/lexicons/helm/src/detect.ts
@@ -1,0 +1,10 @@
+/** Edge-safe template detection for helm (Chart.yaml) — see #426. */
+export function detectTemplate(data: unknown): boolean {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  // Helm charts have apiVersion: v2 in Chart.yaml
+  if (obj.apiVersion === "v2" && typeof obj.name === "string" && typeof obj.version === "string") {
+    return true;
+  }
+  return false;
+}

--- a/lexicons/helm/src/plugin.ts
+++ b/lexicons/helm/src/plugin.ts
@@ -6,6 +6,7 @@
  */
 
 import type { LexiconPlugin, IntrinsicDef, InitTemplateSet } from "@intentius/chant/lexicon";
+import { detectTemplate } from "./detect";
 import { discoverLintRules } from "@intentius/chant/lint/discover";
 import { postSynthChecks as postSynthCheckList } from "./lint/post-synth";
 import { createSkillsLoader, createDiffTool } from "@intentius/chant/lexicon-plugin-helpers";
@@ -54,15 +55,7 @@ export const helmPlugin: LexiconPlugin = {
     ];
   },
 
-  detectTemplate(data: unknown): boolean {
-    if (typeof data !== "object" || data === null) return false;
-    const obj = data as Record<string, unknown>;
-    // Helm charts have apiVersion: v2 in Chart.yaml
-    if (obj.apiVersion === "v2" && typeof obj.name === "string" && typeof obj.version === "string") {
-      return true;
-    }
-    return false;
-  },
+  detectTemplate,
 
   mcpTools() {
     return [createDiffTool(helmSerializer, "Compare current Helm chart build output against previous output", "helm")];

--- a/lexicons/k8s/package.json
+++ b/lexicons/k8s/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts",
+    "./detect": "./src/detect.ts",
     "./lint/post-synth": "./src/lint/post-synth/index.ts",
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",

--- a/lexicons/k8s/src/detect.ts
+++ b/lexicons/k8s/src/detect.ts
@@ -1,0 +1,9 @@
+/** Edge-safe template detection for k8s — extracted from plugin.ts so it imports
+ * without the lint rules (and the TypeScript compiler they pull in). See #426. */
+export function detectTemplate(data: unknown): boolean {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  // K8s manifests have apiVersion + kind
+  if (typeof obj.apiVersion === "string" && typeof obj.kind === "string") return true;
+  return false;
+}

--- a/lexicons/k8s/src/plugin.ts
+++ b/lexicons/k8s/src/plugin.ts
@@ -6,6 +6,7 @@
  */
 
 import type { LexiconPlugin, InitTemplateSet, ResourceMetadata } from "@intentius/chant/lexicon";
+import { detectTemplate } from "./detect";
 import type { LintRule } from "@intentius/chant/lint/rule";
 import { postSynthChecks as postSynthCheckList } from "./lint/post-synth";
 import { createSkillsLoader, createDiffTool, createCatalogResource } from "@intentius/chant/lexicon-plugin-helpers";
@@ -202,15 +203,7 @@ export const service = new Service({
     };
   },
 
-  detectTemplate(data: unknown): boolean {
-    if (typeof data !== "object" || data === null) return false;
-    const obj = data as Record<string, unknown>;
-
-    // K8s manifests have apiVersion + kind
-    if (typeof obj.apiVersion === "string" && typeof obj.kind === "string") return true;
-
-    return false;
-  },
+  detectTemplate,
 
   completionProvider(ctx: import("@intentius/chant/lsp/types").CompletionContext) {
     return k8sCompletions(ctx);

--- a/packages/core/src/audit/detect-bundle.test.ts
+++ b/packages/core/src/audit/detect-bundle.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "vitest";
+import { build } from "esbuild";
+import { fileURLToPath } from "url";
+
+/**
+ * #426: the per-lexicon `detect` modules must be importable on the edge — i.e.
+ * bundling them pulls in NO `typescript` (the compiler that `plugin.ts` drags via
+ * declarative rules) and NOT `plugin.ts` itself. This is what lets the hosted
+ * service content-detect all lexicons on Workers.
+ */
+const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url));
+const LEXICONS = ["k8s", "docker", "aws", "azure", "gcp", "helm"];
+
+describe("detectTemplate modules are edge-bundle clean", () => {
+  test("importing every lexicon's /detect pulls in no typescript or plugin.ts", async () => {
+    const contents =
+      LEXICONS.map((l, i) => `import { detectTemplate as d${i} } from "@intentius/chant-lexicon-${l}/detect";`).join("\n") +
+      `\nexport const detectors = [${LEXICONS.map((_, i) => `d${i}`).join(", ")}];\n`;
+
+    const result = await build({
+      stdin: { contents, resolveDir: repoRoot, loader: "ts" },
+      bundle: true,
+      format: "esm",
+      platform: "node",
+      metafile: true,
+      write: false,
+      outfile: "out.js",
+      logLevel: "silent",
+    });
+
+    const inputs = Object.keys(result.metafile.inputs);
+    expect(inputs.some((p) => p.includes("node_modules/typescript"))).toBe(false);
+    expect(inputs.some((p) => p.endsWith("/plugin.ts"))).toBe(false);
+  }, 30_000);
+});

--- a/packages/core/src/audit/discover.ts
+++ b/packages/core/src/audit/discover.ts
@@ -147,11 +147,11 @@ interface ContentDetector {
    * plugin's detectTemplate. Returns the (possibly normalized) content to feed
    * the checks, or null if it doesn't match.
    */
-  detect(plugin: LexiconPlugin, name: string, content: string): string | null;
+  detect(plugin: DetectPlugin, name: string, content: string): string | null;
 }
 
 /** Run a plugin's detectTemplate over each parsed doc; true if any matches. */
-function anyDoc(plugin: LexiconPlugin, content: string): boolean {
+function anyDoc(plugin: DetectPlugin, content: string): boolean {
   return parseDocs(content).some((doc) => plugin.detectTemplate?.(doc) ?? false);
 }
 
@@ -208,6 +208,17 @@ export interface RepoFile {
   content: string;
 }
 
+/**
+ * The minimal shape `classifyFiles` needs from a lexicon: its name and (for
+ * content-detected lexicons) its `detectTemplate`. Narrower than `LexiconPlugin`
+ * so an edge caller can build detectors from static `@…/detect` imports without
+ * loading the full plugin (which drags the TypeScript compiler — see #426).
+ */
+export interface DetectPlugin {
+  name: string;
+  detectTemplate?: (data: unknown) => boolean;
+}
+
 /** Which CI lexicon a path belongs to (by location — content can't disambiguate github vs forgejo). */
 function ciLexiconForPath(path: string): AuditLexicon | undefined {
   if (/^\.github\/workflows\/[^/]+\.ya?ml$/.test(path)) return "github";
@@ -229,7 +240,7 @@ export function isCandidatePath(path: string): boolean {
 }
 
 /** Collect Helm charts as bundles from an in-memory file set; returns inputs + chart path-prefixes. */
-function classifyHelm(files: RepoFile[], plugin: LexiconPlugin | undefined): { inputs: AuditInput[]; prefixes: string[] } {
+function classifyHelm(files: RepoFile[], plugin: DetectPlugin | undefined): { inputs: AuditInput[]; prefixes: string[] } {
   const inputs: AuditInput[] = [];
   const prefixes: string[] = [];
   if (!plugin) return { inputs, prefixes };
@@ -260,7 +271,7 @@ function classifyHelm(files: RepoFile[], plugin: LexiconPlugin | undefined): { i
  * precedence-ordered content detectors (delegating to each plugin's
  * `detectTemplate`). Lexicons whose plugin isn't provided are skipped.
  */
-export function classifyFiles(files: RepoFile[], plugins: LexiconPlugin[]): AuditInput[] {
+export function classifyFiles(files: RepoFile[], plugins: DetectPlugin[]): AuditInput[] {
   const byName = new Map(plugins.map((p) => [p.name, p]));
 
   // Helm claims whole chart directories first; chart-internal files are excluded


### PR DESCRIPTION
Closes #426. Prerequisite for the Blacklight (#356) handler to content-detect all lexicons on Workers.

## Problem
`classifyFiles` content-detects gcp/k8s/aws/azure/docker(compose)/helm by calling each lexicon's `detectTemplate`. Reaching it means importing the **plugin**, and `plugin.ts` statically imports declarative rules (e.g. `use-typed-actions` → `import * as ts from "typescript"`) — so importing it drags the TS compiler and crashes `workerd` (`__filename`). Same problem #409 solved for checks, now for detection.

## Fix (mirrors #409)
- Each content lexicon gets a standalone, typescript-free `src/detect.ts` exporting `detectTemplate`; `plugin.ts` imports it (Node path unchanged), and it's exposed as `@intentius/chant-lexicon-<lex>/detect`.
- `classifyFiles` narrowed from `LexiconPlugin[]` to `DetectPlugin[]` (`{name, detectTemplate?}`), so an edge caller builds detectors from static `detect` imports. CI lexicons need only `{name}` (path-detected).

## Verification
- Core tsc (CI's typecheck): clean, ~1s
- Full suite green (6220); 167 lexicon/discovery tests; aws example builds via CLI
- New guard test: importing all 6 `detect` modules bundles with **no typescript** and **no plugin.ts** in the graph