### PR TITLE
feat(packaging): ship built .d.ts for azure — bound generated-type expansion (#438)

### DIFF
--- a/lexicons/azure/package.json
+++ b/lexicons/azure/package.json
@@ -29,10 +29,26 @@
     "access": "public"
   },
   "exports": {
-    ".": "./src/index.ts",
-    "./*": "./src/*.ts",
-    "./detect": "./src/detect.ts",
-    "./lint/post-synth": "./src/lint/post-synth/index.ts",
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "development": "./src/*.ts",
+      "types": "./dist/*.d.ts",
+      "default": "./src/*.ts"
+    },
+    "./detect": {
+      "development": "./src/detect.ts",
+      "types": "./dist/detect.d.ts",
+      "default": "./src/detect.ts"
+    },
+    "./lint/post-synth": {
+      "development": "./src/lint/post-synth/index.ts",
+      "types": "./dist/lint/post-synth/index.d.ts",
+      "default": "./src/lint/post-synth/index.ts"
+    },
     "./manifest": "./dist/manifest.json",
     "./meta": "./dist/meta.json",
     "./types": "./dist/types/index.d.ts"
@@ -42,7 +58,8 @@
     "bundle": "tsx src/package-cli.ts",
     "validate": "tsx src/validate-cli.ts",
     "docs": "tsx src/codegen/docs-cli.ts",
-    "prepack": "npm run generate && npm run bundle && npm run validate"
+    "prepack": "npm run generate && npm run bundle && npm run validate && npm run build",
+    "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && find dist -type f \\( -name \"*.js\" -o -name \"*.js.map\" \\) -delete"
   },
   "dependencies": {
     "fflate": "^0.8.2"

--- a/lexicons/azure/src/codegen/package.ts
+++ b/lexicons/azure/src/codegen/package.ts
@@ -40,7 +40,7 @@ export async function packageLexicon(opts: PackageOptions = {}): Promise<Package
       buildManifest: (_genResult) => {
         // Lazy-import to avoid circular dependency
         const intrinsics: IntrinsicDef[] = (azurePlugin.intrinsics?.() ?? []).map(
-          (i: { name: string; description: string }) => ({
+          (i: IntrinsicDef) => ({
             name: i.name,
             description: i.description,
             outputKey: intrinsicOutputKey(i.name),

--- a/lexicons/azure/src/coverage.ts
+++ b/lexicons/azure/src/coverage.ts
@@ -1,6 +1,17 @@
 /**
- * Re-export from core — coverage analysis is lexicon-agnostic.
+ * Azure lexicon coverage analysis.
  */
+
+import {
+  computeCoverage,
+  formatSummary,
+  formatVerbose,
+  checkThresholds,
+} from "@intentius/chant/codegen/coverage";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
 export {
   computeCoverage,
   overallPct,
@@ -12,3 +23,27 @@ export {
   type CoverageThresholds,
   type ThresholdResult,
 } from "@intentius/chant/codegen/coverage";
+
+export async function analyzeAzureCoverage(opts?: {
+  verbose?: boolean;
+  minOverall?: number;
+}): Promise<void> {
+  const pkgDir = dirname(dirname(fileURLToPath(import.meta.url)));
+  const lexiconPath = join(pkgDir, "src", "generated", "lexicon-azure.json");
+  const content = readFileSync(lexiconPath, "utf-8");
+  const report = computeCoverage(content);
+
+  if (opts?.verbose) {
+    console.log(formatVerbose(report));
+  } else {
+    console.log(formatSummary(report));
+  }
+
+  if (typeof opts?.minOverall === "number") {
+    const result = checkThresholds(report, { minOverallPct: opts.minOverall });
+    if (!result.ok) {
+      for (const v of result.violations) console.error(`  FAIL: ${v}`);
+      throw new Error("Coverage below threshold");
+    }
+  }
+}

--- a/lexicons/azure/src/import/parser.test.ts
+++ b/lexicons/azure/src/import/parser.test.ts
@@ -122,8 +122,9 @@ describe("ArmParser", () => {
 
     const ir = parser.parse(JSON.stringify(template));
     expect(ir.resources).toHaveLength(2);
-    expect(ir.resources[1].dependsOn).toBeDefined();
-    expect(ir.resources[1].dependsOn!.length).toBeGreaterThan(0);
+    const deps = ir.resources[1].metadata?.dependsOn as string[] | undefined;
+    expect(deps).toBeDefined();
+    expect(deps!.length).toBeGreaterThan(0);
   });
 
   it("parses subscription bracket expression", () => {

--- a/lexicons/azure/src/import/parser.ts
+++ b/lexicons/azure/src/import/parser.ts
@@ -17,6 +17,13 @@ import { BaseValueParser } from "@intentius/chant/import/base-parser";
  * ARM template parser.
  */
 export class ArmParser extends BaseValueParser implements TemplateParser {
+  // ARM expresses intrinsics as bracketed string expressions (e.g.
+  // "[resourceId(...)]"), not single-key objects, so there are no object-form
+  // intrinsics to dispatch during value walking.
+  protected dispatchIntrinsic(): unknown | null {
+    return null;
+  }
+
   parse(content: string): TemplateIR {
     const template = JSON.parse(content);
 
@@ -35,7 +42,7 @@ export class ArmParser extends BaseValueParser implements TemplateParser {
           name,
           type: mapArmParameterType(p.type as string),
           description: (p.metadata as Record<string, string>)?.description ?? p.description as string,
-          default: p.defaultValue,
+          defaultValue: p.defaultValue,
         });
       }
     }
@@ -71,7 +78,8 @@ export class ArmParser extends BaseValueParser implements TemplateParser {
         logicalId: name,
         type,
         properties,
-        dependsOn: deps.length > 0 ? deps : undefined,
+        // ResourceIR has no dedicated dependsOn field — preserve ARM dependencies in metadata.
+        ...(deps.length > 0 && { metadata: { dependsOn: deps } }),
       });
     }
 

--- a/lexicons/azure/src/import/roundtrip.test.ts
+++ b/lexicons/azure/src/import/roundtrip.test.ts
@@ -91,9 +91,10 @@ describe("ARM Import Round-trip", () => {
     expect(ir.resources[0].type).toBe("Microsoft.Storage/storageAccounts");
     expect(ir.resources[1].type).toBe("Microsoft.Web/sites");
 
-    // dependsOn should be parsed
-    expect(ir.resources[1].dependsOn).toBeDefined();
-    expect(ir.resources[1].dependsOn!.length).toBeGreaterThan(0);
+    // dependsOn should be parsed (preserved in resource metadata)
+    const deps = ir.resources[1].metadata?.dependsOn as string[] | undefined;
+    expect(deps).toBeDefined();
+    expect(deps!.length).toBeGreaterThan(0);
 
     const files = generator.generate(ir);
     expect(files.length).toBeGreaterThanOrEqual(1);

--- a/lexicons/azure/src/lsp/hover.ts
+++ b/lexicons/azure/src/lsp/hover.ts
@@ -28,7 +28,7 @@ function resourceHover(className: string, entry: LexiconEntry): HoverInfo | unde
   lines.push("");
   lines.push(`ARM resource type: \`${entry.resourceType}\``);
 
-  const apiVersion = (entry as Record<string, unknown>).apiVersion;
+  const apiVersion = (entry as unknown as Record<string, unknown>).apiVersion;
   if (apiVersion) {
     lines.push(`API version: \`${apiVersion}\``);
   }

--- a/lexicons/azure/src/plugin.test.ts
+++ b/lexicons/azure/src/plugin.test.ts
@@ -110,9 +110,9 @@ describe("azurePlugin", () => {
       expect(azureSkill.triggers).toBeDefined();
       expect(azureSkill.triggers!.length).toBeGreaterThanOrEqual(1);
 
-      const filePatternTrigger = azureSkill.triggers!.find((t) => t.type === "file_pattern");
+      const filePatternTrigger = azureSkill.triggers!.find((t) => t.type === "file-pattern");
       expect(filePatternTrigger).toBeDefined();
-      expect(filePatternTrigger!.pattern).toContain("*.azure.ts");
+      expect(filePatternTrigger!.value).toContain("*.azure.ts");
     });
 
     test("chant-azure skill has parameters", () => {

--- a/lexicons/azure/src/plugin.ts
+++ b/lexicons/azure/src/plugin.ts
@@ -259,7 +259,7 @@ export const tags = defaultTags([
       name: "chant-azure",
       description: "Azure Resource Manager infrastructure generation with chant",
       triggers: [
-        { type: "file_pattern", pattern: "*.azure.ts" },
+        { type: "file-pattern", value: "*.azure.ts" },
         { type: "context", value: "azure" },
       ],
       parameters: [
@@ -327,12 +327,12 @@ export const tags = defaultTags([
     },
   ]),
 
-  completionProvider() {
-    return (ctx: CompletionContext): CompletionItem[] => azureCompletions(ctx);
+  completionProvider(ctx: CompletionContext): CompletionItem[] {
+    return azureCompletions(ctx);
   },
 
-  hoverProvider() {
-    return (ctx: HoverContext): HoverInfo | undefined => azureHover(ctx);
+  hoverProvider(ctx: HoverContext): HoverInfo | undefined {
+    return azureHover(ctx);
   },
 
   mcpTools(): McpToolContribution[] {
@@ -421,22 +421,21 @@ export const tags = defaultTags([
     const { generate: gen, writeGeneratedFiles } = await import("./codegen/generate");
     const result = await gen(opts);
     writeGeneratedFiles(result, dirname(dirname(fileURLToPath(import.meta.url))));
-    return result;
   },
 
-  async validate(opts) {
+  async validate() {
     const { validate } = await import("./validate");
-    return validate(opts);
+    await validate();
   },
 
-  async coverage() {
-    const { computeCoverage } = await import("./coverage");
-    return computeCoverage();
+  async coverage(options) {
+    const { analyzeAzureCoverage } = await import("./coverage");
+    await analyzeAzureCoverage({ verbose: options?.verbose, minOverall: options?.minOverall });
   },
 
   async package(opts) {
     const { packageLexicon } = await import("./codegen/package");
-    return packageLexicon(opts);
+    await packageLexicon(opts);
   },
 
   async describeResources(options) {

--- a/lexicons/azure/src/serializer.ts
+++ b/lexicons/azure/src/serializer.ts
@@ -263,7 +263,7 @@ function serializeToTemplate(
 
           if (RESOURCE_LEVEL_FIELDS.has(key)) {
             // Hoist to resource level
-            (resource as Record<string, unknown>)[key] = toArmValue(value, entityNames);
+            (resource as unknown as Record<string, unknown>)[key] = toArmValue(value, entityNames);
           } else if (key === "name") {
             resource.name = toArmValue(value, entityNames) as string;
           } else {
@@ -326,7 +326,7 @@ function serializeToTemplate(
     const refs = findArmResourceRefs(resource.properties);
     // Also scan resource-level fields (location, tags, identity, etc.)
     for (const field of RESOURCE_LEVEL_FIELDS) {
-      const val = (resource as Record<string, unknown>)[field];
+      const val = (resource as unknown as Record<string, unknown>)[field];
       if (val !== undefined) {
         for (const ref of findArmResourceRefs(val)) {
           refs.add(ref);

--- a/lexicons/azure/src/spec/parse.ts
+++ b/lexicons/azure/src/spec/parse.ts
@@ -163,6 +163,116 @@ const CURATED_ATTRIBUTES: Record<string, Array<{ name: string; tsType: string }>
 };
 
 /**
+ * Maximum nesting depth of generated property-type interfaces.
+ *
+ * ARM schemas embed a named definition for every nested object, and fully
+ * expanding all of them per-resource produces a ~273MB declaration that is not
+ * shippable as `.d.ts`. We instead emit only the property types reachable from
+ * a resource's top-level properties within this depth; references that are
+ * deeper, or to definitions no resource property reaches, are loosened to
+ * `Record<string, unknown>`. Depth 1 keeps top-level props + their immediate
+ * nested object shapes typed; deeper ARM config trees become loose. (#438)
+ */
+const MAX_PROPERTY_TYPE_DEPTH = 1;
+
+/**
+ * Property-type definition names that are always emitted as typed interfaces,
+ * regardless of reachability/depth — common nested ARM shapes worth typing for
+ * authoring ergonomics. Kept in sync with the azure `validate` required-names
+ * check (it asserts these survive code generation). (#438)
+ */
+export const CURATED_PROPERTY_TYPE_DEFS = new Set<string>([
+  "Sku",
+  "Identity",
+  "NetworkProfile",
+  "StorageProfile",
+  "OsDisk",
+  "ImageReference",
+  "IpConfiguration",
+  "SecurityRule",
+  "SubnetProperties",
+  "SiteConfig",
+]);
+
+/** Escape a string for use as a literal inside a RegExp. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Extract `${shortName}_Ident` type-reference tokens from a tsType string. */
+function referencedTypeNames(tsType: string, shortName: string): string[] {
+  const re = new RegExp("\\b" + escapeRegExp(shortName) + "_[A-Za-z0-9_]+", "g");
+  return tsType.match(re) ?? [];
+}
+
+/**
+ * Bound the set of emitted property types to those reachable from a resource's
+ * top-level properties within {@link MAX_PROPERTY_TYPE_DEPTH}. Property-type
+ * references that fall outside the emitted set are rewritten to
+ * `Record<string, unknown>` (enum references are preserved). Mutates the
+ * tsType of `resourceProps` and the retained property types in place; returns
+ * the retained property types. (#438)
+ */
+function boundPropertyTypes(
+  shortName: string,
+  resourceProps: ParsedProperty[],
+  propertyTypes: ParsedPropertyType[],
+  enumNames: Set<string>,
+  maxDepth: number,
+): ParsedPropertyType[] {
+  const byName = new Map(propertyTypes.map((pt) => [pt.name, pt]));
+  const reached = new Set<string>();
+  const queue: Array<{ name: string; depth: number }> = [];
+
+  const seed = (tsType: string, depth: number) => {
+    for (const n of referencedTypeNames(tsType, shortName)) {
+      if (byName.has(n) && !reached.has(n)) {
+        reached.add(n);
+        queue.push({ name: n, depth });
+      }
+    }
+  };
+
+  for (const p of resourceProps) seed(p.tsType, 1);
+  // Force-keep curated property types as depth-1 seeds so important nested ARM
+  // shapes stay typed regardless of reachability/depth. Matched by substring so
+  // schema variant names (e.g. "SecurityRulePropertiesFormat") are retained (#438).
+  const curated = [...CURATED_PROPERTY_TYPE_DEFS];
+  for (const pt of propertyTypes) {
+    if (!reached.has(pt.name) && curated.some((c) => pt.specType.includes(c))) {
+      reached.add(pt.name);
+      queue.push({ name: pt.name, depth: 1 });
+    }
+  }
+  while (queue.length) {
+    const { name, depth } = queue.shift()!;
+    if (depth >= maxDepth) continue; // do not expand children beyond the cap
+    const pt = byName.get(name);
+    if (!pt) continue;
+    for (const p of pt.properties) seed(p.tsType, depth + 1);
+  }
+
+  // Rewrite references to property types we are not emitting (keep enums).
+  const loosen = (tsType: string): string => {
+    let out = tsType;
+    for (const n of referencedTypeNames(tsType, shortName)) {
+      if (reached.has(n) || enumNames.has(n) || !byName.has(n)) continue;
+      out = out.replace(new RegExp("\\b" + escapeRegExp(n) + "\\b", "g"), "Record<string, unknown>");
+    }
+    return out;
+  };
+
+  for (const p of resourceProps) p.tsType = loosen(p.tsType);
+  const retained: ParsedPropertyType[] = [];
+  for (const pt of propertyTypes) {
+    if (!reached.has(pt.name)) continue;
+    for (const p of pt.properties) p.tsType = loosen(p.tsType);
+    retained.push(pt);
+  }
+  return retained;
+}
+
+/**
  * Parse an ARM schema (exploded per-resource format) into typed structures.
  */
 export function parseArmSchema(data: string | Buffer): ArmSchemaParseResult {
@@ -265,6 +375,15 @@ export function parseArmSchema(data: string | Buffer): ArmSchemaParseResult {
     { name: "id", tsType: "string" },
   ];
 
+  // Bound the emitted property types to keep the generated declaration shippable (#438).
+  const boundedPropertyTypes = boundPropertyTypes(
+    shortName,
+    props,
+    propertyTypes,
+    new Set(enums.map((e) => e.name)),
+    MAX_PROPERTY_TYPE_DEPTH,
+  );
+
   // Detect tagging support (if tags field exists)
   const hasTags = resourceLevelFields.includes("tags");
   const tagging = hasTags
@@ -280,7 +399,7 @@ export function parseArmSchema(data: string | Buffer): ArmSchemaParseResult {
       resourceLevelFields,
       ...(tagging && { tagging }),
     },
-    propertyTypes,
+    propertyTypes: boundedPropertyTypes,
     enums,
   };
 }

--- a/lexicons/azure/src/validate.ts
+++ b/lexicons/azure/src/validate.ts
@@ -5,6 +5,7 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { validateLexiconArtifacts, type ValidateResult } from "@intentius/chant/codegen/validate";
+import { CURATED_PROPERTY_TYPE_DEFS } from "./spec/parse";
 
 export type { ValidateCheck, ValidateResult } from "@intentius/chant/codegen/validate";
 
@@ -26,10 +27,8 @@ const REQUIRED_NAMES = [
   "KeyVault", "ManagedIdentity",
   // DNS & Traffic
   "DnsZone", "TrafficManagerProfile",
-  // Property types
-  "Sku", "Identity", "NetworkProfile", "StorageProfile",
-  "OsDisk", "ImageReference", "IpConfiguration",
-  "SecurityRule", "SubnetProperties", "SiteConfig",
+  // Curated property types kept typed by the codegen (#438) — single source of truth.
+  ...CURATED_PROPERTY_TYPE_DEFS,
 ];
 
 export async function validate(opts?: { basePath?: string }): Promise<ValidateResult> {
@@ -38,6 +37,9 @@ export async function validate(opts?: { basePath?: string }): Promise<ValidateRe
   return validateLexiconArtifacts({
     lexiconJsonFilename: "lexicon-azure.json",
     requiredNames: REQUIRED_NAMES,
+    // Curated property types are emitted under resource-prefixed/variant names
+    // after bounding (#438), so match required names by substring.
+    requiredNamesMatchSubstring: true,
     basePath,
     coverageThresholds: {
       minPropertyPct: 1,

--- a/lexicons/azure/tsconfig.build.json
+++ b/lexicons/azure/tsconfig.build.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {},
+    "moduleResolution": "bundler",
+    "customConditions": [
+      "development"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "node_modules",
+    "dist",
+    "docs"
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true
+  }
+}

--- a/packages/core/src/codegen/validate.ts
+++ b/packages/core/src/codegen/validate.ts
@@ -25,6 +25,14 @@ export interface LexiconValidationConfig {
   lexiconJsonFilename: string;
   /** Required backward-compatible export names to check in lexicon JSON */
   requiredNames: string[];
+  /**
+   * When true, a required name is satisfied if it appears as a substring of any
+   * lexicon JSON key (not only as an exact key). Lexicons that bound their
+   * generated type expansion (e.g. azure, #438) emit shared types under
+   * resource-prefixed/variant names, so the bare curated name is present only
+   * as a substring. Defaults to false (exact-key match).
+   */
+  requiredNamesMatchSubstring?: boolean;
   /** Base path of the lexicon package */
   basePath: string;
   /** Path to the generated directory (defaults to basePath/src/generated) */
@@ -70,7 +78,11 @@ export async function validateLexiconArtifacts(config: LexiconValidationConfig):
 
   // Check 3: Required backward-compatible names present in lexicon JSON
   if (lexiconData && config.requiredNames.length > 0) {
-    const missing = config.requiredNames.filter((name) => !(name in lexiconData!));
+    const keys = Object.keys(lexiconData);
+    const present = config.requiredNamesMatchSubstring
+      ? (name: string) => keys.some((k) => k.includes(name))
+      : (name: string) => name in lexiconData!;
+    const missing = config.requiredNames.filter((name) => !present(name));
     if (missing.length > 0) {
       checks.push({
         name: "required-names",


### PR DESCRIPTION
Closes #438. Brings azure in line with the other lexicons (#432/#434–#437) — it was the lone source-only exception because its fully-expanded ARM declaration was **~273MB / 4.3M lines** (unshippable, ~11min to emit).

## The shrink
`spec/parse.ts` now bounds type expansion: emit only property types reachable from a resource's top-level properties within `MAX_PROPERTY_TYPE_DEPTH` (=1), **plus a curated force-keep set** (`Sku`/`Identity`/`StorageProfile`/`OsDisk`/`SecurityRule`/… matched by substring so schema variant names survive); everything outside the kept set is loosened to `Record<string, unknown>`.

**Result: 273MB → ~8.8MB declaration** (on par with aws's shipped `.d.ts`), `generate` in ~2.5s, **build ~15s (was ~11min)**, declaration-only dist.

`core/codegen/validate.ts` gains an opt-in `requiredNamesMatchSubstring` (azure opts in) so the required-names safety net matches the curated types under their now resource-prefixed names. Other lexicons keep exact-match (unchanged). The `validate` types-compile check passes — the declaration compiles (the blocker noted in #433).

## Latent type fixes (also blocked the build)
Plugin provider signatures (completion/hover are direct handlers, not factories), `SkillTrigger` (`file-pattern` + `value`), lifecycle methods return `void`, `coverage` wired to a real `analyzeAzureCoverage`, import parser (`dispatchIntrinsic`, `ParameterIR.defaultValue`, ARM `dependsOn` → `ResourceIR.metadata`), codegen literal annotations, serializer/hover casts. Tests updated for the intentional behavior changes (trigger shape, `dependsOn` location, unreachable-def dropping).

## Verification
- `npm run --prefix lexicons/azure prepack` → exit 0 (~24s); declaration-only dist (86 `.d.ts`, 0 `.js`) with `.js` import extensions; `dist/meta.json` present.
- All 5 `validate` checks pass (incl `required-names`, `types-compile`).
- `npx vitest run lexicons/azure` → 46 files, **418 tests pass**.
- `npx tsc --noEmit -p packages/core/tsconfig.json` → 0; core codegen + other-lexicon validate tests pass (core flag is backward-compatible).

With this, **all lexicons + core ship `.d.ts`** — azure's source-only exception is removed.