### PR TITLE
fix(audit): edge-harden remaining module-init Node-isms (#428)

### DIFF
--- a/lexicons/gcp/src/lint/post-synth/schema-registry.ts
+++ b/lexicons/gcp/src/lint/post-synth/schema-registry.ts
@@ -6,7 +6,6 @@
  */
 
 import { createRequire } from "module";
-const require = createRequire(import.meta.url);
 
 export interface FieldSchema {
   type: string;
@@ -36,6 +35,10 @@ export function getSchemaRegistry(): Map<string, ResourceSchema> {
 
   cachedRegistry = new Map();
   try {
+    // Built lazily (not at module load) so importing this module stays edge-safe:
+    // `createRequire(import.meta.url)` throws where import.meta.url is undefined
+    // (bundled Workers); there it's caught here and the registry is just empty.
+    const require = createRequire(import.meta.url);
     const lexicon = require("../../generated/lexicon-gcp.json") as Record<string, LexiconEntry>;
     for (const entry of Object.values(lexicon)) {
       if (entry.kind === "resource" && entry.gvkKind && entry.schema) {

--- a/packages/core/src/audit/bundle-decoupling.test.ts
+++ b/packages/core/src/audit/bundle-decoupling.test.ts
@@ -9,36 +9,48 @@ import { fileURLToPath } from "url";
  * `load()`, so with code splitting `cli/plugins` lands in a separate chunk and
  * never in the entry chunk that an embedder bundles.
  */
-const coreEntry = fileURLToPath(new URL("./core.ts", import.meta.url));
+async function entryInputsFor(file: string): Promise<{ entryInputs: string[]; allInputs: string[] }> {
+  const result = await build({
+    entryPoints: [fileURLToPath(new URL(file, import.meta.url))],
+    bundle: true,
+    format: "esm",
+    splitting: true,
+    platform: "node",
+    // Skip node_modules (incl. the huge `typescript` package) — we only care
+    // about which internal modules land in the entry chunk.
+    packages: "external",
+    metafile: true,
+    write: false,
+    outdir: "out",
+    logLevel: "silent",
+  });
+  const outputs = result.metafile.outputs;
+  const entry = Object.values(outputs).find((o) => o.entryPoint?.endsWith(file.replace("./", "audit/")));
+  return {
+    entryInputs: entry ? Object.keys(entry.inputs) : [],
+    allInputs: Object.values(outputs).flatMap((o) => Object.keys(o.inputs)),
+  };
+}
 
-describe("audit core bundle graph", () => {
-  test("auditFiles entry does not statically import cli/plugins", async () => {
-    const result = await build({
-      entryPoints: [coreEntry],
-      bundle: true,
-      format: "esm",
-      splitting: true,
-      platform: "node",
-      // Skip node_modules (incl. the huge `typescript` package) — we only care
-      // about which internal modules land in the entry chunk.
-      packages: "external",
-      metafile: true,
-      write: false,
-      outdir: "out",
-      logLevel: "silent",
-    });
-
-    const outputs = result.metafile.outputs;
-    const entry = Object.values(outputs).find((o) => o.entryPoint?.endsWith("audit/core.ts"));
-    expect(entry, "core.ts entry chunk present").toBeDefined();
-
-    const entryInputs = Object.keys(entry!.inputs);
-    // The entry chunk must not contain cli/plugins source — only a lazy chunk may.
+/**
+ * #408/#426: importing the audit entry points must NOT statically pull in
+ * `cli/plugins` — it drags the config loader and the root barrel (index.ts ->
+ * lint/parser -> the TypeScript compiler), fatal on edge runtimes. `loadPlugins`
+ * / `loadPlugin` are reached only via lazy `import()`, so with code splitting
+ * `cli/plugins` lands in a separate chunk, never the entry an embedder bundles.
+ */
+describe("audit bundle graph (edge-safe entries)", () => {
+  test("audit/core (auditFiles) does not statically import cli/plugins", async () => {
+    const { entryInputs, allInputs } = await entryInputsFor("./core.ts");
+    expect(entryInputs.length, "core.ts entry chunk present").toBeGreaterThan(0);
     expect(entryInputs.some((p) => p.includes("cli/plugins"))).toBe(false);
-
-    // Sanity: cli/plugins is still reachable, just split into its own chunk
-    // (proving we lazy-load it rather than dropping the dependency entirely).
-    const allInputs = Object.values(outputs).flatMap((o) => Object.keys(o.inputs));
+    // Still reachable, just split into its own chunk (lazy, not dropped).
     expect(allInputs.some((p) => p.includes("cli/plugins"))).toBe(true);
+  }, 30_000);
+
+  test("audit/discover (classifyFiles) does not statically import cli/plugins", async () => {
+    const { entryInputs } = await entryInputsFor("./discover.ts");
+    expect(entryInputs.length, "discover.ts entry chunk present").toBeGreaterThan(0);
+    expect(entryInputs.some((p) => p.includes("cli/plugins"))).toBe(false);
   }, 30_000);
 });

--- a/packages/core/src/audit/discover.ts
+++ b/packages/core/src/audit/discover.ts
@@ -30,7 +30,6 @@
 import { readdirSync, readFileSync, statSync } from "fs";
 import { basename, join, relative } from "path";
 import { parseYAML } from "../yaml";
-import { loadPlugin } from "../cli/plugins";
 import type { LexiconPlugin } from "../lexicon";
 import type { AuditInput, AuditLexicon } from "./core";
 
@@ -45,6 +44,11 @@ export const AUDIT_LEXICONS = ["github", "gitlab", "forgejo", "k8s", "docker", "
  * its input and needs no plugin setup.
  */
 export async function loadAuditPlugins(names: readonly string[] = AUDIT_LEXICONS): Promise<LexiconPlugin[]> {
+  // Lazy import: a top-level `cli/plugins` import would pull the root barrel
+  // (index.ts -> lint/parser -> the TypeScript compiler) into anyone importing
+  // `classifyFiles`, crashing edge runtimes. Edge callers build detectors from
+  // static `detect` imports and never call this. See #408/#426.
+  const { loadPlugin } = await import("../cli/plugins");
   const plugins: LexiconPlugin[] = [];
   for (const name of names) {
     try {

--- a/packages/core/src/audit/edge-init-safety.test.ts
+++ b/packages/core/src/audit/edge-init-safety.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "vitest";
+import { readdirSync, readFileSync, existsSync } from "fs";
+import { fileURLToPath } from "url";
+import { join } from "path";
+
+/**
+ * #428: the lexicon modules the hosted service imports on the edge — post-synth
+ * checks (+ their local helpers) and the `detect` modules — must not run Node-only
+ * APIs at module load. `createRequire(import.meta.url)` at module scope throws on
+ * Workers (import.meta.url is undefined), crashing the worker at startup. Anything
+ * that genuinely needs it must do so lazily, inside a function, behind a try.
+ */
+const lexiconsDir = fileURLToPath(new URL("../../../../lexicons", import.meta.url));
+
+function edgeImportedFiles(): string[] {
+  const out: string[] = [];
+  for (const lex of readdirSync(lexiconsDir)) {
+    const detect = join(lexiconsDir, lex, "src", "detect.ts");
+    if (existsSync(detect)) out.push(detect);
+    const ps = join(lexiconsDir, lex, "src", "lint", "post-synth");
+    if (existsSync(ps)) {
+      for (const f of readdirSync(ps)) {
+        if (f.endsWith(".ts") && !f.endsWith(".test.ts")) out.push(join(ps, f));
+      }
+    }
+  }
+  return out;
+}
+
+describe("edge-imported lexicon modules are init-safe", () => {
+  test("no module-scope createRequire(import.meta.url)", () => {
+    const offenders: string[] = [];
+    for (const file of edgeImportedFiles()) {
+      for (const line of readFileSync(file, "utf-8").split("\n")) {
+        // Module scope = no leading whitespace. Inside a function it's indented.
+        if (/^(const|let|var|\s*)?\S.*createRequire\(import\.meta\.url\)/.test(line) && !/^\s/.test(line)) {
+          offenders.push(`${file.replace(lexiconsDir, "lexicons")}: ${line.trim()}`);
+        }
+      }
+    }
+    expect(offenders, "move these into a function (lazy) — they crash edge bundles").toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #428. Found while standing up the Blacklight (#356) handler.

Two module-init side effects crashed `workerd` beyond #408/#426:

1. **`audit/discover.ts`** statically imported `cli/plugins` → root `index.ts` → `lint/parser` → `typescript`. So importing `classifyFiles` dragged the TS compiler (`__filename` crash). Lazy-import `cli/plugins` inside `loadAuditPlugins` (same fix as #408 for core).
2. **`gcp/.../schema-registry.ts`** ran `const require = createRequire(import.meta.url)` at module load; a gcp check imports it, so loading the gcp post-synth barrel crashed on the edge. Moved it inside `getSchemaRegistry`'s `try` — lazy, and degrades to an empty registry on the edge.

The #409 edge-bundle guard only tested the github barrel, so the gcp issue slipped through.

## Guards
- Bundle test now asserts **`classifyFiles`'** entry doesn't statically pull `cli/plugins` (alongside the existing `auditFiles` check).
- New `edge-init-safety` test forbids module-scope `createRequire(import.meta.url)` in edge-imported lexicon modules (post-synth checks + `detect`).

## Verified
The Blacklight handler runs the full all-lexicon audit on `workerd`: `/demo` → 12 findings across github/k8s/docker, all 9 barrels + 6 detect modules init clean, fetch+tree-walk reaches GitHub, SSRF guard holds.

`tsc` + `eslint` clean; full suite 6222 passed.