### PR TITLE
feat(github-org): desired-state config model + loader

### DIFF
--- a/lexicons/github-org/package.json
+++ b/lexicons/github-org/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@intentius/chant-lexicon-github-org",
+  "version": "0.8.1",
+  "description": "GitHub org/repo governance lexicon for chant — desired-state config and reconciliation",
+  "license": "Apache-2.0",
+  "homepage": "https://intentius.io/chant",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/INTENTIUS/chant.git",
+    "directory": "lexicons/github-org"
+  },
+  "bugs": {
+    "url": "https://github.com/INTENTIUS/chant/issues"
+  },
+  "keywords": [
+    "infrastructure-as-code",
+    "iac",
+    "typescript",
+    "github",
+    "github-org",
+    "governance",
+    "chant"
+  ],
+  "type": "module",
+  "files": [
+    "src/",
+    "dist/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "development": "./src/*.ts",
+      "types": "./dist/*.d.ts",
+      "default": "./src/*.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && find dist -type f \\( -name \"*.js\" -o -name \"*.js.map\" \\) -delete"
+  },
+  "peerDependencies": {
+    "@intentius/chant": "^0.8.1"
+  },
+  "devDependencies": {
+    "@intentius/chant": "*",
+    "typescript": "^5.9.3"
+  }
+}

--- a/lexicons/github-org/src/config/load.test.ts
+++ b/lexicons/github-org/src/config/load.test.ts
@@ -1,0 +1,295 @@
+import { describe, test, expect } from "vitest";
+import { loadGovernanceConfig, GovernanceConfigError } from "./load.js";
+import type { GovernanceConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Valid load
+// ---------------------------------------------------------------------------
+
+describe("loadGovernanceConfig — valid input", () => {
+  test("minimal config with empty orgs", () => {
+    const result = loadGovernanceConfig({ orgs: {} });
+    expect(result).toEqual({ orgs: {} });
+  });
+
+  test("full config with all optional fields present", () => {
+    const input = {
+      orgs: {
+        "my-org": {
+          settings: {
+            description: "My org",
+            email: "info@example.com",
+            websiteUrl: "https://example.com",
+            defaultRepositoryPermission: "read",
+            requireTwoFactorAuthentication: true,
+            membersCanCreatePublicRepositories: false,
+            membersCanCreatePrivateRepositories: true,
+            membersCanCreateInternalRepositories: false,
+          },
+          teams: {
+            backend: {
+              description: "Backend engineers",
+              privacy: "closed",
+              members: [
+                { login: "alice", role: "maintainer" },
+                { login: "bob" },
+              ],
+              repos: [
+                { name: "api", permission: "push" },
+              ],
+            },
+          },
+          members: [
+            { login: "carol", role: "admin" },
+            { login: "dave" },
+          ],
+          repos: {
+            "api": {
+              description: "API service",
+              private: true,
+              hasIssues: true,
+              hasProjects: false,
+              hasWiki: false,
+              defaultBranch: "main",
+              allowSquashMerge: true,
+              allowMergeCommit: false,
+              allowRebaseMerge: false,
+              deleteBranchOnMerge: true,
+              topics: ["api", "backend"],
+              branchProtection: [
+                {
+                  pattern: "main",
+                  requirePullRequestReviews: true,
+                  requiredApprovingReviewCount: 1,
+                  dismissStaleReviews: true,
+                  requireCodeOwnerReviews: true,
+                  requireStatusChecks: true,
+                  requiredStatusCheckContexts: ["ci/build"],
+                  requireBranchesToBeUpToDate: true,
+                  restrictPushes: true,
+                  allowForcePushes: false,
+                  allowDeletions: false,
+                  requireLinearHistory: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const result = loadGovernanceConfig(input);
+    const org = result.orgs["my-org"];
+
+    expect(org.settings?.description).toBe("My org");
+    expect(org.settings?.defaultRepositoryPermission).toBe("read");
+    expect(org.teams?.["backend"].members).toHaveLength(2);
+    expect(org.teams?.["backend"].members?.[0].role).toBe("maintainer");
+    expect(org.teams?.["backend"].members?.[1].role).toBeUndefined();
+    expect(org.members).toHaveLength(2);
+    expect(org.repos?.["api"].private).toBe(true);
+    expect(org.repos?.["api"].branchProtection?.[0].pattern).toBe("main");
+    expect(org.repos?.["api"].topics).toEqual(["api", "backend"]);
+  });
+
+  test("returns a normalized GovernanceConfig type", () => {
+    const result: GovernanceConfig = loadGovernanceConfig({
+      orgs: { "test-org": {} },
+    });
+    expect(result.orgs["test-org"]).toEqual({});
+  });
+
+  test("multiple orgs", () => {
+    const result = loadGovernanceConfig({
+      orgs: {
+        "org-a": { settings: { description: "A" } },
+        "org-b": { members: [{ login: "alice" }] },
+      },
+    });
+    expect(Object.keys(result.orgs)).toHaveLength(2);
+    expect(result.orgs["org-a"].settings?.description).toBe("A");
+    expect(result.orgs["org-b"].members?.[0].login).toBe("alice");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selective-by-omission: absent fields are not managed
+// ---------------------------------------------------------------------------
+
+describe("loadGovernanceConfig — selective-by-omission", () => {
+  test("absent top-level org fields are undefined in output", () => {
+    const result = loadGovernanceConfig({ orgs: { "my-org": {} } });
+    const org = result.orgs["my-org"];
+    expect(org.settings).toBeUndefined();
+    expect(org.teams).toBeUndefined();
+    expect(org.members).toBeUndefined();
+    expect(org.repos).toBeUndefined();
+  });
+
+  test("absent OrgSettings fields are undefined in output", () => {
+    const result = loadGovernanceConfig({
+      orgs: { "my-org": { settings: { description: "Only description" } } },
+    });
+    const settings = result.orgs["my-org"].settings;
+    expect(settings?.description).toBe("Only description");
+    expect(settings?.email).toBeUndefined();
+    expect(settings?.requireTwoFactorAuthentication).toBeUndefined();
+  });
+
+  test("team with no members key leaves membership unmanaged", () => {
+    const result = loadGovernanceConfig({
+      orgs: {
+        "my-org": {
+          teams: {
+            "infra": { description: "Infra team" },
+          },
+        },
+      },
+    });
+    const team = result.orgs["my-org"].teams?.["infra"];
+    expect(team?.description).toBe("Infra team");
+    expect(team?.members).toBeUndefined();
+    expect(team?.repos).toBeUndefined();
+  });
+
+  test("repo with no branchProtection key leaves protection unmanaged", () => {
+    const result = loadGovernanceConfig({
+      orgs: {
+        "my-org": {
+          repos: {
+            "frontend": { private: false },
+          },
+        },
+      },
+    });
+    const repo = result.orgs["my-org"].repos?.["frontend"];
+    expect(repo?.private).toBe(false);
+    expect(repo?.branchProtection).toBeUndefined();
+    expect(repo?.topics).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid input rejection
+// ---------------------------------------------------------------------------
+
+describe("loadGovernanceConfig — invalid input rejection", () => {
+  test("rejects null input", () => {
+    expect(() => loadGovernanceConfig(null)).toThrow(GovernanceConfigError);
+  });
+
+  test("rejects string input", () => {
+    expect(() => loadGovernanceConfig("not an object")).toThrow(GovernanceConfigError);
+  });
+
+  test("rejects array input", () => {
+    expect(() => loadGovernanceConfig([])).toThrow(GovernanceConfigError);
+  });
+
+  test("rejects missing orgs field", () => {
+    expect(() => loadGovernanceConfig({})).toThrow(GovernanceConfigError);
+    expect(() => loadGovernanceConfig({})).toThrow(/orgs.*required/);
+  });
+
+  test("rejects orgs as array", () => {
+    expect(() => loadGovernanceConfig({ orgs: [] })).toThrow(GovernanceConfigError);
+  });
+
+  test("rejects invalid defaultRepositoryPermission value", () => {
+    expect(() =>
+      loadGovernanceConfig({
+        orgs: {
+          "my-org": {
+            settings: { defaultRepositoryPermission: "superadmin" },
+          },
+        },
+      })
+    ).toThrow(GovernanceConfigError);
+  });
+
+  test("rejects team member missing login", () => {
+    expect(() =>
+      loadGovernanceConfig({
+        orgs: {
+          "my-org": {
+            teams: {
+              backend: { members: [{ role: "member" }] },
+            },
+          },
+        },
+      })
+    ).toThrow(GovernanceConfigError);
+  });
+
+  test("rejects team repo with invalid permission", () => {
+    expect(() =>
+      loadGovernanceConfig({
+        orgs: {
+          "my-org": {
+            teams: {
+              backend: {
+                repos: [{ name: "api", permission: "owner" }],
+              },
+            },
+          },
+        },
+      })
+    ).toThrow(GovernanceConfigError);
+  });
+
+  test("rejects org member missing login", () => {
+    expect(() =>
+      loadGovernanceConfig({
+        orgs: { "my-org": { members: [{ role: "admin" }] } },
+      })
+    ).toThrow(GovernanceConfigError);
+  });
+
+  test("rejects branch protection missing pattern", () => {
+    expect(() =>
+      loadGovernanceConfig({
+        orgs: {
+          "my-org": {
+            repos: {
+              "api": {
+                branchProtection: [{ requirePullRequestReviews: true }],
+              },
+            },
+          },
+        },
+      })
+    ).toThrow(GovernanceConfigError);
+  });
+
+  test("error contains meaningful field path", () => {
+    let caught: GovernanceConfigError | undefined;
+    try {
+      loadGovernanceConfig({
+        orgs: {
+          "my-org": {
+            teams: {
+              backend: { members: [{ role: "member" }] },
+            },
+          },
+        },
+      });
+    } catch (err) {
+      caught = err as GovernanceConfigError;
+    }
+    expect(caught).toBeInstanceOf(GovernanceConfigError);
+    expect(caught?.field).toContain("members");
+    expect(caught?.message).toContain("login");
+  });
+
+  test("rejects non-boolean value for boolean field", () => {
+    expect(() =>
+      loadGovernanceConfig({
+        orgs: {
+          "my-org": {
+            repos: { "api": { private: "yes" } },
+          },
+        },
+      })
+    ).toThrow(GovernanceConfigError);
+  });
+});

--- a/lexicons/github-org/src/config/load.ts
+++ b/lexicons/github-org/src/config/load.ts
@@ -1,0 +1,255 @@
+import type { GovernanceConfig, OrgConfig, OrgSettings, TeamConfig, TeamMember, TeamRepo, MemberConfig, RepoConfig, BranchProtectionConfig } from "./types.js";
+
+/**
+ * Thrown when `loadGovernanceConfig` receives a value that does not match the
+ * expected shape of a `GovernanceConfig`.
+ */
+export class GovernanceConfigError extends Error {
+  readonly field: string;
+
+  constructor(field: string, message: string) {
+    super(`[governance-config] invalid config at "${field}": ${message}`);
+    this.name = "GovernanceConfigError";
+    this.field = field;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal validators
+// ---------------------------------------------------------------------------
+
+function assertObject(value: unknown, field: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new GovernanceConfigError(field, `expected an object, got ${Array.isArray(value) ? "array" : value === null ? "null" : typeof value}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new GovernanceConfigError(field, `expected a string, got ${typeof value}`);
+  }
+  return value;
+}
+
+function assertBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new GovernanceConfigError(field, `expected a boolean, got ${typeof value}`);
+  }
+  return value;
+}
+
+function assertNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new GovernanceConfigError(field, `expected a finite number, got ${typeof value}`);
+  }
+  return value;
+}
+
+function assertArray(value: unknown, field: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new GovernanceConfigError(field, `expected an array, got ${typeof value}`);
+  }
+  return value;
+}
+
+function assertEnum<T extends string>(value: unknown, field: string, allowed: readonly T[]): T {
+  const s = assertString(value, field);
+  if (!allowed.includes(s as T)) {
+    throw new GovernanceConfigError(field, `expected one of [${allowed.join(", ")}], got "${s}"`);
+  }
+  return s as T;
+}
+
+// ---------------------------------------------------------------------------
+// Field-level normalizers (each returns undefined when the field is absent)
+// ---------------------------------------------------------------------------
+
+function normalizeOrgSettings(raw: unknown, field: string): OrgSettings | undefined {
+  if (raw === undefined) return undefined;
+  const obj = assertObject(raw, field);
+  const result: OrgSettings = {};
+
+  if (obj.description !== undefined) result.description = assertString(obj.description, `${field}.description`);
+  if (obj.email !== undefined) result.email = assertString(obj.email, `${field}.email`);
+  if (obj.websiteUrl !== undefined) result.websiteUrl = assertString(obj.websiteUrl, `${field}.websiteUrl`);
+  if (obj.membersCanCreatePublicRepositories !== undefined) result.membersCanCreatePublicRepositories = assertBoolean(obj.membersCanCreatePublicRepositories, `${field}.membersCanCreatePublicRepositories`);
+  if (obj.membersCanCreatePrivateRepositories !== undefined) result.membersCanCreatePrivateRepositories = assertBoolean(obj.membersCanCreatePrivateRepositories, `${field}.membersCanCreatePrivateRepositories`);
+  if (obj.membersCanCreateInternalRepositories !== undefined) result.membersCanCreateInternalRepositories = assertBoolean(obj.membersCanCreateInternalRepositories, `${field}.membersCanCreateInternalRepositories`);
+  if (obj.defaultRepositoryPermission !== undefined) result.defaultRepositoryPermission = assertEnum(obj.defaultRepositoryPermission, `${field}.defaultRepositoryPermission`, ["none", "read", "write", "admin"] as const);
+  if (obj.requireTwoFactorAuthentication !== undefined) result.requireTwoFactorAuthentication = assertBoolean(obj.requireTwoFactorAuthentication, `${field}.requireTwoFactorAuthentication`);
+
+  return result;
+}
+
+function normalizeTeamMember(raw: unknown, field: string): TeamMember {
+  const obj = assertObject(raw, field);
+  if (obj.login === undefined) throw new GovernanceConfigError(`${field}.login`, "required field missing");
+  const member: TeamMember = { login: assertString(obj.login, `${field}.login`) };
+  if (obj.role !== undefined) member.role = assertEnum(obj.role, `${field}.role`, ["member", "maintainer"] as const);
+  return member;
+}
+
+function normalizeTeamRepo(raw: unknown, field: string): TeamRepo {
+  const obj = assertObject(raw, field);
+  if (obj.name === undefined) throw new GovernanceConfigError(`${field}.name`, "required field missing");
+  if (obj.permission === undefined) throw new GovernanceConfigError(`${field}.permission`, "required field missing");
+  return {
+    name: assertString(obj.name, `${field}.name`),
+    permission: assertEnum(obj.permission, `${field}.permission`, ["pull", "triage", "push", "maintain", "admin"] as const),
+  };
+}
+
+function normalizeTeamConfig(raw: unknown, field: string): TeamConfig {
+  const obj = assertObject(raw, field);
+  const team: TeamConfig = {};
+
+  if (obj.description !== undefined) team.description = assertString(obj.description, `${field}.description`);
+  if (obj.privacy !== undefined) team.privacy = assertEnum(obj.privacy, `${field}.privacy`, ["secret", "closed"] as const);
+  if (obj.parentTeamSlug !== undefined) team.parentTeamSlug = assertString(obj.parentTeamSlug, `${field}.parentTeamSlug`);
+
+  if (obj.members !== undefined) {
+    const arr = assertArray(obj.members, `${field}.members`);
+    team.members = arr.map((m, i) => normalizeTeamMember(m, `${field}.members[${i}]`));
+  }
+
+  if (obj.repos !== undefined) {
+    const arr = assertArray(obj.repos, `${field}.repos`);
+    team.repos = arr.map((r, i) => normalizeTeamRepo(r, `${field}.repos[${i}]`));
+  }
+
+  return team;
+}
+
+function normalizeTeams(raw: unknown, field: string): Record<string, TeamConfig> | undefined {
+  if (raw === undefined) return undefined;
+  const obj = assertObject(raw, field);
+  const result: Record<string, TeamConfig> = {};
+  for (const [slug, teamRaw] of Object.entries(obj)) {
+    result[slug] = normalizeTeamConfig(teamRaw, `${field}.${slug}`);
+  }
+  return result;
+}
+
+function normalizeMemberConfig(raw: unknown, field: string): MemberConfig {
+  const obj = assertObject(raw, field);
+  if (obj.login === undefined) throw new GovernanceConfigError(`${field}.login`, "required field missing");
+  const member: MemberConfig = { login: assertString(obj.login, `${field}.login`) };
+  if (obj.role !== undefined) member.role = assertEnum(obj.role, `${field}.role`, ["member", "admin"] as const);
+  return member;
+}
+
+function normalizeMembers(raw: unknown, field: string): MemberConfig[] | undefined {
+  if (raw === undefined) return undefined;
+  const arr = assertArray(raw, field);
+  return arr.map((m, i) => normalizeMemberConfig(m, `${field}[${i}]`));
+}
+
+function normalizeBranchProtection(raw: unknown, field: string): BranchProtectionConfig {
+  const obj = assertObject(raw, field);
+  if (obj.pattern === undefined) throw new GovernanceConfigError(`${field}.pattern`, "required field missing");
+  const bp: BranchProtectionConfig = { pattern: assertString(obj.pattern, `${field}.pattern`) };
+
+  if (obj.requirePullRequestReviews !== undefined) bp.requirePullRequestReviews = assertBoolean(obj.requirePullRequestReviews, `${field}.requirePullRequestReviews`);
+  if (obj.requiredApprovingReviewCount !== undefined) bp.requiredApprovingReviewCount = assertNumber(obj.requiredApprovingReviewCount, `${field}.requiredApprovingReviewCount`);
+  if (obj.dismissStaleReviews !== undefined) bp.dismissStaleReviews = assertBoolean(obj.dismissStaleReviews, `${field}.dismissStaleReviews`);
+  if (obj.requireCodeOwnerReviews !== undefined) bp.requireCodeOwnerReviews = assertBoolean(obj.requireCodeOwnerReviews, `${field}.requireCodeOwnerReviews`);
+  if (obj.requireStatusChecks !== undefined) bp.requireStatusChecks = assertBoolean(obj.requireStatusChecks, `${field}.requireStatusChecks`);
+  if (obj.requiredStatusCheckContexts !== undefined) {
+    const arr = assertArray(obj.requiredStatusCheckContexts, `${field}.requiredStatusCheckContexts`);
+    bp.requiredStatusCheckContexts = arr.map((c, i) => assertString(c, `${field}.requiredStatusCheckContexts[${i}]`));
+  }
+  if (obj.requireBranchesToBeUpToDate !== undefined) bp.requireBranchesToBeUpToDate = assertBoolean(obj.requireBranchesToBeUpToDate, `${field}.requireBranchesToBeUpToDate`);
+  if (obj.restrictPushes !== undefined) bp.restrictPushes = assertBoolean(obj.restrictPushes, `${field}.restrictPushes`);
+  if (obj.allowForcePushes !== undefined) bp.allowForcePushes = assertBoolean(obj.allowForcePushes, `${field}.allowForcePushes`);
+  if (obj.allowDeletions !== undefined) bp.allowDeletions = assertBoolean(obj.allowDeletions, `${field}.allowDeletions`);
+  if (obj.requireLinearHistory !== undefined) bp.requireLinearHistory = assertBoolean(obj.requireLinearHistory, `${field}.requireLinearHistory`);
+
+  return bp;
+}
+
+function normalizeRepoConfig(raw: unknown, field: string): RepoConfig {
+  const obj = assertObject(raw, field);
+  const repo: RepoConfig = {};
+
+  if (obj.description !== undefined) repo.description = assertString(obj.description, `${field}.description`);
+  if (obj.websiteUrl !== undefined) repo.websiteUrl = assertString(obj.websiteUrl, `${field}.websiteUrl`);
+  if (obj.private !== undefined) repo.private = assertBoolean(obj.private, `${field}.private`);
+  if (obj.hasIssues !== undefined) repo.hasIssues = assertBoolean(obj.hasIssues, `${field}.hasIssues`);
+  if (obj.hasProjects !== undefined) repo.hasProjects = assertBoolean(obj.hasProjects, `${field}.hasProjects`);
+  if (obj.hasWiki !== undefined) repo.hasWiki = assertBoolean(obj.hasWiki, `${field}.hasWiki`);
+  if (obj.defaultBranch !== undefined) repo.defaultBranch = assertString(obj.defaultBranch, `${field}.defaultBranch`);
+  if (obj.allowSquashMerge !== undefined) repo.allowSquashMerge = assertBoolean(obj.allowSquashMerge, `${field}.allowSquashMerge`);
+  if (obj.allowMergeCommit !== undefined) repo.allowMergeCommit = assertBoolean(obj.allowMergeCommit, `${field}.allowMergeCommit`);
+  if (obj.allowRebaseMerge !== undefined) repo.allowRebaseMerge = assertBoolean(obj.allowRebaseMerge, `${field}.allowRebaseMerge`);
+  if (obj.deleteBranchOnMerge !== undefined) repo.deleteBranchOnMerge = assertBoolean(obj.deleteBranchOnMerge, `${field}.deleteBranchOnMerge`);
+
+  if (obj.branchProtection !== undefined) {
+    const arr = assertArray(obj.branchProtection, `${field}.branchProtection`);
+    repo.branchProtection = arr.map((bp, i) => normalizeBranchProtection(bp, `${field}.branchProtection[${i}]`));
+  }
+
+  if (obj.topics !== undefined) {
+    const arr = assertArray(obj.topics, `${field}.topics`);
+    repo.topics = arr.map((t, i) => assertString(t, `${field}.topics[${i}]`));
+  }
+
+  return repo;
+}
+
+function normalizeRepos(raw: unknown, field: string): Record<string, RepoConfig> | undefined {
+  if (raw === undefined) return undefined;
+  const obj = assertObject(raw, field);
+  const result: Record<string, RepoConfig> = {};
+  for (const [name, repoRaw] of Object.entries(obj)) {
+    result[name] = normalizeRepoConfig(repoRaw, `${field}.${name}`);
+  }
+  return result;
+}
+
+function normalizeOrgConfig(raw: unknown, field: string): OrgConfig {
+  const obj = assertObject(raw, field);
+  const org: OrgConfig = {};
+
+  if (obj.settings !== undefined) org.settings = normalizeOrgSettings(obj.settings, `${field}.settings`);
+  if (obj.teams !== undefined) org.teams = normalizeTeams(obj.teams, `${field}.teams`);
+  if (obj.members !== undefined) org.members = normalizeMembers(obj.members, `${field}.members`);
+  if (obj.repos !== undefined) org.repos = normalizeRepos(obj.repos, `${field}.repos`);
+
+  return org;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate and normalize a governance config object.
+ *
+ * `input` is typically the result of parsing a YAML/JSON/TS config file. It
+ * must be a plain object with an `orgs` key mapping org names to `OrgConfig`
+ * objects.
+ *
+ * Throws `GovernanceConfigError` with a descriptive `field` path on invalid
+ * shape. Returns a fully-typed `GovernanceConfig` on success.
+ *
+ * Selective-by-omission: fields absent from the input are absent from the
+ * returned config, meaning they will not be reconciled against live GitHub
+ * state.
+ */
+export function loadGovernanceConfig(input: unknown): GovernanceConfig {
+  const root = assertObject(input, "<root>");
+
+  if (root.orgs === undefined) {
+    throw new GovernanceConfigError("<root>.orgs", "required field missing");
+  }
+
+  const orgsRaw = assertObject(root.orgs, "<root>.orgs");
+  const orgs: Record<string, OrgConfig> = {};
+
+  for (const [orgName, orgRaw] of Object.entries(orgsRaw)) {
+    orgs[orgName] = normalizeOrgConfig(orgRaw, `orgs.${orgName}`);
+  }
+
+  return { orgs };
+}

--- a/lexicons/github-org/src/config/types.ts
+++ b/lexicons/github-org/src/config/types.ts
@@ -1,0 +1,217 @@
+/**
+ * Desired-state config types for GitHub org/repo governance.
+ *
+ * Selective-by-omission: every field is optional. An absent field means
+ * "not managed" — chant will not read, diff, or modify that aspect of the
+ * live GitHub state. Only fields that are explicitly present are reconciled.
+ */
+
+// ---------------------------------------------------------------------------
+// Org settings
+// ---------------------------------------------------------------------------
+
+/** High-level org-level settings. Absent fields are not managed. */
+export interface OrgSettings {
+  /** Public description shown on the org profile page. */
+  description?: string;
+  /** Public email address for the org. */
+  email?: string;
+  /** URL of the org's website. */
+  websiteUrl?: string;
+  /** Whether the org's member list is publicly visible. */
+  membersCanCreatePublicRepositories?: boolean;
+  /** Whether members can create private repositories. */
+  membersCanCreatePrivateRepositories?: boolean;
+  /** Whether members can create internal repositories (Enterprise only). */
+  membersCanCreateInternalRepositories?: boolean;
+  /** Default repository permission granted to all members: none | read | write | admin. */
+  defaultRepositoryPermission?: "none" | "read" | "write" | "admin";
+  /** Whether two-factor authentication is required for all members. */
+  requireTwoFactorAuthentication?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Teams
+// ---------------------------------------------------------------------------
+
+/** Membership role within a team. */
+export type TeamRole = "member" | "maintainer";
+
+/** A member entry within a team. */
+export interface TeamMember {
+  /** GitHub login of the user. */
+  login: string;
+  /** Role in the team. Defaults to "member" when omitted. */
+  role?: TeamRole;
+}
+
+/** Repository access level granted to a team. */
+export type TeamRepoPermission = "pull" | "triage" | "push" | "maintain" | "admin";
+
+/** A repository access entry within a team. */
+export interface TeamRepo {
+  /** Repository name (without org prefix). */
+  name: string;
+  /** Permission level the team gets on this repository. */
+  permission: TeamRepoPermission;
+}
+
+/** Desired state for a single GitHub team. Absent fields are not managed. */
+export interface TeamConfig {
+  /** Human-readable team description. */
+  description?: string;
+  /** Team visibility: "secret" (default) or "closed" (visible to all org members). */
+  privacy?: "secret" | "closed";
+  /** Parent team slug, if this team is nested under another. */
+  parentTeamSlug?: string;
+  /**
+   * Team members and their roles.
+   * Absent means membership is not managed by chant.
+   */
+  members?: TeamMember[];
+  /**
+   * Repositories the team has access to.
+   * Absent means repo permissions are not managed by chant.
+   */
+  repos?: TeamRepo[];
+}
+
+// ---------------------------------------------------------------------------
+// Org members
+// ---------------------------------------------------------------------------
+
+/** Membership role within the org. */
+export type OrgMemberRole = "member" | "admin";
+
+/** Desired state for a single org member. */
+export interface MemberConfig {
+  /** GitHub login of the user. */
+  login: string;
+  /** Role in the org. Defaults to "member" when omitted. */
+  role?: OrgMemberRole;
+}
+
+// ---------------------------------------------------------------------------
+// Repos
+// ---------------------------------------------------------------------------
+
+/** Branch protection rule for a single branch pattern. Absent fields are not managed. */
+export interface BranchProtectionConfig {
+  /** Branch name pattern (e.g. "main", "release/*"). */
+  pattern: string;
+  /** Require pull request reviews before merging. */
+  requirePullRequestReviews?: boolean;
+  /** Number of approving reviews required. */
+  requiredApprovingReviewCount?: number;
+  /** Dismiss stale reviews when new commits are pushed. */
+  dismissStaleReviews?: boolean;
+  /** Require review from code owners. */
+  requireCodeOwnerReviews?: boolean;
+  /** Require status checks to pass before merging. */
+  requireStatusChecks?: boolean;
+  /** List of required status check contexts. */
+  requiredStatusCheckContexts?: string[];
+  /** Require branches to be up to date before merging. */
+  requireBranchesToBeUpToDate?: boolean;
+  /** Restrict who can push to matching branches. */
+  restrictPushes?: boolean;
+  /** Allow force pushes. */
+  allowForcePushes?: boolean;
+  /** Allow branch deletions. */
+  allowDeletions?: boolean;
+  /** Require linear history (no merge commits). */
+  requireLinearHistory?: boolean;
+}
+
+/** Desired state for a single repository. Absent fields are not managed. */
+export interface RepoConfig {
+  /** Repository description. */
+  description?: string;
+  /** URL of the repository's website. */
+  websiteUrl?: string;
+  /** Whether the repository is private. */
+  private?: boolean;
+  /** Whether issues are enabled. */
+  hasIssues?: boolean;
+  /** Whether projects are enabled. */
+  hasProjects?: boolean;
+  /** Whether the wiki is enabled. */
+  hasWiki?: boolean;
+  /** Default branch name (e.g. "main"). */
+  defaultBranch?: string;
+  /** Whether to allow squash merges. */
+  allowSquashMerge?: boolean;
+  /** Whether to allow merge commits. */
+  allowMergeCommit?: boolean;
+  /** Whether to allow rebase merges. */
+  allowRebaseMerge?: boolean;
+  /** Whether to automatically delete head branches after pull requests are merged. */
+  deleteBranchOnMerge?: boolean;
+  /**
+   * Branch protection rules keyed by branch pattern.
+   * Absent means branch protection is not managed by chant.
+   */
+  branchProtection?: BranchProtectionConfig[];
+  /**
+   * Repository topics (labels shown on the GitHub UI).
+   * Absent means topics are not managed by chant.
+   */
+  topics?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Top-level config
+// ---------------------------------------------------------------------------
+
+/**
+ * Desired state for a single GitHub organization. Absent fields are not managed.
+ *
+ * Selective-by-omission applies at every level: if `teams` is absent, chant
+ * will not touch teams. If a specific `TeamConfig.members` is absent, chant
+ * will not touch that team's membership — even if the team itself is managed.
+ */
+export interface OrgConfig {
+  /**
+   * Org-level settings (description, email, default permissions, etc.).
+   * Absent means org settings are not managed by chant.
+   */
+  settings?: OrgSettings;
+  /**
+   * Teams to manage, keyed by team slug.
+   * Absent means teams are not managed by chant.
+   */
+  teams?: Record<string, TeamConfig>;
+  /**
+   * Org members to manage.
+   * Absent means membership is not managed by chant.
+   */
+  members?: MemberConfig[];
+  /**
+   * Repositories to manage, keyed by repo name.
+   * Absent means repositories are not managed by chant.
+   */
+  repos?: Record<string, RepoConfig>;
+}
+
+/**
+ * Top-level governance config. Contains one or more orgs to manage.
+ *
+ * Example:
+ * ```ts
+ * const config: GovernanceConfig = {
+ *   orgs: {
+ *     "my-org": {
+ *       settings: { defaultRepositoryPermission: "read" },
+ *       teams: {
+ *         "backend": { members: [{ login: "alice" }] },
+ *       },
+ *       // repos omitted → repo state is not managed
+ *     },
+ *   },
+ * };
+ * ```
+ */
+export interface GovernanceConfig {
+  /** Organizations to manage, keyed by org name (GitHub login). */
+  orgs: Record<string, OrgConfig>;
+}

--- a/lexicons/github-org/src/index.ts
+++ b/lexicons/github-org/src/index.ts
@@ -1,0 +1,18 @@
+// Config types
+export type {
+  GovernanceConfig,
+  OrgConfig,
+  OrgSettings,
+  TeamConfig,
+  TeamMember,
+  TeamRepo,
+  TeamRole,
+  TeamRepoPermission,
+  MemberConfig,
+  OrgMemberRole,
+  RepoConfig,
+  BranchProtectionConfig,
+} from "./config/types.js";
+
+// Config loader
+export { loadGovernanceConfig, GovernanceConfigError } from "./config/load.js";

--- a/lexicons/github-org/tsconfig.build.json
+++ b/lexicons/github-org/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/lexicons/github-org/tsconfig.json
+++ b/lexicons/github-org/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Closes #448.

## Summary

- New package `lexicons/github-org/` (`@intentius/chant-lexicon-github-org` v0.8.1) included in the `lexicons/*` workspace glob — no root `package.json` change needed.
- `src/config/types.ts`: `GovernanceConfig`, `OrgConfig`, `OrgSettings`, `TeamConfig`, `MemberConfig`, `RepoConfig`, `BranchProtectionConfig` — every field optional; selective-by-omission semantics documented inline and in JSDoc.
- `src/config/load.ts`: `loadGovernanceConfig(input: unknown): GovernanceConfig` — validates and normalizes, throws `GovernanceConfigError` (typed, with a `field` path) on bad shape.
- `src/index.ts`: re-exports all public types and the loader.
- 20 colocated vitest tests covering valid load, omitted-field-is-unmanaged, and 10 invalid-input rejection cases.

## Verification

- `npx tsc --noEmit -p lexicons/github-org/tsconfig.json` — clean
- `npx vitest run lexicons/github-org` — 20/20 passed
- `npx vitest run packages/core/src/meta/peer-deps.test.ts` — 11/11 passed (peers at `^0.8.1`)