### PR TITLE
feat(packaging): ship built .d.ts for k8s lexicon (#433)

### DIFF
--- a/lexicons/k8s/package.json
+++ b/lexicons/k8s/package.json
@@ -29,10 +29,26 @@
     "access": "public"
   },
   "exports": {
-    ".": "./src/index.ts",
-    "./*": "./src/*.ts",
-    "./detect": "./src/detect.ts",
-    "./lint/post-synth": "./src/lint/post-synth/index.ts",
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "development": "./src/*.ts",
+      "types": "./dist/*.d.ts",
+      "default": "./src/*.ts"
+    },
+    "./detect": {
+      "development": "./src/detect.ts",
+      "types": "./dist/detect.d.ts",
+      "default": "./src/detect.ts"
+    },
+    "./lint/post-synth": {
+      "development": "./src/lint/post-synth/index.ts",
+      "types": "./dist/lint/post-synth/index.d.ts",
+      "default": "./src/lint/post-synth/index.ts"
+    },
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"
@@ -42,7 +58,8 @@
     "bundle": "tsx src/package-cli.ts",
     "validate": "tsx src/validate-cli.ts",
     "docs": "tsx src/codegen/docs-cli.ts",
-    "prepack": "npm run generate && npm run bundle && npm run validate"
+    "prepack": "npm run generate && npm run bundle && npm run validate && npm run build",
+    "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && find dist -type f \\( -name \"*.js\" -o -name \"*.js.map\" \\) -delete"
   },
   "dependencies": {
     "js-yaml": "^4.1.1",

--- a/lexicons/k8s/src/composites/argo-app.ts
+++ b/lexicons/k8s/src/composites/argo-app.ts
@@ -97,7 +97,7 @@ export interface ArgoAppForOptions {
   defaults?: { application?: Partial<Record<string, unknown>> };
 }
 
-export interface ArgoAppForResult {
+export type ArgoAppForResult = {
   application: InstanceType<typeof ApplicationResource>;
 }
 
@@ -196,7 +196,7 @@ export interface ArgoAppSetForRegionsOptions {
   defaults?: { applicationSet?: Partial<Record<string, unknown>> };
 }
 
-export interface ArgoAppSetForRegionsResult {
+export type ArgoAppSetForRegionsResult = {
   applicationSet: InstanceType<typeof ApplicationSetResource>;
 }
 
@@ -324,7 +324,7 @@ export interface RegisterArgoClusterOptions {
   defaults?: { secret?: Partial<Record<string, unknown>> };
 }
 
-export interface RegisterArgoClusterResult {
+export type RegisterArgoClusterResult = {
   secret: InstanceType<typeof SecretResource>;
 }
 

--- a/lexicons/k8s/tsconfig.build.json
+++ b/lexicons/k8s/tsconfig.build.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {},
+    "moduleResolution": "bundler",
+    "customConditions": [
+      "development"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "node_modules",
+    "dist",
+    "docs"
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true
+  }
+}


### PR DESCRIPTION
First increment of #433. Applies the #432 packaging pattern to **k8s** — the one deferred lexicon that's a clean, type-only fix.

## Changes
- Conditional `exports` (`development`/`default` → src, `types` → dist `.d.ts`), declaration-only build (`tsc` → `tsc-alias` → strip `.js`), prepack wiring, `tsconfig.build.json`.
- Fix the latent type errors blocking declaration emit in `composites/argo-app.ts`: the three Argo result types were passed as the explicit `M` arg to `Composite<P, M extends CompositeMembers>`. A **named interface** has no implicit index signature, so it fails `Record<string, Declarable>` even though its members are `Declarable`. Converting them to **type aliases** (which get an implicit index signature) satisfies the constraint while preserving the member typing the public functions return.

## Verification
- `npm run --prefix lexicons/k8s build` → declaration-only dist (125 `.d.ts`, 0 `.js`), tsc-alias adds `.js` import extensions for nodenext consumers.
- k8s composite suite (386 tests), barrel-guards, lexicon-export, core typecheck all green. (Suite audit/update timeouts seen locally are contention flakes — pass in isolation.)

## Still deferred in #433
- **aws** — attribute classification in codegen (e.g. Lambda `Function.Arn` is emitted as a settable constructor prop, not a `readonly` output attribute, so `func.Arn` doesn't typecheck; `Role.Arn` is correct).
- **docker** — `DockerParser`/`DockerGenerator` implement a different IR contract (`ParseResult`/`DockerIR[]`) than core's `TemplateParser`/`TypeScriptGenerator` (`TemplateIR`), yet are wired into core's `chant import` pipeline — a latent mismatch needing an adapter or removal.
- **temporal** — dead lint rules (tmp001/tmp002).
- **azure** — 308K generated file makes declaration emit too slow (codegen split).