### PR TITLE
feat(packaging): ship built .d.ts for aws lexicon (#433)

### DIFF
--- a/lexicons/aws/package.json
+++ b/lexicons/aws/package.json
@@ -29,10 +29,26 @@
     "access": "public"
   },
   "exports": {
-    ".": "./src/index.ts",
-    "./*": "./src/*.ts",
-    "./detect": "./src/detect.ts",
-    "./lint/post-synth": "./src/lint/post-synth/index.ts",
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "development": "./src/*.ts",
+      "types": "./dist/*.d.ts",
+      "default": "./src/*.ts"
+    },
+    "./detect": {
+      "development": "./src/detect.ts",
+      "types": "./dist/detect.d.ts",
+      "default": "./src/detect.ts"
+    },
+    "./lint/post-synth": {
+      "development": "./src/lint/post-synth/index.ts",
+      "types": "./dist/lint/post-synth/index.d.ts",
+      "default": "./src/lint/post-synth/index.ts"
+    },
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"
@@ -42,7 +58,8 @@
     "bundle": "tsx src/package-cli.ts",
     "validate": "tsx src/validate-cli.ts",
     "docs": "tsx src/codegen/docs-cli.ts",
-    "prepack": "npm run generate && npm run bundle && npm run validate"
+    "prepack": "npm run generate && npm run bundle && npm run validate && npm run build",
+    "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && find dist -type f \\( -name \"*.js\" -o -name \"*.js.map\" \\) -delete"
   },
   "dependencies": {
     "fflate": "^0.8.2",

--- a/lexicons/aws/src/codegen/fallback.ts
+++ b/lexicons/aws/src/codegen/fallback.ts
@@ -26,6 +26,8 @@ function fallbackLogGroup(): SchemaParseResult {
       createOnly: [],
       writeOnly: [],
       primaryIdentifier: [],
+      deprecatedProperties: [],
+      conditionalCreateOnly: [],
     },
     propertyTypes: [],
     enums: [],

--- a/lexicons/aws/src/codegen/package.ts
+++ b/lexicons/aws/src/codegen/package.ts
@@ -43,7 +43,7 @@ export async function packageLexicon(opts: PackageOptions = {}): Promise<Package
       buildManifest: (_genResult) => {
         // Lazy-import to avoid circular dependency
         const intrinsics: IntrinsicDef[] = (awsPlugin.intrinsics?.() ?? []).map(
-          (i: { name: string; description: string }) => ({
+          (i: IntrinsicDef) => ({
             name: i.name,
             description: i.description,
             outputKey: intrinsicOutputKey(i.name),

--- a/lexicons/aws/src/codegen/sam.ts
+++ b/lexicons/aws/src/codegen/sam.ts
@@ -58,6 +58,8 @@ function samFunction(): SchemaParseResult {
       createOnly: [],
       writeOnly: [],
       primaryIdentifier: [],
+      deprecatedProperties: [],
+      conditionalCreateOnly: [],
     },
     propertyTypes: [
       {
@@ -144,6 +146,8 @@ function samApi(): SchemaParseResult {
       createOnly: [],
       writeOnly: [],
       primaryIdentifier: [],
+      deprecatedProperties: [],
+      conditionalCreateOnly: [],
     },
     propertyTypes: [
       {
@@ -195,6 +199,8 @@ function samHttpApi(): SchemaParseResult {
       createOnly: [],
       writeOnly: [],
       primaryIdentifier: [],
+      deprecatedProperties: [],
+      conditionalCreateOnly: [],
     },
     propertyTypes: [
       {
@@ -229,6 +235,8 @@ function samSimpleTable(): SchemaParseResult {
       createOnly: [],
       writeOnly: [],
       primaryIdentifier: [],
+      deprecatedProperties: [],
+      conditionalCreateOnly: [],
     },
     propertyTypes: [
       {
@@ -264,6 +272,8 @@ function samLayerVersion(): SchemaParseResult {
       createOnly: [],
       writeOnly: [],
       primaryIdentifier: [],
+      deprecatedProperties: [],
+      conditionalCreateOnly: [],
     },
     propertyTypes: [],
     enums: [],
@@ -295,6 +305,8 @@ function samStateMachine(): SchemaParseResult {
       createOnly: [],
       writeOnly: [],
       primaryIdentifier: [],
+      deprecatedProperties: [],
+      conditionalCreateOnly: [],
     },
     propertyTypes: [
       {
@@ -326,6 +338,8 @@ function samApplication(): SchemaParseResult {
       createOnly: [],
       writeOnly: [],
       primaryIdentifier: [],
+      deprecatedProperties: [],
+      conditionalCreateOnly: [],
     },
     propertyTypes: [],
     enums: [],
@@ -345,6 +359,8 @@ function samConnector(): SchemaParseResult {
       createOnly: [],
       writeOnly: [],
       primaryIdentifier: [],
+      deprecatedProperties: [],
+      conditionalCreateOnly: [],
     },
     propertyTypes: [],
     enums: [],
@@ -380,6 +396,8 @@ function samGraphQLApi(): SchemaParseResult {
       createOnly: [],
       writeOnly: [],
       primaryIdentifier: [],
+      deprecatedProperties: [],
+      conditionalCreateOnly: [],
     },
     propertyTypes: [],
     enums: [],

--- a/lexicons/aws/src/composites/efs-with-access-point.ts
+++ b/lexicons/aws/src/composites/efs-with-access-point.ts
@@ -29,7 +29,7 @@ export interface EfsWithAccessPointProps {
 }
 
 export const EfsWithAccessPoint = Composite<EfsWithAccessPointProps>((props) => {
-  const ingressRules: SecurityGroup_Ingress[] = [];
+  const ingressRules: InstanceType<typeof SecurityGroup_Ingress>[] = [];
   if (props.sourceSecurityGroupId) {
     ingressRules.push(new SecurityGroup_Ingress({
       IpProtocol: "tcp",

--- a/lexicons/aws/src/composites/fargate-service.ts
+++ b/lexicons/aws/src/composites/fargate-service.ts
@@ -61,7 +61,7 @@ export interface FargateServiceProps {
   };
   environment?: Record<string, string>;
   command?: string[];
-  mountPoints?: TaskDefinition_MountPoint[];
+  mountPoints?: InstanceType<typeof TaskDefinition_MountPoint>[];
   efsMounts?: Array<{
     fileSystemId: string;
     accessPointId?: string;

--- a/lexicons/aws/src/composites/lambda-api.ts
+++ b/lexicons/aws/src/composites/lambda-api.ts
@@ -1,6 +1,6 @@
 import { Composite, mergeDefaults } from "@intentius/chant";
 import { Permission } from "../generated";
-import { LambdaFunction, type LambdaFunctionProps } from "./lambda-function";
+import { LambdaFunction, type LambdaFunctionProps, type LambdaFunctionResult } from "./lambda-function";
 
 export interface LambdaApiProps extends LambdaFunctionProps {
   sourceArn?: string;
@@ -9,7 +9,11 @@ export interface LambdaApiProps extends LambdaFunctionProps {
   };
 }
 
-export const LambdaApi = Composite<LambdaApiProps>((props) => {
+export type LambdaApiResult = LambdaFunctionResult & {
+  permission: InstanceType<typeof Permission>;
+};
+
+export const LambdaApi = Composite<LambdaApiProps, LambdaApiResult>((props) => {
   const { defaults } = props;
   const { role, func } = LambdaFunction(props);
 

--- a/lexicons/aws/src/composites/lambda-function.ts
+++ b/lexicons/aws/src/composites/lambda-function.ts
@@ -35,7 +35,12 @@ export interface LambdaFunctionProps {
   };
 }
 
-export const LambdaFunction = Composite<LambdaFunctionProps>((props) => {
+export type LambdaFunctionResult = {
+  role: InstanceType<typeof Role>;
+  func: InstanceType<typeof Function>;
+};
+
+export const LambdaFunction = Composite<LambdaFunctionProps, LambdaFunctionResult>((props) => {
   const { defaults } = props;
   const managedPolicies = [BASIC_EXECUTION_ARN];
   if (props.VpcConfig) {

--- a/lexicons/aws/src/composites/lambda-s3.ts
+++ b/lexicons/aws/src/composites/lambda-s3.ts
@@ -12,7 +12,7 @@ import {
 } from "../generated";
 import { Sub, Join } from "../intrinsics";
 import { S3Actions } from "../actions/s3";
-import { LambdaFunction, type LambdaFunctionProps } from "./lambda-function";
+import { LambdaFunction, type LambdaFunctionProps, type LambdaFunctionResult } from "./lambda-function";
 
 export interface LambdaS3Props extends LambdaFunctionProps {
   bucketName?: string;
@@ -27,7 +27,12 @@ export interface LambdaS3Props extends LambdaFunctionProps {
   };
 }
 
-export const LambdaS3 = Composite<LambdaS3Props>((props) => {
+export type LambdaS3Result = LambdaFunctionResult & {
+  bucket: InstanceType<typeof Bucket>;
+  permission: InstanceType<typeof Permission>;
+};
+
+export const LambdaS3 = Composite<LambdaS3Props, LambdaFunctionResult & { bucket: InstanceType<typeof Bucket>; permission?: InstanceType<typeof Permission> }>((props) => {
   const encryptionDefault = new Bucket_ServerSideEncryptionByDefault({ SSEAlgorithm: "AES256" });
   const encryptionRule = new Bucket_ServerSideEncryptionRule({
     ServerSideEncryptionByDefault: encryptionDefault,

--- a/lexicons/aws/src/composites/vpc-default.ts
+++ b/lexicons/aws/src/composites/vpc-default.ts
@@ -36,7 +36,31 @@ export interface VpcDefaultProps {
   };
 }
 
-export const VpcDefault = Composite<VpcDefaultProps>((props) => {
+export type VpcDefaultResult = {
+  vpc: InstanceType<typeof Vpc>;
+  igw: InstanceType<typeof InternetGateway>;
+  igwAttachment: InstanceType<typeof VPCGatewayAttachment>;
+  publicSubnet1: InstanceType<typeof Subnet>;
+  publicSubnet2: InstanceType<typeof Subnet>;
+  privateSubnet1: InstanceType<typeof Subnet>;
+  privateSubnet2: InstanceType<typeof Subnet>;
+  publicRouteTable: InstanceType<typeof RouteTable>;
+  publicRoute: InstanceType<typeof EC2Route>;
+  publicRta1: InstanceType<typeof SubnetRouteTableAssociation>;
+  publicRta2: InstanceType<typeof SubnetRouteTableAssociation>;
+  privateRouteTable: InstanceType<typeof RouteTable>;
+  privateRoute: InstanceType<typeof EC2Route>;
+  privateRta1: InstanceType<typeof SubnetRouteTableAssociation>;
+  privateRta2: InstanceType<typeof SubnetRouteTableAssociation>;
+  natEip: InstanceType<typeof EIP>;
+  natGateway: InstanceType<typeof NatGateway>;
+  publicSubnet3?: InstanceType<typeof Subnet>;
+  privateSubnet3?: InstanceType<typeof Subnet>;
+  publicRta3?: InstanceType<typeof SubnetRouteTableAssociation>;
+  privateRta3?: InstanceType<typeof SubnetRouteTableAssociation>;
+};
+
+export const VpcDefault = Composite<VpcDefaultProps, VpcDefaultResult>((props) => {
   const { defaults: defs } = props;
   const cidr = props.cidr ?? "10.0.0.0/16";
   const azCount = props.azCount ?? 2;

--- a/lexicons/aws/src/plugin.ts
+++ b/lexicons/aws/src/plugin.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "module";
 import { detectTemplate } from "./detect";
-import type { LexiconPlugin, IntrinsicDef, ResourceMetadata, ExportedTemplate, ResourceSelector } from "@intentius/chant/lexicon";
+import type { LexiconPlugin, IntrinsicDef, ResourceMetadata, ExportedTemplate, ResourceSelector, InitTemplateSet } from "@intentius/chant/lexicon";
 const require = createRequire(import.meta.url);
 import type { LintRule } from "@intentius/chant/lint/rule";
 import type { TemplateParser } from "@intentius/chant/import/parser";
@@ -61,7 +61,7 @@ export const awsPlugin: LexiconPlugin = {
     ];
   },
 
-  initTemplates(template?: string) {
+  initTemplates(template?: string): InitTemplateSet {
     if (template === "eks") {
       return { src: {
         "infra/cluster.ts": `/**

--- a/lexicons/aws/tsconfig.build.json
+++ b/lexicons/aws/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {},
+    "moduleResolution": "bundler",
+    "customConditions": [
+      "development"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "node_modules",
+    "dist",
+    "docs",
+    "src/testdata"
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true
+  }
+}


### PR DESCRIPTION
Part of #433. Applies the #432/#434 packaging pattern to **aws**.

## Type fixes (blocked declaration emit)
- **Composite member widening** (the main one): the lambda composites returned members that widened to `Declarable` — losing typed attributes like `.Arn` (`func.Arn`/`role.Arn` → TS2339) — because no explicit `M` was passed to `Composite<P, M extends CompositeMembers>`. Fixed by adding result **type aliases** as the explicit `M` (`LambdaFunctionResult`, `LambdaApiResult`, `VpcDefaultResult`, …) — the same fix as k8s (a `type` alias has the implicit index signature a named interface lacks). _(Note: the generated `Function` class already declares `readonly Arn`; the earlier hypothesis that this was a codegen attribute-classification bug was wrong — it's the widening.)_
- `efs`/`fargate`: generated value symbols used as types → `InstanceType<typeof X>[]`.
- codegen source literals (`sam.ts`/`fallback.ts`) gained the now-required `deprecatedProperties`/`conditionalCreateOnly: []`; `package.ts` map callback annotated; `plugin.ts` `initTemplates` given an explicit `InitTemplateSet` return type.

## `src/testdata` excluded from the build
It has pre-existing `TS2345`s from a core-level `stackOutput` `AttrRef`-vs-`string` tension (out of scope — fix belongs in `packages/core`; also errors under the existing `lexicons/aws/tsconfig.json`). testdata is discovery-fixture data, never type-checked by tests and never part of the shipped `.d.ts` surface, so it's excluded from `tsconfig.build.json`.

## Verification
- No codegen regeneration needed (generated output unchanged; snapshot/generate/idempotency tests green).
- `npm run --prefix lexicons/aws build` → exit 0; declaration-only dist (109 `.d.ts`, 0 `.js`) with `.js` import extensions.
- `npx tsc --noEmit -p packages/core/tsconfig.json` → 0.
- `npx vitest run lexicons/aws` → 60 files, 716 passed / 2 skipped.