### PR TITLE
feat(github-org): governance plan/diff primitive

### DIFF
--- a/lexicons/github-org/src/index.ts
+++ b/lexicons/github-org/src/index.ts
@@ -20,3 +20,21 @@ export { loadGovernanceConfig, GovernanceConfigError } from "./config/load.js";
 // GitHub App auth client
 export type { MintOptions, InstallationToken, AppClientOptions, AppClient } from "./auth/app-client.js";
 export { mintInstallationToken, createAppClient, AppAuthError } from "./auth/app-client.js";
+
+// Reconcile: plan/diff primitive
+export type {
+  ChangeKind,
+  ChangeSetEntry,
+  ChangeSet,
+  FieldChange,
+  DiffOptions,
+  LiveOrgSettings,
+  LiveTeamMember,
+  LiveTeamRepo,
+  LiveTeamConfig,
+  LiveMemberConfig,
+  LiveBranchProtectionConfig,
+  LiveRepoConfig,
+  LiveOrgState,
+} from "./reconcile/diff.js";
+export { diff, summarizeChangeSet, renderChangeSet } from "./reconcile/diff.js";

--- a/lexicons/github-org/src/reconcile/diff.test.ts
+++ b/lexicons/github-org/src/reconcile/diff.test.ts
@@ -1,0 +1,547 @@
+import { describe, it, expect } from "vitest";
+import {
+  diff,
+  renderChangeSet,
+  summarizeChangeSet,
+} from "./diff.js";
+import type { DiffOptions, LiveOrgState, ChangeSet } from "./diff.js";
+import type { OrgConfig } from "../config/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function noOwnership(): DiffOptions {
+  return {};
+}
+
+function ownAll(): DiffOptions {
+  return { isOwned: () => true };
+}
+
+function ownOnly(owned: string[]): DiffOptions {
+  return { isOwned: (_type, key) => owned.includes(key) };
+}
+
+// ---------------------------------------------------------------------------
+// Org settings
+// ---------------------------------------------------------------------------
+
+describe("diff — org settings", () => {
+  it("emits create when desired has settings and live has none", () => {
+    const desired: OrgConfig = {
+      settings: { description: "My org", defaultRepositoryPermission: "read" },
+    };
+    const live: LiveOrgState = {};
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(1);
+    expect(cs.entries[0]).toMatchObject({
+      kind: "create",
+      resourceType: "org-settings",
+      key: "org-settings",
+      after: desired.settings,
+    });
+  });
+
+  it("emits update with field-level diff when settings differ", () => {
+    const desired: OrgConfig = {
+      settings: { description: "New description", defaultRepositoryPermission: "write" },
+    };
+    const live: LiveOrgState = {
+      settings: { description: "Old description", defaultRepositoryPermission: "read" },
+    };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(1);
+    const entry = cs.entries[0];
+    expect(entry.kind).toBe("update");
+    expect(entry.fields).toHaveLength(2);
+    const fieldNames = entry.fields!.map((f) => f.field);
+    expect(fieldNames).toContain("description");
+    expect(fieldNames).toContain("defaultRepositoryPermission");
+    const descField = entry.fields!.find((f) => f.field === "description")!;
+    expect(descField.before).toBe("Old description");
+    expect(descField.after).toBe("New description");
+  });
+
+  it("emits no change when desired settings match live", () => {
+    const desired: OrgConfig = {
+      settings: { description: "Same", defaultRepositoryPermission: "read" },
+    };
+    const live: LiveOrgState = {
+      settings: { description: "Same", defaultRepositoryPermission: "read" },
+    };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(0);
+  });
+
+  it("selective-by-omission: absent settings field is not diffed", () => {
+    // desired only manages `description`; `email` is not present even though it
+    // differs in live — it must not produce a change.
+    const desired: OrgConfig = {
+      settings: { description: "My org" },
+    };
+    const live: LiveOrgState = {
+      settings: { description: "My org", email: "contact@example.com" },
+    };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(0);
+  });
+
+  it("emits no change when settings are absent from desired (not managed)", () => {
+    const desired: OrgConfig = {};
+    const live: LiveOrgState = { settings: { description: "Something" } };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Teams
+// ---------------------------------------------------------------------------
+
+describe("diff — teams", () => {
+  it("emits create for a team not present in live", () => {
+    const desired: OrgConfig = {
+      teams: { backend: { description: "Backend team" } },
+    };
+    const live: LiveOrgState = { teams: {} };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(1);
+    expect(cs.entries[0]).toMatchObject({
+      kind: "create",
+      resourceType: "team",
+      key: "backend",
+    });
+  });
+
+  it("emits update when team description changes", () => {
+    const desired: OrgConfig = {
+      teams: { backend: { description: "New description" } },
+    };
+    const live: LiveOrgState = {
+      teams: { backend: { description: "Old description" } },
+    };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(1);
+    expect(cs.entries[0].kind).toBe("update");
+    expect(cs.entries[0].fields).toHaveLength(1);
+    expect(cs.entries[0].fields![0].field).toBe("description");
+  });
+
+  it("emits delete for a live team not in desired when owned", () => {
+    const desired: OrgConfig = { teams: {} };
+    const live: LiveOrgState = { teams: { "old-team": { description: "Gone" } } };
+    const cs = diff("my-org", desired, live, ownAll());
+    expect(cs.entries).toHaveLength(1);
+    expect(cs.entries[0]).toMatchObject({ kind: "delete", resourceType: "team", key: "old-team" });
+  });
+
+  it("ownership-gated delete: unmanaged live team is NOT deleted", () => {
+    const desired: OrgConfig = { teams: {} };
+    const live: LiveOrgState = { teams: { "unmanaged-team": { description: "Not ours" } } };
+    const cs = diff("my-org", desired, live, noOwnership());
+    expect(cs.entries).toHaveLength(0);
+  });
+
+  it("emits no changes when teams is absent from desired", () => {
+    const desired: OrgConfig = {};
+    const live: LiveOrgState = { teams: { backend: { description: "Backend" } } };
+    const cs = diff("my-org", desired, live, ownAll());
+    expect(cs.entries).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Team members
+// ---------------------------------------------------------------------------
+
+describe("diff — team members", () => {
+  it("emits create for a new team member", () => {
+    const desired: OrgConfig = {
+      teams: {
+        backend: {
+          members: [{ login: "alice", role: "maintainer" }],
+        },
+      },
+    };
+    const live: LiveOrgState = {
+      teams: { backend: { members: [] } },
+    };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(1);
+    expect(cs.entries[0]).toMatchObject({
+      kind: "create",
+      resourceType: "team-member",
+      key: "backend/alice",
+    });
+  });
+
+  it("emits update when member role changes", () => {
+    const desired: OrgConfig = {
+      teams: {
+        backend: { members: [{ login: "alice", role: "maintainer" }] },
+      },
+    };
+    const live: LiveOrgState = {
+      teams: { backend: { members: [{ login: "alice", role: "member" }] } },
+    };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(1);
+    expect(cs.entries[0].kind).toBe("update");
+    expect(cs.entries[0].fields![0]).toMatchObject({
+      field: "role",
+      before: "member",
+      after: "maintainer",
+    });
+  });
+
+  it("emits delete for removed member when owned", () => {
+    const desired: OrgConfig = {
+      teams: { backend: { members: [] } },
+    };
+    const live: LiveOrgState = {
+      teams: { backend: { members: [{ login: "bob", role: "member" }] } },
+    };
+    const cs = diff("my-org", desired, live, ownOnly(["backend/bob"]));
+    const deletes = cs.entries.filter((e) => e.kind === "delete");
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].key).toBe("backend/bob");
+  });
+
+  it("ownership-gated: unmanaged member is NOT deleted", () => {
+    const desired: OrgConfig = {
+      teams: { backend: { members: [{ login: "alice" }] } },
+    };
+    const live: LiveOrgState = {
+      teams: {
+        backend: {
+          members: [
+            { login: "alice", role: "member" },
+            { login: "unmanaged-user", role: "member" },
+          ],
+        },
+      },
+    };
+    const cs = diff("my-org", desired, live, noOwnership());
+    const deletes = cs.entries.filter((e) => e.kind === "delete");
+    expect(deletes).toHaveLength(0);
+  });
+
+  it("selective-by-omission: absent members field means membership is not managed", () => {
+    const desired: OrgConfig = {
+      teams: { backend: { description: "Backend" } }, // no members key
+    };
+    const live: LiveOrgState = {
+      teams: {
+        backend: {
+          description: "Backend",
+          members: [{ login: "alice", role: "member" }],
+        },
+      },
+    };
+    const cs = diff("my-org", desired, live, ownAll());
+    // No team changes (description matches), no member creates/deletes
+    expect(cs.entries).toHaveLength(0);
+  });
+
+  it("defaults missing role to 'member' for comparison", () => {
+    const desired: OrgConfig = {
+      teams: {
+        backend: { members: [{ login: "alice" }] }, // role absent → defaults to member
+      },
+    };
+    const live: LiveOrgState = {
+      teams: { backend: { members: [{ login: "alice", role: "member" }] } },
+    };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(0); // no diff
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Org members
+// ---------------------------------------------------------------------------
+
+describe("diff — org members", () => {
+  it("emits create for a new org member", () => {
+    const desired: OrgConfig = {
+      members: [{ login: "charlie", role: "admin" }],
+    };
+    const live: LiveOrgState = { members: [] };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(1);
+    expect(cs.entries[0]).toMatchObject({
+      kind: "create",
+      resourceType: "member",
+      key: "charlie",
+    });
+  });
+
+  it("emits delete for removed member when owned", () => {
+    const desired: OrgConfig = { members: [] };
+    const live: LiveOrgState = { members: [{ login: "dave", role: "member" }] };
+    const cs = diff("my-org", desired, live, ownOnly(["dave"]));
+    expect(cs.entries).toHaveLength(1);
+    expect(cs.entries[0]).toMatchObject({ kind: "delete", key: "dave" });
+  });
+
+  it("ownership-gated: unowned live member is NOT deleted", () => {
+    const desired: OrgConfig = { members: [{ login: "alice" }] };
+    const live: LiveOrgState = {
+      members: [
+        { login: "alice", role: "member" },
+        { login: "external", role: "member" },
+      ],
+    };
+    const cs = diff("my-org", desired, live, noOwnership());
+    expect(cs.entries.filter((e) => e.kind === "delete")).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Repos
+// ---------------------------------------------------------------------------
+
+describe("diff — repos", () => {
+  it("emits create for a new repo", () => {
+    const desired: OrgConfig = {
+      repos: { "my-repo": { description: "A repo", private: true } },
+    };
+    const live: LiveOrgState = { repos: {} };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(1);
+    expect(cs.entries[0]).toMatchObject({
+      kind: "create",
+      resourceType: "repo",
+      key: "my-repo",
+    });
+  });
+
+  it("emits update when repo description changes", () => {
+    const desired: OrgConfig = {
+      repos: { "my-repo": { description: "New" } },
+    };
+    const live: LiveOrgState = {
+      repos: { "my-repo": { description: "Old" } },
+    };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(1);
+    expect(cs.entries[0].kind).toBe("update");
+    expect(cs.entries[0].fields![0].field).toBe("description");
+  });
+
+  it("emits delete for a live repo when owned", () => {
+    const desired: OrgConfig = { repos: {} };
+    const live: LiveOrgState = { repos: { "old-repo": { description: "Gone" } } };
+    const cs = diff("my-org", desired, live, ownOnly(["old-repo"]));
+    expect(cs.entries).toHaveLength(1);
+    expect(cs.entries[0]).toMatchObject({ kind: "delete", resourceType: "repo", key: "old-repo" });
+  });
+
+  it("ownership-gated: unmanaged live repo is NOT deleted", () => {
+    const desired: OrgConfig = { repos: {} };
+    const live: LiveOrgState = { repos: { "external-repo": {} } };
+    const cs = diff("my-org", desired, live, noOwnership());
+    expect(cs.entries).toHaveLength(0);
+  });
+
+  it("selective-by-omission: absent repos field means repos are not managed", () => {
+    const desired: OrgConfig = {}; // repos key absent
+    const live: LiveOrgState = { repos: { "some-repo": { description: "Whatever" } } };
+    const cs = diff("my-org", desired, live, ownAll());
+    expect(cs.entries).toHaveLength(0);
+  });
+
+  it("diffs topics as sorted arrays", () => {
+    const desired: OrgConfig = {
+      repos: { "my-repo": { topics: ["typescript", "iac"] } },
+    };
+    const live: LiveOrgState = {
+      repos: { "my-repo": { topics: ["iac", "old-topic"] } },
+    };
+    const cs = diff("my-org", desired, live);
+    const topicsField = cs.entries[0]?.fields?.find((f) => f.field === "topics");
+    expect(topicsField).toBeDefined();
+  });
+
+  it("no-op when repo fields match live", () => {
+    const desired: OrgConfig = {
+      repos: { "my-repo": { description: "Same", private: false } },
+    };
+    const live: LiveOrgState = {
+      repos: { "my-repo": { description: "Same", private: false } },
+    };
+    const cs = diff("my-org", desired, live);
+    expect(cs.entries).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Branch protection
+// ---------------------------------------------------------------------------
+
+describe("diff — branch protection", () => {
+  it("emits create for a new branch protection rule", () => {
+    const desired: OrgConfig = {
+      repos: {
+        "my-repo": {
+          branchProtection: [
+            { pattern: "main", requirePullRequestReviews: true, requiredApprovingReviewCount: 2 },
+          ],
+        },
+      },
+    };
+    const live: LiveOrgState = { repos: { "my-repo": {} } };
+    const cs = diff("my-org", desired, live);
+    const creates = cs.entries.filter((e) => e.kind === "create" && e.resourceType === "branch-protection");
+    expect(creates).toHaveLength(1);
+    expect(creates[0].key).toBe("my-repo/main");
+  });
+
+  it("emits update when branch protection rule changes", () => {
+    const desired: OrgConfig = {
+      repos: {
+        "my-repo": {
+          branchProtection: [{ pattern: "main", requiredApprovingReviewCount: 2 }],
+        },
+      },
+    };
+    const live: LiveOrgState = {
+      repos: {
+        "my-repo": {
+          branchProtection: [{ pattern: "main", requiredApprovingReviewCount: 1 }],
+        },
+      },
+    };
+    const cs = diff("my-org", desired, live);
+    const updates = cs.entries.filter((e) => e.kind === "update" && e.resourceType === "branch-protection");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].fields![0].field).toBe("requiredApprovingReviewCount");
+  });
+
+  it("selective-by-omission: absent branchProtection means rules are not managed", () => {
+    const desired: OrgConfig = {
+      repos: { "my-repo": { description: "A repo" } }, // no branchProtection key
+    };
+    const live: LiveOrgState = {
+      repos: {
+        "my-repo": {
+          description: "A repo",
+          branchProtection: [{ pattern: "main", requirePullRequestReviews: true }],
+        },
+      },
+    };
+    const cs = diff("my-org", desired, live, ownAll());
+    expect(cs.entries).toHaveLength(0);
+  });
+
+  it("ownership-gated: unmanaged live branch-protection rule is NOT deleted", () => {
+    const desired: OrgConfig = {
+      repos: { "my-repo": { branchProtection: [] } },
+    };
+    const live: LiveOrgState = {
+      repos: {
+        "my-repo": {
+          branchProtection: [{ pattern: "release/*", allowForcePushes: false }],
+        },
+      },
+    };
+    const cs = diff("my-org", desired, live, noOwnership());
+    expect(cs.entries.filter((e) => e.kind === "delete")).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stable ordering
+// ---------------------------------------------------------------------------
+
+describe("diff — stable ordering", () => {
+  it("entries are sorted by resource type then key", () => {
+    const desired: OrgConfig = {
+      settings: { description: "Org" },
+      teams: {
+        zteam: { members: [{ login: "zee" }] },
+        ateam: { members: [{ login: "alice" }] },
+      },
+      members: [{ login: "bob" }],
+    };
+    const live: LiveOrgState = {};
+    const cs = diff("my-org", desired, live);
+    const types = cs.entries.map((e) => e.resourceType);
+    // org-settings before team before team-member before member
+    const settingsIdx = types.indexOf("org-settings");
+    const teamIdx = types.indexOf("team");
+    const memberIdx = types.findIndex((t) => t === "member");
+    expect(settingsIdx).toBeLessThan(teamIdx);
+    expect(teamIdx).toBeLessThan(memberIdx);
+    // Teams themselves are sorted alphabetically
+    const teamEntries = cs.entries.filter((e) => e.resourceType === "team");
+    expect(teamEntries[0].key).toBe("ateam");
+    expect(teamEntries[1].key).toBe("zteam");
+  });
+
+  it("produces identical output for identical inputs (deterministic)", () => {
+    const desired: OrgConfig = {
+      teams: {
+        c: { members: [{ login: "z" }, { login: "a" }] },
+        a: {},
+      },
+    };
+    const live: LiveOrgState = {};
+    const cs1 = diff("my-org", desired, live);
+    const cs2 = diff("my-org", desired, live);
+    expect(cs1.entries.map((e) => e.key)).toEqual(cs2.entries.map((e) => e.key));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Summary + render helpers
+// ---------------------------------------------------------------------------
+
+describe("summarizeChangeSet", () => {
+  it("counts entries per kind", () => {
+    const desired: OrgConfig = {
+      settings: { description: "New" },
+      teams: { newteam: {} },
+      members: [{ login: "alice" }],
+    };
+    const live: LiveOrgState = {
+      settings: { description: "Old" },
+    };
+    const cs = diff("my-org", desired, live);
+    const counts = summarizeChangeSet(cs);
+    expect(counts.update).toBeGreaterThanOrEqual(1); // settings update
+    expect(counts.create).toBeGreaterThanOrEqual(2); // team + member
+    expect(counts.delete).toBe(0);
+  });
+});
+
+describe("renderChangeSet", () => {
+  it("returns a non-empty string with the org name", () => {
+    const desired: OrgConfig = {
+      settings: { description: "My org" },
+    };
+    const live: LiveOrgState = {};
+    const cs = diff("my-org", desired, live);
+    const output = renderChangeSet(cs);
+    expect(output).toContain("my-org");
+    expect(output).toContain("create");
+  });
+
+  it("returns 'No changes' when the change set is empty", () => {
+    const cs: ChangeSet = { org: "empty-org", entries: [] };
+    expect(renderChangeSet(cs)).toContain("No changes");
+  });
+
+  it("includes field-level diff lines in update output", () => {
+    const desired: OrgConfig = {
+      settings: { description: "New" },
+    };
+    const live: LiveOrgState = { settings: { description: "Old" } };
+    const cs = diff("my-org", desired, live);
+    const output = renderChangeSet(cs);
+    expect(output).toContain("description");
+    expect(output).toContain("Old");
+    expect(output).toContain("New");
+  });
+});

--- a/lexicons/github-org/src/reconcile/diff.ts
+++ b/lexicons/github-org/src/reconcile/diff.ts
@@ -1,0 +1,675 @@
+/**
+ * Governance plan/diff primitive.
+ *
+ * Given a desired-state config and a fetched live snapshot of the same
+ * resources, compute a typed change set (creates / updates / deletes).
+ *
+ * Selective-by-omission: a field absent from desired is never a diff. A
+ * managed collection emits deletes ONLY for entries the caller declares it
+ * owns via an explicit ownership predicate — never blanket deletion.
+ *
+ * Pure, deterministic, no I/O.
+ */
+import type {
+  OrgConfig,
+  OrgSettings,
+  TeamConfig,
+  TeamMember,
+  TeamRepo,
+  MemberConfig,
+  RepoConfig,
+  BranchProtectionConfig,
+} from "../config/types.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A single field-level change: what the old value was and what it will become. */
+export interface FieldChange {
+  field: string;
+  before: unknown;
+  after: unknown;
+}
+
+/** The kind of operation this change represents. */
+export type ChangeKind = "create" | "update" | "delete";
+
+/** A single entry in the change set. */
+export interface ChangeSetEntry {
+  kind: ChangeKind;
+  /**
+   * High-level resource category (e.g. "org-settings", "team", "member",
+   * "repo", "team-member", "team-repo", "branch-protection").
+   */
+  resourceType: string;
+  /**
+   * Unique key identifying this resource within its type.
+   * - For top-level resources: "org-settings", a team slug, a member login, a
+   *   repo name.
+   * - For nested resources: "<parent>/<child>" (e.g. "backend/alice" for a
+   *   team member, "my-repo/main" for a branch protection rule).
+   */
+  key: string;
+  /** The live value before the change (absent for creates). */
+  before?: unknown;
+  /** The desired value after the change (absent for deletes). */
+  after?: unknown;
+  /**
+   * Field-level diff, populated for `update` entries. Each entry describes
+   * one field that differs between desired and live.
+   */
+  fields?: FieldChange[];
+}
+
+/** The full set of changes to reconcile for one org. */
+export interface ChangeSet {
+  /** GitHub org login this change set applies to. */
+  org: string;
+  /** All proposed changes, in stable order (see `RESOURCE_TYPE_ORDER`). */
+  entries: ChangeSetEntry[];
+}
+
+/** Options controlling diff behaviour. */
+export interface DiffOptions {
+  /**
+   * Ownership predicate for collection entries (team members, team repos,
+   * org members, branch protection rules, etc.).
+   *
+   * When the desired config declares a collection (e.g. `team.members`), the
+   * diff considers deleting live entries not found in desired. An entry is
+   * only emitted as `delete` when this predicate returns `true` for it.
+   *
+   * If omitted, deletes are never emitted for collection entries — equivalent
+   * to "assume nothing is owned".
+   *
+   * @param resourceType - The resource type string (same as `ChangeSetEntry.resourceType`).
+   * @param key - The entry key (same as `ChangeSetEntry.key`).
+   * @returns `true` if chant owns this entry and may delete it.
+   */
+  isOwned?: (resourceType: string, key: string) => boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Live snapshot types
+// ---------------------------------------------------------------------------
+
+/**
+ * Live snapshot of a single org's state. Every sub-type mirrors the desired
+ * config shape but uses concrete (non-optional) values.
+ */
+export interface LiveOrgSettings {
+  description?: string;
+  email?: string;
+  websiteUrl?: string;
+  membersCanCreatePublicRepositories?: boolean;
+  membersCanCreatePrivateRepositories?: boolean;
+  membersCanCreateInternalRepositories?: boolean;
+  defaultRepositoryPermission?: "none" | "read" | "write" | "admin";
+  requireTwoFactorAuthentication?: boolean;
+}
+
+export interface LiveTeamMember {
+  login: string;
+  role: "member" | "maintainer";
+}
+
+export interface LiveTeamRepo {
+  name: string;
+  permission: "pull" | "triage" | "push" | "maintain" | "admin";
+}
+
+export interface LiveTeamConfig {
+  description?: string;
+  privacy?: "secret" | "closed";
+  parentTeamSlug?: string;
+  members?: LiveTeamMember[];
+  repos?: LiveTeamRepo[];
+}
+
+export interface LiveMemberConfig {
+  login: string;
+  role: "member" | "admin";
+}
+
+export interface LiveBranchProtectionConfig {
+  pattern: string;
+  requirePullRequestReviews?: boolean;
+  requiredApprovingReviewCount?: number;
+  dismissStaleReviews?: boolean;
+  requireCodeOwnerReviews?: boolean;
+  requireStatusChecks?: boolean;
+  requiredStatusCheckContexts?: string[];
+  requireBranchesToBeUpToDate?: boolean;
+  restrictPushes?: boolean;
+  allowForcePushes?: boolean;
+  allowDeletions?: boolean;
+  requireLinearHistory?: boolean;
+}
+
+export interface LiveRepoConfig {
+  description?: string;
+  websiteUrl?: string;
+  private?: boolean;
+  hasIssues?: boolean;
+  hasProjects?: boolean;
+  hasWiki?: boolean;
+  defaultBranch?: string;
+  allowSquashMerge?: boolean;
+  allowMergeCommit?: boolean;
+  allowRebaseMerge?: boolean;
+  deleteBranchOnMerge?: boolean;
+  branchProtection?: LiveBranchProtectionConfig[];
+  topics?: string[];
+}
+
+export interface LiveOrgState {
+  settings?: LiveOrgSettings;
+  teams?: Record<string, LiveTeamConfig>;
+  members?: LiveMemberConfig[];
+  repos?: Record<string, LiveRepoConfig>;
+}
+
+// ---------------------------------------------------------------------------
+// Resource type ordering — stable output across runs
+// ---------------------------------------------------------------------------
+
+const RESOURCE_TYPE_ORDER = [
+  "org-settings",
+  "team",
+  "team-member",
+  "team-repo",
+  "member",
+  "repo",
+  "branch-protection",
+] as const;
+
+// ---------------------------------------------------------------------------
+// diff — top-level entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a typed change set for one org.
+ *
+ * @param org - GitHub org login.
+ * @param desired - Desired state from the governance config.
+ * @param live - Live snapshot fetched from the GitHub API.
+ * @param opts - Diff options (ownership predicate, etc.).
+ */
+export function diff(
+  org: string,
+  desired: OrgConfig,
+  live: LiveOrgState,
+  opts: DiffOptions = {},
+): ChangeSet {
+  const entries: ChangeSetEntry[] = [];
+
+  diffSettings(desired.settings, live.settings, entries);
+  diffTeams(desired.teams, live.teams ?? {}, opts, entries);
+  diffMembers(desired.members, live.members ?? [], opts, entries);
+  diffRepos(desired.repos, live.repos ?? {}, opts, entries);
+
+  // Sort into canonical order
+  const typeIndex = (t: string): number => {
+    const i = (RESOURCE_TYPE_ORDER as readonly string[]).indexOf(t);
+    return i === -1 ? RESOURCE_TYPE_ORDER.length : i;
+  };
+  entries.sort((a, b) => {
+    const ti = typeIndex(a.resourceType) - typeIndex(b.resourceType);
+    if (ti !== 0) return ti;
+    return a.key.localeCompare(b.key);
+  });
+
+  return { org, entries };
+}
+
+// ---------------------------------------------------------------------------
+// Org settings
+// ---------------------------------------------------------------------------
+
+function diffSettings(
+  desired: OrgSettings | undefined,
+  live: LiveOrgSettings | undefined,
+  out: ChangeSetEntry[],
+): void {
+  // Org settings are not managed when absent
+  if (desired === undefined) return;
+
+  if (live === undefined) {
+    out.push({ kind: "create", resourceType: "org-settings", key: "org-settings", after: desired });
+    return;
+  }
+
+  const fields = diffObject(desired as Record<string, unknown>, live as Record<string, unknown>);
+  if (fields.length > 0) {
+    out.push({
+      kind: "update",
+      resourceType: "org-settings",
+      key: "org-settings",
+      before: live,
+      after: desired,
+      fields,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Teams
+// ---------------------------------------------------------------------------
+
+function diffTeams(
+  desired: Record<string, TeamConfig> | undefined,
+  live: Record<string, LiveTeamConfig>,
+  opts: DiffOptions,
+  out: ChangeSetEntry[],
+): void {
+  if (desired === undefined) return;
+
+  // Creates and updates
+  for (const [slug, desiredTeam] of Object.entries(desired)) {
+    const liveTeam = live[slug];
+    if (!liveTeam) {
+      out.push({ kind: "create", resourceType: "team", key: slug, after: desiredTeam });
+      continue;
+    }
+    // Diff top-level team fields (exclude members/repos — handled separately)
+    const teamFields = diffObjectKeys(
+      desiredTeam as Record<string, unknown>,
+      liveTeam as Record<string, unknown>,
+      ["description", "privacy", "parentTeamSlug"],
+    );
+    if (teamFields.length > 0) {
+      out.push({
+        kind: "update",
+        resourceType: "team",
+        key: slug,
+        before: liveTeam,
+        after: desiredTeam,
+        fields: teamFields,
+      });
+    }
+
+    // Team members
+    diffTeamMembers(slug, desiredTeam.members, liveTeam.members ?? [], opts, out);
+
+    // Team repos
+    diffTeamRepos(slug, desiredTeam.repos, liveTeam.repos ?? [], opts, out);
+  }
+
+  // Deletes: live teams not in desired
+  for (const slug of Object.keys(live)) {
+    if (!Object.prototype.hasOwnProperty.call(desired, slug)) {
+      const key = slug;
+      if (opts.isOwned?.("team", key)) {
+        out.push({ kind: "delete", resourceType: "team", key, before: live[slug] });
+      }
+    }
+  }
+}
+
+function diffTeamMembers(
+  teamSlug: string,
+  desired: TeamMember[] | undefined,
+  live: LiveTeamMember[],
+  opts: DiffOptions,
+  out: ChangeSetEntry[],
+): void {
+  if (desired === undefined) return; // not managed
+
+  const desiredByLogin = new Map(desired.map((m) => [m.login, m]));
+  const liveByLogin = new Map(live.map((m) => [m.login, m]));
+
+  // Creates and updates
+  for (const [login, dm] of desiredByLogin) {
+    const lm = liveByLogin.get(login);
+    const effectiveRole = dm.role ?? "member";
+    if (!lm) {
+      out.push({
+        kind: "create",
+        resourceType: "team-member",
+        key: `${teamSlug}/${login}`,
+        after: { login, role: effectiveRole },
+      });
+    } else if (lm.role !== effectiveRole) {
+      out.push({
+        kind: "update",
+        resourceType: "team-member",
+        key: `${teamSlug}/${login}`,
+        before: lm,
+        after: { login, role: effectiveRole },
+        fields: [{ field: "role", before: lm.role, after: effectiveRole }],
+      });
+    }
+  }
+
+  // Deletes: ownership-gated
+  for (const [login, lm] of liveByLogin) {
+    if (!desiredByLogin.has(login)) {
+      const key = `${teamSlug}/${login}`;
+      if (opts.isOwned?.("team-member", key)) {
+        out.push({ kind: "delete", resourceType: "team-member", key, before: lm });
+      }
+    }
+  }
+}
+
+function diffTeamRepos(
+  teamSlug: string,
+  desired: TeamRepo[] | undefined,
+  live: LiveTeamRepo[],
+  opts: DiffOptions,
+  out: ChangeSetEntry[],
+): void {
+  if (desired === undefined) return;
+
+  const desiredByName = new Map(desired.map((r) => [r.name, r]));
+  const liveByName = new Map(live.map((r) => [r.name, r]));
+
+  for (const [name, dr] of desiredByName) {
+    const lr = liveByName.get(name);
+    if (!lr) {
+      out.push({
+        kind: "create",
+        resourceType: "team-repo",
+        key: `${teamSlug}/${name}`,
+        after: dr,
+      });
+    } else if (lr.permission !== dr.permission) {
+      out.push({
+        kind: "update",
+        resourceType: "team-repo",
+        key: `${teamSlug}/${name}`,
+        before: lr,
+        after: dr,
+        fields: [{ field: "permission", before: lr.permission, after: dr.permission }],
+      });
+    }
+  }
+
+  for (const [name, lr] of liveByName) {
+    if (!desiredByName.has(name)) {
+      const key = `${teamSlug}/${name}`;
+      if (opts.isOwned?.("team-repo", key)) {
+        out.push({ kind: "delete", resourceType: "team-repo", key, before: lr });
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Org members
+// ---------------------------------------------------------------------------
+
+function diffMembers(
+  desired: MemberConfig[] | undefined,
+  live: LiveMemberConfig[],
+  opts: DiffOptions,
+  out: ChangeSetEntry[],
+): void {
+  if (desired === undefined) return;
+
+  const desiredByLogin = new Map(desired.map((m) => [m.login, m]));
+  const liveByLogin = new Map(live.map((m) => [m.login, m]));
+
+  for (const [login, dm] of desiredByLogin) {
+    const lm = liveByLogin.get(login);
+    const effectiveRole = dm.role ?? "member";
+    if (!lm) {
+      out.push({
+        kind: "create",
+        resourceType: "member",
+        key: login,
+        after: { login, role: effectiveRole },
+      });
+    } else if (lm.role !== effectiveRole) {
+      out.push({
+        kind: "update",
+        resourceType: "member",
+        key: login,
+        before: lm,
+        after: { login, role: effectiveRole },
+        fields: [{ field: "role", before: lm.role, after: effectiveRole }],
+      });
+    }
+  }
+
+  for (const [login, lm] of liveByLogin) {
+    if (!desiredByLogin.has(login)) {
+      const key = login;
+      if (opts.isOwned?.("member", key)) {
+        out.push({ kind: "delete", resourceType: "member", key, before: lm });
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Repos
+// ---------------------------------------------------------------------------
+
+function diffRepos(
+  desired: Record<string, RepoConfig> | undefined,
+  live: Record<string, LiveRepoConfig>,
+  opts: DiffOptions,
+  out: ChangeSetEntry[],
+): void {
+  if (desired === undefined) return;
+
+  for (const [name, dr] of Object.entries(desired)) {
+    const lr = live[name];
+    if (!lr) {
+      out.push({ kind: "create", resourceType: "repo", key: name, after: dr });
+      continue;
+    }
+    const repoFields = diffObjectKeys(
+      dr as Record<string, unknown>,
+      lr as Record<string, unknown>,
+      [
+        "description", "websiteUrl", "private", "hasIssues", "hasProjects",
+        "hasWiki", "defaultBranch", "allowSquashMerge", "allowMergeCommit",
+        "allowRebaseMerge", "deleteBranchOnMerge",
+      ],
+    );
+    // Topics: compare as sorted arrays if desired has topics
+    if (dr.topics !== undefined) {
+      const desiredTopics = [...dr.topics].sort().join(",");
+      const liveTopics = [...(lr.topics ?? [])].sort().join(",");
+      if (desiredTopics !== liveTopics) {
+        repoFields.push({ field: "topics", before: lr.topics ?? [], after: dr.topics });
+      }
+    }
+    if (repoFields.length > 0) {
+      out.push({
+        kind: "update",
+        resourceType: "repo",
+        key: name,
+        before: lr,
+        after: dr,
+        fields: repoFields,
+      });
+    }
+
+    // Branch protection rules
+    diffBranchProtection(name, dr.branchProtection, lr.branchProtection ?? [], opts, out);
+  }
+
+  for (const name of Object.keys(live)) {
+    if (!Object.prototype.hasOwnProperty.call(desired, name)) {
+      if (opts.isOwned?.("repo", name)) {
+        out.push({ kind: "delete", resourceType: "repo", key: name, before: live[name] });
+      }
+    }
+  }
+}
+
+function diffBranchProtection(
+  repoName: string,
+  desired: BranchProtectionConfig[] | undefined,
+  live: LiveBranchProtectionConfig[],
+  opts: DiffOptions,
+  out: ChangeSetEntry[],
+): void {
+  if (desired === undefined) return;
+
+  const desiredByPattern = new Map(desired.map((r) => [r.pattern, r]));
+  const liveByPattern = new Map(live.map((r) => [r.pattern, r]));
+
+  const bpFields: Array<keyof BranchProtectionConfig> = [
+    "requirePullRequestReviews",
+    "requiredApprovingReviewCount",
+    "dismissStaleReviews",
+    "requireCodeOwnerReviews",
+    "requireStatusChecks",
+    "requireBranchesToBeUpToDate",
+    "restrictPushes",
+    "allowForcePushes",
+    "allowDeletions",
+    "requireLinearHistory",
+  ];
+
+  for (const [pattern, db] of desiredByPattern) {
+    const lb = liveByPattern.get(pattern);
+    const key = `${repoName}/${pattern}`;
+    if (!lb) {
+      out.push({ kind: "create", resourceType: "branch-protection", key, after: db });
+      continue;
+    }
+    const fields = diffObjectKeys(
+      db as unknown as Record<string, unknown>,
+      lb as unknown as Record<string, unknown>,
+      bpFields as string[],
+    );
+    // Special-case: requiredStatusCheckContexts (array comparison)
+    if (db.requiredStatusCheckContexts !== undefined) {
+      const ds = [...db.requiredStatusCheckContexts].sort().join(",");
+      const ls = [...(lb.requiredStatusCheckContexts ?? [])].sort().join(",");
+      if (ds !== ls) {
+        fields.push({
+          field: "requiredStatusCheckContexts",
+          before: lb.requiredStatusCheckContexts ?? [],
+          after: db.requiredStatusCheckContexts,
+        });
+      }
+    }
+    if (fields.length > 0) {
+      out.push({
+        kind: "update",
+        resourceType: "branch-protection",
+        key,
+        before: lb,
+        after: db,
+        fields,
+      });
+    }
+  }
+
+  for (const [pattern, lb] of liveByPattern) {
+    if (!desiredByPattern.has(pattern)) {
+      const key = `${repoName}/${pattern}`;
+      if (opts.isOwned?.("branch-protection", key)) {
+        out.push({ kind: "delete", resourceType: "branch-protection", key, before: lb });
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Object-level field diffing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Diff only the keys present in `desired` against `live`. Returns one
+ * FieldChange per key where the values differ (using deep equality via JSON).
+ * Keys absent from `desired` are not compared — selective-by-omission.
+ */
+function diffObject(
+  desired: Record<string, unknown>,
+  live: Record<string, unknown>,
+): FieldChange[] {
+  const fields: FieldChange[] = [];
+  for (const key of Object.keys(desired)) {
+    const dv = desired[key];
+    const lv = live[key];
+    if (!deepEqual(dv, lv)) {
+      fields.push({ field: key, before: lv, after: dv });
+    }
+  }
+  return fields;
+}
+
+/**
+ * Diff only the listed keys (if present in desired) against live.
+ */
+function diffObjectKeys(
+  desired: Record<string, unknown>,
+  live: Record<string, unknown>,
+  keys: string[],
+): FieldChange[] {
+  const fields: FieldChange[] = [];
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(desired, key)) continue;
+    const dv = desired[key];
+    const lv = live[key];
+    if (!deepEqual(dv, lv)) {
+      fields.push({ field: key, before: lv, after: dv });
+    }
+  }
+  return fields;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// ---------------------------------------------------------------------------
+// Summary helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Count entries per change kind.
+ */
+export function summarizeChangeSet(cs: ChangeSet): Record<ChangeKind, number> {
+  const counts: Record<ChangeKind, number> = { create: 0, update: 0, delete: 0 };
+  for (const e of cs.entries) counts[e.kind]++;
+  return counts;
+}
+
+/**
+ * Human-readable plan summary for dry-run output. Pure — returns a string.
+ */
+export function renderChangeSet(cs: ChangeSet): string {
+  const counts = summarizeChangeSet(cs);
+  const header = `Plan for ${cs.org}: ${counts.create} to create, ${counts.update} to update, ${counts.delete} to delete`;
+
+  if (cs.entries.length === 0) return `${header}\nNo changes.`;
+
+  const lines: string[] = [header];
+
+  const byKind: Record<ChangeKind, ChangeSetEntry[]> = { create: [], update: [], delete: [] };
+  for (const e of cs.entries) byKind[e.kind].push(e);
+
+  const ORDER: ChangeKind[] = ["create", "update", "delete"];
+  for (const kind of ORDER) {
+    const group = byKind[kind];
+    if (group.length === 0) continue;
+    lines.push(`\n${kind.toUpperCase()}:`);
+    for (const e of group) {
+      lines.push(`  [${e.resourceType}] ${e.key}`);
+      for (const f of e.fields ?? []) {
+        lines.push(`    ${f.field}: ${fmt(f.before)} → ${fmt(f.after)}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function fmt(v: unknown): string {
+  if (v === undefined) return "<unset>";
+  if (typeof v === "string") return v.length > 60 ? `${v.slice(0, 57)}...` : v;
+  const json = JSON.stringify(v);
+  return json.length > 60 ? `${json.slice(0, 57)}...` : json;
+}


### PR DESCRIPTION
Closes #450.

## Summary

- Adds `lexicons/github-org/src/reconcile/diff.ts`: a pure `diff(org, desired, live, opts): ChangeSet` function covering org settings, teams (top-level fields + members + repos), org members, repositories (fields + topics + branch protection rules).
- Selective-by-omission at every level: an absent field or collection in desired generates zero changes.
- Deletes are ownership-gated via an `isOwned` predicate in `DiffOptions`; unmanaged live entries are never deleted.
- Update entries carry field-level `FieldChange[]` (before/after per changed field).
- Stable ordering: resource types in canonical order, then alphabetical key within each type.
- `summarizeChangeSet` and `renderChangeSet` helpers for dry-run output.
- Re-exports all public types and functions from `src/index.ts`.

## Test plan

- [x] `npx tsc --noEmit -p lexicons/github-org/tsconfig.json` — clean
- [x] `npx vitest run lexicons/github-org` — 71 tests pass (36 new, 35 pre-existing)
- [x] Tests cover: create, update, delete, no-op, omitted-is-unmanaged, ownership-gated delete, stable ordering, render helpers