### PR TITLE
feat(packaging): ship built .d.ts for docker lexicon (#433)

### DIFF
--- a/lexicons/docker/package.json
+++ b/lexicons/docker/package.json
@@ -30,10 +30,26 @@
     "access": "public"
   },
   "exports": {
-    ".": "./src/index.ts",
-    "./*": "./src/*.ts",
-    "./detect": "./src/detect.ts",
-    "./lint/post-synth": "./src/lint/post-synth/index.ts",
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "development": "./src/*.ts",
+      "types": "./dist/*.d.ts",
+      "default": "./src/*.ts"
+    },
+    "./detect": {
+      "development": "./src/detect.ts",
+      "types": "./dist/detect.d.ts",
+      "default": "./src/detect.ts"
+    },
+    "./lint/post-synth": {
+      "development": "./src/lint/post-synth/index.ts",
+      "types": "./dist/lint/post-synth/index.d.ts",
+      "default": "./src/lint/post-synth/index.ts"
+    },
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"
@@ -43,7 +59,8 @@
     "bundle": "tsx src/package-cli.ts",
     "validate": "tsx src/validate-cli.ts",
     "docs": "tsx src/codegen/docs-cli.ts",
-    "prepack": "npm run generate && npm run bundle && npm run validate"
+    "prepack": "npm run generate && npm run bundle && npm run validate && npm run build",
+    "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && find dist -type f \\( -name \"*.js\" -o -name \"*.js.map\" \\) -delete"
   },
   "devDependencies": {
     "@intentius/chant": "*",

--- a/lexicons/docker/src/import/adapter.ts
+++ b/lexicons/docker/src/import/adapter.ts
@@ -1,0 +1,87 @@
+/**
+ * Adapters bridging the docker-specific DockerParser/DockerGenerator
+ * (which speak DockerIR / ParseResult / GenerateResult) to the core
+ * TemplateParser / TypeScriptGenerator interfaces consumed by
+ * `chant import` (packages/core/src/cli/commands/import.ts).
+ *
+ * The core import pipeline parses content into a TemplateIR (a flat list of
+ * ResourceIR), optionally organizes resources into category files, then asks
+ * the generator to emit GeneratedFile[]. We map each DockerIR to a ResourceIR
+ * keyed by its `kind` (service/volume/network/config/secret/dockerfile) and
+ * reverse the mapping in the generator so DockerGenerator can do the real work.
+ */
+
+import type { TemplateIR, TemplateParser, ResourceIR } from "@intentius/chant/import/parser";
+import type { GeneratedFile, TypeScriptGenerator } from "@intentius/chant/import/generator";
+import { DockerParser } from "./parser";
+import type { DockerIR, DockerfileStage } from "./parser";
+import { DockerGenerator } from "./generator";
+
+/** Convert a DockerIR into the core ResourceIR shape. */
+function dockerIrToResource(entity: DockerIR): ResourceIR {
+  if (entity.kind === "dockerfile") {
+    return {
+      logicalId: entity.name,
+      type: entity.kind,
+      properties: { stages: entity.stages },
+    };
+  }
+  return {
+    logicalId: entity.name,
+    type: entity.kind,
+    properties: entity.props,
+  };
+}
+
+/** Convert a core ResourceIR back into a DockerIR for DockerGenerator. */
+function resourceToDockerIr(resource: ResourceIR): DockerIR {
+  const name = resource.logicalId;
+  switch (resource.type) {
+    case "dockerfile":
+      return {
+        kind: "dockerfile",
+        name,
+        stages: (resource.properties.stages as DockerfileStage[] | undefined) ?? [],
+      };
+    case "service":
+    case "volume":
+    case "network":
+    case "config":
+    case "secret":
+      return {
+        kind: resource.type,
+        name,
+        props: resource.properties,
+      };
+    default:
+      // Unknown types from upstream organization are treated as services so
+      // they still round-trip rather than being silently dropped.
+      return { kind: "service", name, props: resource.properties };
+  }
+}
+
+/**
+ * TemplateParser adapter — wraps DockerParser.parse and maps its DockerIR
+ * entities to a TemplateIR.
+ */
+export class DockerTemplateParser implements TemplateParser {
+  parse(content: string): TemplateIR {
+    const { entities } = new DockerParser().parse(content);
+    return {
+      resources: entities.map(dockerIrToResource),
+      parameters: [],
+    };
+  }
+}
+
+/**
+ * TypeScriptGenerator adapter — converts a TemplateIR back into DockerIR[]
+ * and delegates to DockerGenerator, returning a single generated file.
+ */
+export class DockerTemplateGenerator implements TypeScriptGenerator {
+  generate(ir: TemplateIR): GeneratedFile[] {
+    const entities = ir.resources.map(resourceToDockerIr);
+    const { source } = new DockerGenerator().generate(entities);
+    return [{ path: "main.ts", content: source }];
+  }
+}

--- a/lexicons/docker/src/plugin.ts
+++ b/lexicons/docker/src/plugin.ts
@@ -16,8 +16,7 @@ import { dockerSerializer } from "./serializer";
 import { noLatestTagRule } from "./lint/rules/no-latest-tag";
 import { dockerCompletions } from "./lsp/completions";
 import { dockerHover } from "./lsp/hover";
-import { DockerParser } from "./import/parser";
-import { DockerGenerator } from "./import/generator";
+import { DockerTemplateParser, DockerTemplateGenerator } from "./import/adapter";
 
 export const dockerPlugin: LexiconPlugin = {
   name: "docker",
@@ -99,11 +98,11 @@ export const api = new Service({
   },
 
   templateParser() {
-    return new DockerParser();
+    return new DockerTemplateParser();
   },
 
   templateGenerator() {
-    return new DockerGenerator();
+    return new DockerTemplateGenerator();
   },
 
   async generate(options?: { verbose?: boolean }): Promise<void> {

--- a/lexicons/docker/src/serializer.ts
+++ b/lexicons/docker/src/serializer.ts
@@ -286,7 +286,7 @@ export const dockerSerializer: Serializer = {
         continue;
       }
 
-      const et = (entity as Record<string, unknown>).entityType as string;
+      const et = (entity as unknown as Record<string, unknown>).entityType as string;
 
       if (et === "Docker::Compose::Service") {
         services.set(name, entity);

--- a/lexicons/docker/tsconfig.build.json
+++ b/lexicons/docker/tsconfig.build.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {},
+    "moduleResolution": "bundler",
+    "customConditions": [
+      "development"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "node_modules",
+    "dist",
+    "docs"
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true
+  }
+}


### PR DESCRIPTION
Part of #433. Applies the #432/#434 packaging pattern to **docker**.

## Type fix (blocked declaration emit)
The docker plugin advertised `templateParser()`/`templateGenerator()` returning `DockerParser`/`DockerGenerator`, but those speak a docker-specific IR contract (`ParseResult` / `DockerIR[]` / `GenerateResult`) — incompatible with core's `TemplateParser`/`TypeScriptGenerator` (`TemplateIR` → `GeneratedFile[]`) that `chant import` calls. So docker import was type-incompatible **and broken at runtime**.

Docker template import is a real, tested feature (parser/generator/roundtrip suites + testdata), so the fix is a thin **lossless adapter** (`src/import/adapter.ts`) that maps `DockerIR`↔`ResourceIR` and delegates to the existing `DockerParser`/`DockerGenerator` (untouched, along with their tests). The plugin now returns the adapters, which `implement` the core interfaces — matching how k8s's parser/generator conform.

Plus the mechanical `Declarable`→`Record` cast widening in `serializer.ts`.

## Packaging
Conditional `exports` (`development`/`default`→src, `types`→dist `.d.ts`), declaration-only build (`tsc` → `tsc-alias` → strip `.js`), prepack wiring, `tsconfig.build.json`.

## Verification
- `npm run --prefix lexicons/docker build` → exit 0; declaration-only dist (47 `.d.ts`, 0 `.js`) with `.js` import extensions.
- `npx tsc --noEmit -p packages/core/tsconfig.json` → 0.
- `npx vitest run lexicons/docker` → 17 files, 159 tests pass.