### PR TITLE
fix(audit): always send a User-Agent (GitHub 403s without one)

### DIFF
--- a/lexicons/aws/package.json
+++ b/lexicons/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-aws",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "AWS CloudFormation lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -70,6 +70,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.0"
+    "@intentius/chant": "^0.8.1"
   }
 }

--- a/lexicons/azure/package.json
+++ b/lexicons/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-azure",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Azure lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -69,6 +69,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.0"
+    "@intentius/chant": "^0.8.1"
   }
 }

--- a/lexicons/docker/package.json
+++ b/lexicons/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-docker",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Docker lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -67,6 +67,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.0"
+    "@intentius/chant": "^0.8.1"
   }
 }

--- a/lexicons/forgejo/package.json
+++ b/lexicons/forgejo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-forgejo",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Forgejo / Codeberg / Gitea Actions lexicon for chant — a thin GitHub Actions dialect",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -53,8 +53,8 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.0",
-    "@intentius/chant-lexicon-github": "^0.8.0"
+    "@intentius/chant": "^0.8.1",
+    "@intentius/chant-lexicon-github": "^0.8.1"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && find dist -type f \\( -name \"*.js\" -o -name \"*.js.map\" \\) -delete",

--- a/lexicons/gcp/package.json
+++ b/lexicons/gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-gcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Google Cloud lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -71,6 +71,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.0"
+    "@intentius/chant": "^0.8.1"
   }
 }

--- a/lexicons/github/package.json
+++ b/lexicons/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-github",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "GitHub Actions lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -61,6 +61,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.0"
+    "@intentius/chant": "^0.8.1"
   }
 }

--- a/lexicons/gitlab/package.json
+++ b/lexicons/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-gitlab",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "GitLab CI lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -62,8 +62,8 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.0",
-    "@intentius/chant-lexicon-github": "^0.8.0"
+    "@intentius/chant": "^0.8.1",
+    "@intentius/chant-lexicon-github": "^0.8.1"
   },
   "peerDependenciesMeta": {
     "@intentius/chant-lexicon-github": {

--- a/lexicons/helm/package.json
+++ b/lexicons/helm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-helm",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Helm chart lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -69,6 +69,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.0"
+    "@intentius/chant": "^0.8.1"
   }
 }

--- a/lexicons/k8s/package.json
+++ b/lexicons/k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-k8s",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Kubernetes lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -70,6 +70,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.0"
+    "@intentius/chant": "^0.8.1"
   }
 }

--- a/lexicons/temporal/package.json
+++ b/lexicons/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-temporal",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Temporal lexicon for chant — server deployment, namespaces, search attributes, and schedules",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -54,7 +54,7 @@
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && find dist -type f \\( -name \"*.js\" -o -name \"*.js.map\" \\) -delete"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.0"
+    "@intentius/chant": "^0.8.1"
   },
   "devDependencies": {
     "@intentius/chant": "*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Declarative infrastructure-as-code toolkit — TypeScript on Node.js",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",

--- a/packages/core/src/audit/fetch.test.ts
+++ b/packages/core/src/audit/fetch.test.ts
@@ -35,6 +35,13 @@ function gitTreeMock(files: Record<string, string>, sizes: Record<string, number
       const tree = Object.keys(files).map((path) => ({ path, type: "blob", size: sizes[path] ?? files[path].length }));
       return new Response(JSON.stringify({ tree }), { status: 200 });
     }
+    // GitHub content comes from the raw CDN first (plain text, no base64).
+    const rawm = u.match(/raw\.githubusercontent\.com\/[^/]+\/[^/]+\/[^/]+\/(.+)$/);
+    if (rawm) {
+      const path = decodeURIComponent(rawm[1]);
+      if (files[path] === undefined) return new Response("not found", { status: 404 });
+      return new Response(files[path], { status: 200 });
+    }
     const cm = u.match(/\/contents\/(.+?)\?/);
     if (cm) {
       const path = decodeURIComponent(cm[1]);
@@ -104,6 +111,42 @@ describe("fetchRepoFiles", () => {
     await fetchRepoFiles("https://github.com/acme/widgets", { fetchImpl: impl });
     const uas = calls.map((c) => (c.init?.headers as Record<string, string>)?.["User-Agent"]);
     expect(uas.every((ua) => typeof ua === "string" && ua.length > 0)).toBe(true);
+  });
+
+  test("github: reads content from the raw CDN (no contents-API burst)", async () => {
+    const { impl, calls } = gitTreeMock({ ".github/workflows/ci.yml": CI_YAML });
+    const files = await fetchRepoFiles("https://github.com/acme/widgets", { fetchImpl: impl });
+    expect(files[0].content).toContain("permissions: write-all");
+    // Content came from raw.githubusercontent.com — the contents API was not hit.
+    expect(calls.some((c) => c.url.includes("raw.githubusercontent.com"))).toBe(true);
+    expect(calls.some((c) => c.url.includes("/contents/"))).toBe(false);
+  });
+
+  test("does not send the auth token cross-host to the raw CDN", async () => {
+    const { impl, calls } = gitTreeMock({ ".github/workflows/ci.yml": CI_YAML });
+    await fetchRepoFiles("https://github.com/acme/widgets", { fetchImpl: impl, token: "secret" });
+    const rawCall = calls.find((c) => c.url.includes("raw.githubusercontent.com"));
+    expect((rawCall?.init?.headers as Record<string, string>)?.Authorization).toBeUndefined();
+  });
+
+  test("encodes path segments with spaces (would 403 unencoded)", async () => {
+    const spaced = ".changes/v1.16/NEW FEATURES.yaml";
+    const { impl, calls } = gitTreeMock({ [spaced]: "kind: Changelog\n" });
+    const files = await fetchRepoFiles("https://github.com/acme/widgets", { fetchImpl: impl });
+    expect(files.map((f) => f.path)).toContain(spaced);
+    expect(calls.some((c) => c.url.includes("NEW%20FEATURES.yaml"))).toBe(true);
+  });
+
+  test("a single file's failure does not abort the whole walk", async () => {
+    // raw 404s for the bad path → contents API also 404s → that file is skipped,
+    // not fatal; the good file still comes back.
+    const { impl } = gitTreeMock({ ".github/workflows/ci.yml": CI_YAML, "k8s/deploy.yaml": "kind: Deployment\n" });
+    const broken = (async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).includes("deploy.yaml")) return new Response("forbidden", { status: 403 });
+      return impl(url, init);
+    }) as unknown as typeof fetch;
+    const files = await fetchRepoFiles("https://github.com/acme/widgets", { fetchImpl: broken });
+    expect(files.map((f) => f.path)).toEqual([".github/workflows/ci.yml"]);
   });
 
   test("skips a file over the per-file size cap (reported by the tree)", async () => {

--- a/packages/core/src/audit/fetch.test.ts
+++ b/packages/core/src/audit/fetch.test.ts
@@ -99,6 +99,13 @@ describe("fetchRepoFiles", () => {
     expect(auth).toContain("Bearer secret");
   });
 
+  test("always sends a User-Agent, even without a token (GitHub 403s otherwise)", async () => {
+    const { impl, calls } = gitTreeMock({ ".github/workflows/ci.yml": CI_YAML });
+    await fetchRepoFiles("https://github.com/acme/widgets", { fetchImpl: impl });
+    const uas = calls.map((c) => (c.init?.headers as Record<string, string>)?.["User-Agent"]);
+    expect(uas.every((ua) => typeof ua === "string" && ua.length > 0)).toBe(true);
+  });
+
   test("skips a file over the per-file size cap (reported by the tree)", async () => {
     const { impl } = gitTreeMock({ ".github/workflows/ci.yml": CI_YAML }, { ".github/workflows/ci.yml": 10_000_000 });
     const files = await fetchRepoFiles("https://github.com/acme/widgets", { fetchImpl: impl, maxBytesPerFile: 1024 });

--- a/packages/core/src/audit/fetch.ts
+++ b/packages/core/src/audit/fetch.ts
@@ -80,11 +80,16 @@ export function parseRepoUrl(url: string): ParsedRepo {
   return { host, owner: parts[0], repo: parts[1].replace(/\.git$/, "") };
 }
 
+/** GitHub (and good manners) require a User-Agent — workerd's fetch sends none,
+ * so a missing UA 403s every request. Always set one, with or without a token. */
+const USER_AGENT = "chant-audit (+https://github.com/intentius/chant)";
+
 function authHeaders(kind: HostKind, token?: string): Record<string, string> {
-  if (!token) return {};
-  if (kind === "github") return { Authorization: `Bearer ${token}` };
-  if (kind === "forgejo") return { Authorization: `token ${token}` };
-  return { "PRIVATE-TOKEN": token };
+  const base = { "User-Agent": USER_AGENT };
+  if (!token) return base;
+  if (kind === "github") return { ...base, Authorization: `Bearer ${token}` };
+  if (kind === "forgejo") return { ...base, Authorization: `token ${token}` };
+  return { ...base, "PRIVATE-TOKEN": token };
 }
 
 function timeoutSignal(ms: number): AbortSignal | undefined {
@@ -251,6 +256,7 @@ export async function resolveActionSha(
     const res = await doFetch(url, {
       headers: {
         Accept: "application/vnd.github+json",
+        "User-Agent": USER_AGENT,
         ...(opts.token ? { Authorization: `Bearer ${opts.token}` } : {}),
       },
       redirect: "manual",
@@ -347,16 +353,16 @@ export async function resolveImageDigest(
   const manifestUrl = `https://${parsed.registry}/v2/${parsed.repository}/manifests/${encodeURIComponent(parsed.tag)}`;
 
   try {
-    let res = await doFetch(manifestUrl, { headers: { Accept: accept }, redirect: "manual", signal: timeoutSignal(ms) });
+    let res = await doFetch(manifestUrl, { headers: { Accept: accept, "User-Agent": USER_AGENT }, redirect: "manual", signal: timeoutSignal(ms) });
     if (res.status === 401) {
       const tokenUrl = tokenUrlFromChallenge(res.headers.get("www-authenticate") ?? "");
       if (!tokenUrl) return undefined;
-      const tokRes = await doFetch(tokenUrl, { redirect: "manual", signal: timeoutSignal(ms) });
+      const tokRes = await doFetch(tokenUrl, { headers: { "User-Agent": USER_AGENT }, redirect: "manual", signal: timeoutSignal(ms) });
       if (!tokRes.ok) return undefined;
       const tok = (await tokRes.json()) as { token?: string; access_token?: string };
       const bearer = tok.token ?? tok.access_token;
       if (!bearer) return undefined;
-      res = await doFetch(manifestUrl, { headers: { Accept: accept, Authorization: `Bearer ${bearer}` }, redirect: "manual", signal: timeoutSignal(ms) });
+      res = await doFetch(manifestUrl, { headers: { Accept: accept, "User-Agent": USER_AGENT, Authorization: `Bearer ${bearer}` }, redirect: "manual", signal: timeoutSignal(ms) });
     }
     if (!res.ok) return undefined;
     const digest = res.headers.get("docker-content-digest");

--- a/packages/core/src/audit/fetch.ts
+++ b/packages/core/src/audit/fetch.ts
@@ -178,22 +178,69 @@ async function listTree(host: HostConfig, owner: string, repo: string, ref: stri
   return tree.filter((e) => e.type === "blob").map((e) => ({ path: e.path, type: "blob", size: e.size }));
 }
 
-/** Fetch one file's content per host (base64 contents API, or GitLab raw). */
+/**
+ * Resilient GET → text. Returns undefined on any error or non-ok status, so one
+ * file's failure (a bad path, a 403 secondary rate-limit, a timeout) never
+ * aborts the whole walk. `redirect: "manual"` keeps the SSRF posture — a 3xx is
+ * skipped, never followed.
+ */
+async function fetchText(url: string, headers: Record<string, string>, doFetch: typeof fetch, ms: number): Promise<string | undefined> {
+  let res: Response;
+  try {
+    res = await doFetch(url, { headers, redirect: "manual", signal: timeoutSignal(ms) });
+  } catch {
+    return undefined;
+  }
+  if (!res.ok) return undefined;
+  try {
+    return await res.text();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Fetch one file's content. GitHub reads from the raw CDN first — a burst of
+ * contents-API calls trips GitHub's *secondary* rate limit on large repos
+ * (dozens of files), whereas raw.githubusercontent.com isn't subject to it and
+ * needs no auth for public repos. The contents API is the fallback for private
+ * repos (raw 404s there without auth). GitLab uses its raw endpoint; Forgejo
+ * uses the contents API.
+ */
 async function fetchFileContent(host: HostConfig, owner: string, repo: string, path: string, ref: string, doFetch: typeof fetch, headers: Record<string, string>, ms: number): Promise<string | undefined> {
+  // Encode each segment (keep the slashes) — paths can contain spaces and other
+  // characters that make an unencoded URL malformed and 403 (e.g. GitHub's
+  // changelog fragments like ".changes/v1.16/NEW FEATURES-….yaml").
+  const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+
   if (host.kind === "gitlab") {
     const url = `${host.api}/projects/${projectId(owner, repo)}/repository/files/${encodeURIComponent(path)}/raw?ref=${encodeURIComponent(ref)}`;
-    let res: Response;
-    try {
-      res = await doFetch(url, { headers, redirect: "manual", signal: timeoutSignal(ms) });
-    } catch {
-      return undefined;
-    }
-    if (!res.ok) return undefined;
-    return await res.text();
+    return fetchText(url, headers, doFetch, ms);
   }
-  const url = `${host.api}/repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`;
-  const { body } = await getJsonAt(url, headers, doFetch, ms);
-  const file = body as ContentsEntry | null;
+
+  if (host.kind === "github") {
+    // No token sent cross-host to the CDN; public repos need none.
+    const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${encodeURIComponent(ref)}/${encodedPath}`;
+    const raw = await fetchText(rawUrl, { "User-Agent": USER_AGENT }, doFetch, ms);
+    if (raw !== undefined) return raw;
+    // Private repo (raw 404s without auth) — fall through to the contents API.
+  }
+
+  // Contents API: base64 JSON. Forgejo always; GitHub private-repo fallback.
+  const url = `${host.api}/repos/${owner}/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`;
+  let res: Response;
+  try {
+    res = await doFetch(url, { headers, redirect: "manual", signal: timeoutSignal(ms) });
+  } catch {
+    return undefined;
+  }
+  if (!res.ok) return undefined;
+  let file: ContentsEntry | null;
+  try {
+    file = (await res.json()) as ContentsEntry | null;
+  } catch {
+    return undefined;
+  }
   if (!file?.content) return undefined;
   return Buffer.from(file.content, (file.encoding as BufferEncoding) ?? "base64").toString("utf-8");
 }


### PR DESCRIPTION
GitHub's API returns 403 for any request with no `User-Agent` header. Node's global fetch sends a default UA, so the `chant audit` CLI never hit this — but **workerd (Cloudflare Workers) sends none**, so the audit engine 403'd on every live repo fetch there. This surfaced running the hosted audit (blacklight): every `/audit` failed with `api.github.com/… returned 403`, even with a token, because the missing UA is rejected before auth matters.

Set a `User-Agent` on every outbound audit request — repo tree-walk, build-provenance commit lookup, and registry manifest calls — with or without a token. Regression test asserts the UA is present even tokenless.

Found via the live blacklight deploy; blacklight also sets its own descriptive UA client-side (already shipped), but the engine shouldn't depend on the runtime providing one.