### PR TITLE
feat(github-org): GitHub App installation-token auth client

### DIFF
--- a/lexicons/github-org/src/auth/app-client.test.ts
+++ b/lexicons/github-org/src/auth/app-client.test.ts
@@ -91,11 +91,14 @@ describe("mintInstallationToken", () => {
     const jwt = capturedAuth.replace("Bearer ", "");
     const parts = jwt.split(".");
     expect(parts).toHaveLength(3);
+    const header = JSON.parse(atob(parts[0].replace(/-/g, "+").replace(/_/g, "/")));
+    expect(header.alg).toBe("RS256");
+    expect(header.typ).toBe("JWT");
     const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
     expect(payload.iss).toBe("999");
     expect(typeof payload.iat).toBe("number");
     expect(typeof payload.exp).toBe("number");
-    expect(payload.exp - payload.iat).toBe(660); // 10 min + 60s backdate
+    expect(payload.exp - payload.iat).toBe(600); // 9 min window + 60s backdate
   });
 
   test("throws AppAuthError on 401", async () => {
@@ -238,6 +241,37 @@ describe("createAppClient", () => {
     expect(mintCount).toBe(1); // only one token mint for all 3 calls
   });
 
+  test("two concurrent requests trigger only one token mint", async () => {
+    let mintCount = 0;
+
+    const mockFetch: typeof fetch = async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("access_tokens")) {
+        mintCount++;
+        // Defer to a microtask so the second concurrent request reaches
+        // getToken() while the first mint is still in flight.
+        await Promise.resolve();
+        return makeTokenResponse(`tok_${mintCount}`);
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    const client = createAppClient({
+      appId: "1",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "2",
+      fetchImpl: mockFetch,
+    });
+
+    // Fire two requests in parallel with no token cached yet.
+    await Promise.all([
+      client.request("GET", "/orgs/my-org"),
+      client.request("GET", "/orgs/my-org/teams"),
+    ]);
+
+    expect(mintCount).toBe(1); // single-flight guard collapses to one mint
+  });
+
   test("refreshes token when near expiry", async () => {
     let mintCount = 0;
     const expiredAt = new Date(Date.now() + 30_000).toISOString(); // expires in 30s (< 60s skew)
@@ -323,6 +357,7 @@ describe("createAppClient", () => {
     const err = await client.request("GET", "/orgs/my-org").catch((e) => e as AppAuthError);
     expect(err).toBeInstanceOf(AppAuthError);
     expect(err.statusCode).toBe(403);
+    expect(err.message).toMatch(/Forbidden/); // response body surfaced for debugging
   });
 
   test("accepts a full URL as the path", async () => {

--- a/lexicons/github-org/src/auth/app-client.test.ts
+++ b/lexicons/github-org/src/auth/app-client.test.ts
@@ -1,0 +1,348 @@
+import { describe, test, expect, beforeAll } from "vitest";
+import { mintInstallationToken, createAppClient, AppAuthError } from "./app-client.js";
+
+// ---------------------------------------------------------------------------
+// Test RSA key pair generated once for the whole suite.
+// We use crypto.subtle directly here (same as the implementation) to avoid
+// any external key-gen dependency.
+// ---------------------------------------------------------------------------
+
+let testPrivateKeyPem: string;
+let testPublicKey: CryptoKey;
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)));
+}
+
+beforeAll(async () => {
+  const pair = await crypto.subtle.generateKey(
+    { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+    true,
+    ["sign", "verify"],
+  );
+  testPublicKey = pair.publicKey;
+
+  // Export as PKCS#8 and wrap in PEM — this is the format the implementation
+  // accepts natively (PKCS#8 path).
+  const pkcs8 = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
+  const b64 = arrayBufferToBase64(pkcs8);
+  const lines = b64.match(/.{1,64}/g)!.join("\n");
+  testPrivateKeyPem = `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const EXPIRES_AT = new Date(Date.now() + 3600_000).toISOString(); // +1 h
+
+function makeTokenResponse(token = "ghs_test_token", expiresAt = EXPIRES_AT): Response {
+  return new Response(JSON.stringify({ token, expires_at: expiresAt }), {
+    status: 201,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// mintInstallationToken
+// ---------------------------------------------------------------------------
+
+describe("mintInstallationToken", () => {
+  test("exchanges JWT for an installation token", async () => {
+    let capturedRequest: Request | undefined;
+    const mockFetch: typeof fetch = async (input, init) => {
+      capturedRequest = new Request(input as RequestInfo, init);
+      return makeTokenResponse();
+    };
+
+    const result = await mintInstallationToken({
+      appId: "12345",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "67890",
+      fetchImpl: mockFetch,
+    });
+
+    expect(result.token).toBe("ghs_test_token");
+    expect(result.expiresAt).toBe(EXPIRES_AT);
+    expect(capturedRequest?.url).toBe(
+      "https://api.github.com/app/installations/67890/access_tokens",
+    );
+    expect(capturedRequest?.method).toBe("POST");
+    const authHeader = capturedRequest?.headers.get("Authorization");
+    expect(authHeader).toMatch(/^Bearer ey/); // JWT starts with ey (base64 of {"alg"...})
+    expect(capturedRequest?.headers.get("Accept")).toBe("application/vnd.github+json");
+  });
+
+  test("JWT contains correct iss claim", async () => {
+    let capturedAuth = "";
+    const mockFetch: typeof fetch = async (_, init) => {
+      capturedAuth = (init?.headers as Record<string, string>)["Authorization"] ?? "";
+      return makeTokenResponse();
+    };
+
+    await mintInstallationToken({
+      appId: "999",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "1",
+      fetchImpl: mockFetch,
+    });
+
+    // Decode the JWT payload (middle segment)
+    const jwt = capturedAuth.replace("Bearer ", "");
+    const parts = jwt.split(".");
+    expect(parts).toHaveLength(3);
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
+    expect(payload.iss).toBe("999");
+    expect(typeof payload.iat).toBe("number");
+    expect(typeof payload.exp).toBe("number");
+    expect(payload.exp - payload.iat).toBe(660); // 10 min + 60s backdate
+  });
+
+  test("throws AppAuthError on 401", async () => {
+    const mockFetch: typeof fetch = async () =>
+      new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 });
+
+    await expect(
+      mintInstallationToken({
+        appId: "1",
+        privateKeyPem: testPrivateKeyPem,
+        installationId: "2",
+        fetchImpl: mockFetch,
+      }),
+    ).rejects.toThrow(AppAuthError);
+
+    await expect(
+      mintInstallationToken({
+        appId: "1",
+        privateKeyPem: testPrivateKeyPem,
+        installationId: "2",
+        fetchImpl: mockFetch,
+      }),
+    ).rejects.toThrow(/JWT/);
+  });
+
+  test("throws AppAuthError on 404", async () => {
+    const mockFetch: typeof fetch = async () =>
+      new Response(JSON.stringify({ message: "Not Found" }), { status: 404 });
+
+    const err = await mintInstallationToken({
+      appId: "1",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "999",
+      fetchImpl: mockFetch,
+    }).catch((e) => e as AppAuthError);
+
+    expect(err).toBeInstanceOf(AppAuthError);
+    expect(err.statusCode).toBe(404);
+    expect(err.message).toMatch(/999/);
+    expect(err.message).toMatch(/not found/i);
+  });
+
+  test("throws AppAuthError on unexpected status", async () => {
+    const mockFetch: typeof fetch = async () =>
+      new Response("Internal Server Error", { status: 500 });
+
+    const err = await mintInstallationToken({
+      appId: "1",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "2",
+      fetchImpl: mockFetch,
+    }).catch((e) => e as AppAuthError);
+
+    expect(err).toBeInstanceOf(AppAuthError);
+    expect(err.statusCode).toBe(500);
+  });
+
+  test("throws AppAuthError on bad key PEM", async () => {
+    await expect(
+      mintInstallationToken({
+        appId: "1",
+        privateKeyPem: "-----BEGIN PRIVATE KEY-----\nnotvalidbase64!!!\n-----END PRIVATE KEY-----",
+        installationId: "2",
+        fetchImpl: async () => makeTokenResponse(),
+      }),
+    ).rejects.toThrow(AppAuthError);
+  });
+
+  test("throws AppAuthError on network failure", async () => {
+    const mockFetch: typeof fetch = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+
+    await expect(
+      mintInstallationToken({
+        appId: "1",
+        privateKeyPem: testPrivateKeyPem,
+        installationId: "2",
+        fetchImpl: mockFetch,
+      }),
+    ).rejects.toThrow(AppAuthError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createAppClient
+// ---------------------------------------------------------------------------
+
+describe("createAppClient", () => {
+  test("injects Authorization header on first request", async () => {
+    let requestCount = 0;
+    let capturedAuth = "";
+
+    const mockFetch: typeof fetch = async (input, init) => {
+      requestCount++;
+      const headers = init?.headers as Record<string, string>;
+      if (typeof input === "string" && input.includes("access_tokens")) {
+        return makeTokenResponse("tok_first");
+      }
+      capturedAuth = headers["Authorization"] ?? "";
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    const client = createAppClient({
+      appId: "1",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "2",
+      fetchImpl: mockFetch,
+    });
+
+    await client.request("GET", "/orgs/my-org");
+
+    expect(capturedAuth).toBe("Bearer tok_first");
+    expect(requestCount).toBe(2); // 1 token mint + 1 API call
+  });
+
+  test("reuses cached token on subsequent requests", async () => {
+    let mintCount = 0;
+
+    const mockFetch: typeof fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("access_tokens")) {
+        mintCount++;
+        return makeTokenResponse(`tok_${mintCount}`);
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    const client = createAppClient({
+      appId: "1",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "2",
+      fetchImpl: mockFetch,
+    });
+
+    await client.request("GET", "/orgs/my-org");
+    await client.request("GET", "/orgs/my-org/teams");
+    await client.request("GET", "/repos/my-org/my-repo");
+
+    expect(mintCount).toBe(1); // only one token mint for all 3 calls
+  });
+
+  test("refreshes token when near expiry", async () => {
+    let mintCount = 0;
+    const expiredAt = new Date(Date.now() + 30_000).toISOString(); // expires in 30s (< 60s skew)
+    const freshAt = new Date(Date.now() + 3600_000).toISOString();
+
+    const mockFetch: typeof fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("access_tokens")) {
+        mintCount++;
+        return makeTokenResponse(`tok_${mintCount}`, mintCount === 1 ? expiredAt : freshAt);
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    const client = createAppClient({
+      appId: "1",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "2",
+      fetchImpl: mockFetch,
+    });
+
+    // First call mints a token that expires in 30s (below the 60s skew threshold)
+    await client.request("GET", "/orgs/my-org");
+    // Second call should detect near-expiry and refresh
+    await client.request("GET", "/orgs/my-org/members");
+
+    expect(mintCount).toBe(2);
+  });
+
+  test("forwards request body as JSON", async () => {
+    let capturedBody: unknown;
+
+    const mockFetch: typeof fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("access_tokens")) return makeTokenResponse();
+      capturedBody = init?.body ? JSON.parse(init.body as string) : undefined;
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    const client = createAppClient({
+      appId: "1",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "2",
+      fetchImpl: mockFetch,
+    });
+
+    await client.request("PATCH", "/repos/my-org/my-repo", { private: true });
+    expect(capturedBody).toEqual({ private: true });
+  });
+
+  test("handles 204 No Content gracefully", async () => {
+    const mockFetch: typeof fetch = async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("access_tokens")) return makeTokenResponse();
+      return new Response(null, { status: 204 });
+    };
+
+    const client = createAppClient({
+      appId: "1",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "2",
+      fetchImpl: mockFetch,
+    });
+
+    const result = await client.request("DELETE", "/teams/1/members/alice");
+    expect(result).toEqual({});
+  });
+
+  test("throws AppAuthError on non-ok API response", async () => {
+    const mockFetch: typeof fetch = async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("access_tokens")) return makeTokenResponse();
+      return new Response(JSON.stringify({ message: "Forbidden" }), { status: 403 });
+    };
+
+    const client = createAppClient({
+      appId: "1",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "2",
+      fetchImpl: mockFetch,
+    });
+
+    const err = await client.request("GET", "/orgs/my-org").catch((e) => e as AppAuthError);
+    expect(err).toBeInstanceOf(AppAuthError);
+    expect(err.statusCode).toBe(403);
+  });
+
+  test("accepts a full URL as the path", async () => {
+    let capturedUrl = "";
+
+    const mockFetch: typeof fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("access_tokens")) return makeTokenResponse();
+      capturedUrl = url;
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    const client = createAppClient({
+      appId: "1",
+      privateKeyPem: testPrivateKeyPem,
+      installationId: "2",
+      fetchImpl: mockFetch,
+    });
+
+    await client.request("GET", "https://api.github.com/orgs/my-org");
+    expect(capturedUrl).toBe("https://api.github.com/orgs/my-org");
+  });
+});

--- a/lexicons/github-org/src/auth/app-client.ts
+++ b/lexicons/github-org/src/auth/app-client.ts
@@ -1,0 +1,292 @@
+/**
+ * GitHub App installation-token auth client.
+ *
+ * Mints a short-lived App JWT (RS256 via Web Crypto), exchanges it for an
+ * installation access token, and exposes a thin authed REST client that
+ * auto-refreshes before the token expires.
+ *
+ * No native modules — Web Crypto only (runs in Node ≥ 16 and edge runtimes).
+ */
+
+import type { webcrypto } from "node:crypto";
+
+const API_BASE = "https://api.github.com";
+const USER_AGENT = "chant-governance (+https://github.com/intentius/chant)";
+
+/** Number of seconds before expiry to refresh proactively. */
+const REFRESH_SKEW_S = 60;
+
+// ── JWT helpers (RS256 via crypto.subtle) ────────────────────────────────────
+
+function b64url(buf: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function jsonB64url(obj: unknown): string {
+  return btoa(unescape(encodeURIComponent(JSON.stringify(obj))))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Parse a PKCS#8 or PKCS#1 RSA PEM and import it as a CryptoKey for RS256
+ * signing.
+ *
+ * GitHub App private keys are distributed as PKCS#1 ("RSA PRIVATE KEY"). Web
+ * Crypto only accepts PKCS#8, so we convert the raw DER by prepending the
+ * PKCS#8 AlgorithmIdentifier header when we detect a PKCS#1 PEM.
+ */
+async function importRsaPrivateKey(pem: string): Promise<webcrypto.CryptoKey> {
+  const stripped = pem
+    .replace(/-----BEGIN (?:RSA )?PRIVATE KEY-----/, "")
+    .replace(/-----END (?:RSA )?PRIVATE KEY-----/, "")
+    .replace(/\s+/g, "");
+
+  let derBytes: Uint8Array;
+  try {
+    const binary = atob(stripped);
+    derBytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      derBytes[i] = binary.charCodeAt(i);
+    }
+  } catch {
+    throw new AppAuthError("private key PEM contains invalid base64");
+  }
+
+  const isPkcs1 = /-----BEGIN RSA PRIVATE KEY-----/.test(pem);
+  let keyDer: Uint8Array;
+  if (isPkcs1) {
+    // Wrap PKCS#1 RSA key in a PKCS#8 PrivateKeyInfo container.
+    // PKCS#8 AlgorithmIdentifier for rsaEncryption OID 1.2.840.113549.1.1.1:
+    //   SEQUENCE { OID 1.2.840.113549.1.1.1, NULL }
+    const algorithmIdentifier = new Uint8Array([
+      0x30, 0x0d,            // SEQUENCE (13 bytes)
+      0x06, 0x09,            // OID (9 bytes)
+      0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01,
+      0x05, 0x00,            // NULL
+    ]);
+    // OCTET STRING wrapper: 0x04 + length + content
+    const octetStr = encodeDerTlv(0x04, derBytes);
+    // PKCS#8 PrivateKeyInfo SEQUENCE:
+    //   INTEGER 0 (version)
+    //   algorithmIdentifier
+    //   OCTET STRING (pkcs1 key)
+    const version = new Uint8Array([0x02, 0x01, 0x00]); // INTEGER 0
+    const inner = concatUint8(version, algorithmIdentifier, octetStr);
+    keyDer = encodeDerTlv(0x30, inner); // SEQUENCE
+  } else {
+    keyDer = derBytes;
+  }
+
+  try {
+    return (await crypto.subtle.importKey(
+      "pkcs8",
+      keyDer,
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      false,
+      ["sign"],
+    )) as webcrypto.CryptoKey;
+  } catch (err) {
+    throw new AppAuthError(
+      `failed to import private key: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function encodeDerTlv(tag: number, content: Uint8Array): Uint8Array {
+  const len = content.byteLength;
+  let lenBytes: Uint8Array;
+  if (len < 0x80) {
+    lenBytes = new Uint8Array([len]);
+  } else if (len < 0x100) {
+    lenBytes = new Uint8Array([0x81, len]);
+  } else {
+    lenBytes = new Uint8Array([0x82, (len >> 8) & 0xff, len & 0xff]);
+  }
+  return concatUint8(new Uint8Array([tag]), lenBytes, content);
+}
+
+function concatUint8(...arrays: Uint8Array[]): Uint8Array {
+  const total = arrays.reduce((sum, a) => sum + a.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const a of arrays) {
+    out.set(a, offset);
+    offset += a.byteLength;
+  }
+  return out;
+}
+
+/** Build and sign an App JWT valid for ~10 minutes. */
+async function buildAppJwt(appId: string, key: webcrypto.CryptoKey): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const header = jsonB64url({ alg: "RS256", typ: "JWT" });
+  const payload = jsonB64url({ iat: now - 60, exp: now + 600, iss: appId });
+  const sigInput = new TextEncoder().encode(`${header}.${payload}`);
+  const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key as Parameters<typeof crypto.subtle.sign>[1], sigInput);
+  return `${header}.${payload}.${b64url(sig)}`;
+}
+
+// ── Public errors ────────────────────────────────────────────────────────────
+
+export class AppAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+  ) {
+    super(message);
+    this.name = "AppAuthError";
+  }
+}
+
+// ── mintInstallationToken ────────────────────────────────────────────────────
+
+export interface MintOptions {
+  /** GitHub App ID (numeric string or number). */
+  appId: string | number;
+  /** RSA private key in PEM format (PKCS#1 or PKCS#8). */
+  privateKeyPem: string;
+  /** GitHub App installation ID. */
+  installationId: string | number;
+  /** Injectable fetch for testing. Defaults to the global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface InstallationToken {
+  token: string;
+  /** ISO-8601 expiry from the GitHub API response. */
+  expiresAt: string;
+}
+
+/**
+ * Build an App JWT, exchange it at `POST /app/installations/{id}/access_tokens`,
+ * and return the short-lived installation token + its expiry.
+ */
+export async function mintInstallationToken(opts: MintOptions): Promise<InstallationToken> {
+  const { appId, privateKeyPem, installationId, fetchImpl } = opts;
+  const doFetch = fetchImpl ?? fetch;
+
+  const key = await importRsaPrivateKey(privateKeyPem);
+  const jwt = await buildAppJwt(String(appId), key);
+
+  const url = `${API_BASE}/app/installations/${installationId}/access_tokens`;
+  let res: Response;
+  try {
+    res = await doFetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      redirect: "manual",
+    });
+  } catch (err) {
+    throw new AppAuthError(
+      `network error minting installation token: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (res.status === 401) {
+    throw new AppAuthError("GitHub rejected the App JWT — check appId and privateKeyPem", 401);
+  }
+  if (res.status === 404) {
+    throw new AppAuthError(
+      `installation ${installationId} not found — check installationId and App permissions`,
+      404,
+    );
+  }
+  if (!res.ok) {
+    throw new AppAuthError(`unexpected status ${res.status} from GitHub token endpoint`, res.status);
+  }
+
+  let body: { token?: string; expires_at?: string };
+  try {
+    body = (await res.json()) as { token?: string; expires_at?: string };
+  } catch {
+    throw new AppAuthError("could not parse GitHub token response as JSON");
+  }
+
+  if (!body.token || !body.expires_at) {
+    throw new AppAuthError("GitHub token response missing token or expires_at field");
+  }
+
+  return { token: body.token, expiresAt: body.expires_at };
+}
+
+// ── createAppClient ──────────────────────────────────────────────────────────
+
+export interface AppClientOptions extends MintOptions {}
+
+export interface AppClient {
+  /**
+   * Make an authed GitHub API request. The token is injected automatically and
+   * refreshed if within REFRESH_SKEW_S of expiry.
+   */
+  request<T = unknown>(method: string, path: string, body?: unknown): Promise<T>;
+}
+
+/**
+ * Returns a thin authed REST client that mints an installation token on the
+ * first call and refreshes it before it expires.
+ */
+export function createAppClient(opts: AppClientOptions): AppClient {
+  let cached: InstallationToken | null = null;
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  async function getToken(): Promise<string> {
+    const nowS = Math.floor(Date.now() / 1000);
+    if (cached) {
+      const expiryS = Math.floor(new Date(cached.expiresAt).getTime() / 1000);
+      if (expiryS - nowS > REFRESH_SKEW_S) {
+        return cached.token;
+      }
+    }
+    cached = await mintInstallationToken(opts);
+    return cached.token;
+  }
+
+  return {
+    async request<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
+      const token = await getToken();
+      const url = path.startsWith("http") ? path : `${API_BASE}${path}`;
+      let res: Response;
+      try {
+        res = await doFetch(url, {
+          method,
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            "User-Agent": USER_AGENT,
+            "X-GitHub-Api-Version": "2022-11-28",
+            ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+          },
+          redirect: "manual",
+          ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+        });
+      } catch (err) {
+        throw new AppAuthError(
+          `network error on ${method} ${path}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      if (!res.ok) {
+        throw new AppAuthError(`${method} ${path} returned ${res.status}`, res.status);
+      }
+
+      // 204 No Content — return empty object cast to T
+      if (res.status === 204) return {} as T;
+
+      try {
+        return (await res.json()) as T;
+      } catch {
+        throw new AppAuthError(`could not parse response from ${method} ${path} as JSON`);
+      }
+    },
+  };
+}

--- a/lexicons/github-org/src/auth/app-client.ts
+++ b/lexicons/github-org/src/auth/app-client.ts
@@ -121,11 +121,18 @@ function concatUint8(...arrays: Uint8Array[]): Uint8Array {
   return out;
 }
 
-/** Build and sign an App JWT valid for ~10 minutes. */
+/**
+ * Build and sign an App JWT valid for ~9 minutes.
+ *
+ * GitHub rejects App JWTs whose `exp` is more than 10 minutes in the future. We
+ * cap at 9 minutes (`now + 540`) to leave clock-skew headroom — a host clock
+ * running fast would otherwise push `exp` past the limit and trigger a 422.
+ * `iat` is backdated 60s for the same reason (host clock running slow).
+ */
 async function buildAppJwt(appId: string, key: webcrypto.CryptoKey): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const header = jsonB64url({ alg: "RS256", typ: "JWT" });
-  const payload = jsonB64url({ iat: now - 60, exp: now + 600, iss: appId });
+  const payload = jsonB64url({ iat: now - 60, exp: now + 540, iss: appId });
   const sigInput = new TextEncoder().encode(`${header}.${payload}`);
   const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key as Parameters<typeof crypto.subtle.sign>[1], sigInput);
   return `${header}.${payload}.${b64url(sig)}`;
@@ -237,6 +244,11 @@ export interface AppClient {
  */
 export function createAppClient(opts: AppClientOptions): AppClient {
   let cached: InstallationToken | null = null;
+  // Single-flight guard: when a mint is in progress, concurrent callers await
+  // the same promise instead of each kicking off their own token exchange. The
+  // reconciler makes parallel request() calls, so without this two stale/empty
+  // reads would double-mint and waste rate-limit quota.
+  let pendingMint: Promise<InstallationToken> | null = null;
   const doFetch = opts.fetchImpl ?? fetch;
 
   async function getToken(): Promise<string> {
@@ -247,7 +259,12 @@ export function createAppClient(opts: AppClientOptions): AppClient {
         return cached.token;
       }
     }
-    cached = await mintInstallationToken(opts);
+    if (!pendingMint) {
+      pendingMint = mintInstallationToken(opts).finally(() => {
+        pendingMint = null;
+      });
+    }
+    cached = await pendingMint;
     return cached.token;
   }
 
@@ -276,7 +293,17 @@ export function createAppClient(opts: AppClientOptions): AppClient {
       }
 
       if (!res.ok) {
-        throw new AppAuthError(`${method} ${path} returned ${res.status}`, res.status);
+        // GitHub API error bodies carry the failure reason (e.g. which field is
+        // invalid) and contain no secrets, so surfacing them is safe and makes
+        // prod debugging possible. Cap the length to keep error messages sane.
+        let detail = "";
+        try {
+          const text = await res.text();
+          if (text) detail = `: ${text.slice(0, 500)}`;
+        } catch {
+          // best-effort — fall back to the bare status line
+        }
+        throw new AppAuthError(`${method} ${path} returned ${res.status}${detail}`, res.status);
       }
 
       // 204 No Content — return empty object cast to T

--- a/lexicons/github-org/src/index.ts
+++ b/lexicons/github-org/src/index.ts
@@ -16,3 +16,7 @@ export type {
 
 // Config loader
 export { loadGovernanceConfig, GovernanceConfigError } from "./config/load.js";
+
+// GitHub App auth client
+export type { MintOptions, InstallationToken, AppClientOptions, AppClient } from "./auth/app-client.js";
+export { mintInstallationToken, createAppClient, AppAuthError } from "./auth/app-client.js";


### PR DESCRIPTION
Closes #449.

## Summary

- `lexicons/github-org/src/auth/app-client.ts`: `mintInstallationToken` builds an RS256 App JWT via Web Crypto (`crypto.subtle`) and exchanges it at `POST /app/installations/{id}/access_tokens`. `createAppClient` wraps it in a thin authed REST client that caches the token and refreshes 60 s before expiry.
- Handles both PKCS#8 (`BEGIN PRIVATE KEY`) and PKCS#1 (`BEGIN RSA PRIVATE KEY`) PEM formats — GitHub distributes App keys as PKCS#1; the module converts to PKCS#8 in-memory using a DER TLV wrapper before passing to `crypto.subtle.importKey`.
- No native modules; no @octokit. Edge-runtime-safe.
- Public API re-exported from `src/index.ts`.

## Test plan

- [ ] `npx tsc --noEmit -p lexicons/github-org/tsconfig.json` — clean
- [ ] `npx vitest run lexicons/github-org` — 34 tests pass (20 pre-existing config tests + 14 new auth tests)
- Tests cover: token exchange, JWT `iss`/`iat`/`exp` claims, header injection, token reuse, near-expiry refresh, request body forwarding, 204 handling, 401/404/500 errors, bad key PEM, network failure.