### PR TITLE
feat(packaging): trim aws consumer-facing .d.ts; share the bounding helper (#440)

### DIFF
--- a/lexicons/aws/src/codegen/__snapshots__/snapshot.test.ts.snap
+++ b/lexicons/aws/src/codegen/__snapshots__/snapshot.test.ts.snap
@@ -158,7 +158,6 @@ exports[`snapshot tests > generated resource names 1`] = `
   "EventSource",
   "Function",
   "Function_Code",
-  "Function_Tag",
   "GraphQLApi",
   "HttpApi",
   "HttpApi_CorsConfiguration",

--- a/lexicons/aws/src/spec/parse.ts
+++ b/lexicons/aws/src/spec/parse.ts
@@ -17,8 +17,18 @@ import {
   type JsonSchemaProperty,
   type JsonSchemaDefinition,
 } from "@intentius/chant/codegen/json-schema";
+import { boundPropertyTypes } from "@intentius/chant/codegen/bound-property-types";
 
 export type { PropertyConstraints } from "@intentius/chant/codegen/json-schema";
+
+/**
+ * Maximum nesting depth of generated property-type interfaces. Bounds the
+ * shipped `.d.ts` size: property types reachable from a resource's top-level
+ * properties within this depth stay typed; deeper ones are loosened to
+ * `Record<string, unknown>`. Set high enough that the shapes composites consume
+ * (which reach a few levels into CFN config) remain typed. (#440)
+ */
+const MAX_PROPERTY_TYPE_DEPTH = 3;
 
 export interface ParsedProperty {
   name: string;
@@ -182,6 +192,16 @@ export function parseCFNSchema(data: string | Buffer): SchemaParseResult {
     replacementStrategy = schema.replacementStrategy;
   }
 
+  // Bound the emitted property types to keep the shipped declaration small while
+  // preserving the shapes composites and shallow authoring rely on (#440).
+  const boundedPropertyTypes = boundPropertyTypes(
+    shortName,
+    props,
+    propertyTypes,
+    new Set(enums.map((e) => e.name)),
+    { maxDepth: MAX_PROPERTY_TYPE_DEPTH },
+  );
+
   return {
     resource: {
       typeName: schema.typeName,
@@ -195,7 +215,7 @@ export function parseCFNSchema(data: string | Buffer): SchemaParseResult {
       ...(replacementStrategy && { replacementStrategy }),
       ...(tagging && { tagging }),
     },
-    propertyTypes,
+    propertyTypes: boundedPropertyTypes,
     enums,
   };
 }

--- a/lexicons/azure/src/spec/parse.ts
+++ b/lexicons/azure/src/spec/parse.ts
@@ -24,6 +24,8 @@ import {
   type JsonSchemaDefinition,
 } from "@intentius/chant/codegen/json-schema";
 
+import { boundPropertyTypes } from "@intentius/chant/codegen/bound-property-types";
+
 export type { PropertyConstraints } from "@intentius/chant/codegen/json-schema";
 
 export interface ParsedProperty {
@@ -194,84 +196,6 @@ export const CURATED_PROPERTY_TYPE_DEFS = new Set<string>([
   "SiteConfig",
 ]);
 
-/** Escape a string for use as a literal inside a RegExp. */
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/** Extract `${shortName}_Ident` type-reference tokens from a tsType string. */
-function referencedTypeNames(tsType: string, shortName: string): string[] {
-  const re = new RegExp("\\b" + escapeRegExp(shortName) + "_[A-Za-z0-9_]+", "g");
-  return tsType.match(re) ?? [];
-}
-
-/**
- * Bound the set of emitted property types to those reachable from a resource's
- * top-level properties within {@link MAX_PROPERTY_TYPE_DEPTH}. Property-type
- * references that fall outside the emitted set are rewritten to
- * `Record<string, unknown>` (enum references are preserved). Mutates the
- * tsType of `resourceProps` and the retained property types in place; returns
- * the retained property types. (#438)
- */
-function boundPropertyTypes(
-  shortName: string,
-  resourceProps: ParsedProperty[],
-  propertyTypes: ParsedPropertyType[],
-  enumNames: Set<string>,
-  maxDepth: number,
-): ParsedPropertyType[] {
-  const byName = new Map(propertyTypes.map((pt) => [pt.name, pt]));
-  const reached = new Set<string>();
-  const queue: Array<{ name: string; depth: number }> = [];
-
-  const seed = (tsType: string, depth: number) => {
-    for (const n of referencedTypeNames(tsType, shortName)) {
-      if (byName.has(n) && !reached.has(n)) {
-        reached.add(n);
-        queue.push({ name: n, depth });
-      }
-    }
-  };
-
-  for (const p of resourceProps) seed(p.tsType, 1);
-  // Force-keep curated property types as depth-1 seeds so important nested ARM
-  // shapes stay typed regardless of reachability/depth. Matched by substring so
-  // schema variant names (e.g. "SecurityRulePropertiesFormat") are retained (#438).
-  const curated = [...CURATED_PROPERTY_TYPE_DEFS];
-  for (const pt of propertyTypes) {
-    if (!reached.has(pt.name) && curated.some((c) => pt.specType.includes(c))) {
-      reached.add(pt.name);
-      queue.push({ name: pt.name, depth: 1 });
-    }
-  }
-  while (queue.length) {
-    const { name, depth } = queue.shift()!;
-    if (depth >= maxDepth) continue; // do not expand children beyond the cap
-    const pt = byName.get(name);
-    if (!pt) continue;
-    for (const p of pt.properties) seed(p.tsType, depth + 1);
-  }
-
-  // Rewrite references to property types we are not emitting (keep enums).
-  const loosen = (tsType: string): string => {
-    let out = tsType;
-    for (const n of referencedTypeNames(tsType, shortName)) {
-      if (reached.has(n) || enumNames.has(n) || !byName.has(n)) continue;
-      out = out.replace(new RegExp("\\b" + escapeRegExp(n) + "\\b", "g"), "Record<string, unknown>");
-    }
-    return out;
-  };
-
-  for (const p of resourceProps) p.tsType = loosen(p.tsType);
-  const retained: ParsedPropertyType[] = [];
-  for (const pt of propertyTypes) {
-    if (!reached.has(pt.name)) continue;
-    for (const p of pt.properties) p.tsType = loosen(p.tsType);
-    retained.push(pt);
-  }
-  return retained;
-}
-
 /**
  * Parse an ARM schema (exploded per-resource format) into typed structures.
  */
@@ -381,7 +305,7 @@ export function parseArmSchema(data: string | Buffer): ArmSchemaParseResult {
     props,
     propertyTypes,
     new Set(enums.map((e) => e.name)),
-    MAX_PROPERTY_TYPE_DEPTH,
+    { maxDepth: MAX_PROPERTY_TYPE_DEPTH, curatedDefs: CURATED_PROPERTY_TYPE_DEFS },
   );
 
   // Detect tagging support (if tags field exists)

--- a/packages/core/src/codegen/bound-property-types.test.ts
+++ b/packages/core/src/codegen/bound-property-types.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "vitest";
+import { boundPropertyTypes, type BoundablePropertyType } from "./bound-property-types";
+
+interface Prop {
+  name: string;
+  tsType: string;
+}
+interface PT extends BoundablePropertyType {
+  name: string;
+  specType: string;
+  properties: Prop[];
+}
+
+function pt(name: string, props: Array<[string, string]>): PT {
+  return { name, specType: name.split("_")[1] ?? name, properties: props.map(([n, t]) => ({ name: n, tsType: t })) };
+}
+
+describe("boundPropertyTypes", () => {
+  test("drops property types unreachable from resource props", () => {
+    const props: Prop[] = [{ name: "sku", tsType: "R_Sku" }];
+    const types = [pt("R_Sku", [["name", "string"]]), pt("R_Unused", [["x", "string"]])];
+    const kept = boundPropertyTypes("R", props, types, new Set(), { maxDepth: 2 });
+    expect(kept.map((t) => t.name)).toEqual(["R_Sku"]);
+  });
+
+  test("caps nesting depth and loosens references beyond the cap", () => {
+    const props: Prop[] = [{ name: "a", tsType: "R_A" }];
+    const types = [
+      pt("R_A", [["b", "R_B"]]),
+      pt("R_B", [["c", "R_C"]]),
+      pt("R_C", [["d", "string"]]),
+    ];
+    const kept = boundPropertyTypes("R", props, types, new Set(), { maxDepth: 1 });
+    // depth 1: R_A kept, its child R_B not expanded -> loosened, R_C dropped
+    expect(kept.map((t) => t.name)).toEqual(["R_A"]);
+    expect(kept[0].properties[0].tsType).toBe("Record<string, unknown>");
+    expect(props[0].tsType).toBe("R_A"); // resource prop ref to a kept type is preserved
+  });
+
+  test("force-keeps curated property types by substring regardless of reachability", () => {
+    const props: Prop[] = [];
+    const types = [pt("R_SecurityRulePropertiesFormat", [["x", "string"]]), pt("R_Other", [["y", "string"]])];
+    const kept = boundPropertyTypes("R", props, types, new Set(), {
+      maxDepth: 1,
+      curatedDefs: ["SecurityRule"],
+    });
+    expect(kept.map((t) => t.name)).toEqual(["R_SecurityRulePropertiesFormat"]);
+  });
+
+  test("preserves enum references when loosening", () => {
+    const props: Prop[] = [{ name: "a", tsType: "R_A" }];
+    const types = [pt("R_A", [["mode", "R_ModeEnum"], ["nested", "R_Deep"]]), pt("R_Deep", [["x", "string"]])];
+    const kept = boundPropertyTypes("R", props, types, new Set(["R_ModeEnum"]), { maxDepth: 1 });
+    expect(kept[0].properties[0].tsType).toBe("R_ModeEnum"); // enum kept
+    expect(kept[0].properties[1].tsType).toBe("Record<string, unknown>"); // deep type loosened
+  });
+});

--- a/packages/core/src/codegen/bound-property-types.ts
+++ b/packages/core/src/codegen/bound-property-types.ts
@@ -1,0 +1,110 @@
+/**
+ * Bound the set of generated property-type interfaces a lexicon emits.
+ *
+ * Cloud provider schemas (ARM, CloudFormation, …) embed a named definition for
+ * every nested object. Fully expanding all of them per-resource produces huge
+ * `.d.ts` declarations (azure was ~273MB — see #438). This helper keeps only
+ * the property types reachable from a resource's top-level properties within a
+ * depth bound, plus a curated force-keep set; references that fall outside the
+ * kept set are rewritten to `Record<string, unknown>`. Enum references are
+ * preserved. The input property refs are mutated in place. (#438, #440)
+ */
+
+/** A reference carrying a TypeScript type string, mutated in place when loosened. */
+export interface BoundablePropertyRef {
+  tsType: string;
+}
+
+/** A generated property type (named interface) and its properties. */
+export interface BoundablePropertyType {
+  name: string;
+  specType: string;
+  properties: BoundablePropertyRef[];
+}
+
+export interface BoundPropertyTypeOptions {
+  /** Maximum nesting depth of emitted property-type interfaces. */
+  maxDepth: number;
+  /**
+   * Definition-name substrings to always keep regardless of reachability/depth
+   * (e.g. common nested shapes worth typing for authoring ergonomics). Matched
+   * by substring against each property type's `specType`.
+   */
+  curatedDefs?: Iterable<string>;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Extract `${shortName}_Ident` type-reference tokens from a tsType string. */
+function referencedTypeNames(tsType: string, shortName: string): string[] {
+  const re = new RegExp("\\b" + escapeRegExp(shortName) + "_[A-Za-z0-9_]+", "g");
+  return tsType.match(re) ?? [];
+}
+
+/**
+ * Filter `propertyTypes` to the bounded set and loosen out-of-set references.
+ * Mutates the `tsType` of `resourceProps` and retained property types; returns
+ * the retained property types.
+ */
+export function boundPropertyTypes<PT extends BoundablePropertyType>(
+  shortName: string,
+  resourceProps: BoundablePropertyRef[],
+  propertyTypes: PT[],
+  enumNames: Set<string>,
+  options: BoundPropertyTypeOptions,
+): PT[] {
+  const { maxDepth } = options;
+  const curated = options.curatedDefs ? [...options.curatedDefs] : [];
+  const byName = new Map(propertyTypes.map((pt) => [pt.name, pt] as const));
+  const reached = new Set<string>();
+  const queue: Array<{ name: string; depth: number }> = [];
+
+  const seed = (tsType: string, depth: number) => {
+    for (const n of referencedTypeNames(tsType, shortName)) {
+      if (byName.has(n) && !reached.has(n)) {
+        reached.add(n);
+        queue.push({ name: n, depth });
+      }
+    }
+  };
+
+  for (const p of resourceProps) seed(p.tsType, 1);
+  // Force-keep curated property types (depth-1 seeds), matched by substring so
+  // schema variant names (e.g. "SecurityRulePropertiesFormat") are retained.
+  if (curated.length > 0) {
+    for (const pt of propertyTypes) {
+      if (!reached.has(pt.name) && curated.some((c) => pt.specType.includes(c))) {
+        reached.add(pt.name);
+        queue.push({ name: pt.name, depth: 1 });
+      }
+    }
+  }
+  while (queue.length) {
+    const { name, depth } = queue.shift()!;
+    if (depth >= maxDepth) continue; // do not expand children beyond the cap
+    const pt = byName.get(name);
+    if (!pt) continue;
+    for (const p of pt.properties) seed(p.tsType, depth + 1);
+  }
+
+  // Rewrite references to property types we are not emitting (keep enums).
+  const loosen = (tsType: string): string => {
+    let out = tsType;
+    for (const n of referencedTypeNames(tsType, shortName)) {
+      if (reached.has(n) || enumNames.has(n) || !byName.has(n)) continue;
+      out = out.replace(new RegExp("\\b" + escapeRegExp(n) + "\\b", "g"), "Record<string, unknown>");
+    }
+    return out;
+  };
+
+  for (const p of resourceProps) p.tsType = loosen(p.tsType);
+  const retained: PT[] = [];
+  for (const pt of propertyTypes) {
+    if (!reached.has(pt.name)) continue;
+    for (const p of pt.properties) p.tsType = loosen(p.tsType);
+    retained.push(pt);
+  }
+  return retained;
+}


### PR DESCRIPTION
Follow-up to #438/#439. aws shipped a **~171K-line** generated declaration — a heavy `tsc` cost for any consumer. Apply the same expansion-bounding used for azure.

## Changes
- **Shared helper**: extracted the bounding logic into `@intentius/chant/codegen/bound-property-types` (with a focused unit test) and refactored **azure**'s parser to use it — behavior-preserving (identical output, all 418 azure tests still pass).
- **aws**: bound property-type expansion at **depth 3** — the minimum that keeps every composite's nested CFN shapes typed (depth 2 drops e.g. `Bucket_ServerSideEncryptionByDefault`, used by the lambda-s3 composite). Deeper references loosen to `Record<string, unknown>`.

## Result
- aws generated `index.d.ts`: **171,592 → 130,357 lines (~24% smaller)**.
- All **1615** aws resources intact (verified `AWS::CloudFront::Distribution` etc. still present) — only deep, rarely-authored property types loosened. Snapshot updated for the dropped names.

## Scope
Other lexicons need no trimming: **gcp** ~26K lines, **k8s** ~3K, the rest <500 — already small. azure (~200K after #438) and aws (~130K) were the large ones.

## Verification
- `npm run --prefix lexicons/aws prepack` → exit 0; aws `vitest` 718 pass (snapshot updated).
- azure `vitest` 418 pass (shared-helper refactor is a no-op on output).
- `npx tsc --noEmit -p packages/core/tsconfig.json` → 0; new `bound-property-types` unit test green.