### PR TITLE
feat(github-org): reconcile guardrail library

### DIFF
--- a/lexicons/github-org/src/index.ts
+++ b/lexicons/github-org/src/index.ts
@@ -38,3 +38,22 @@ export type {
   LiveOrgState,
 } from "./reconcile/diff.js";
 export { diff, summarizeChangeSet, renderChangeSet } from "./reconcile/diff.js";
+
+// Reconcile: guardrails
+export type {
+  GuardrailDiagnostic,
+  GuardrailResult,
+  RemovalDeltaCapOptions,
+  AdminFloorOptions,
+  RequiredAdminsOptions,
+  RequireSelfOptions,
+  GuardrailConfig,
+} from "./reconcile/guardrails.js";
+export {
+  resolveRenames,
+  removalDeltaCap,
+  adminFloor,
+  requiredAdmins,
+  requireSelf,
+  runGuardrails,
+} from "./reconcile/guardrails.js";

--- a/lexicons/github-org/src/reconcile/guardrails.test.ts
+++ b/lexicons/github-org/src/reconcile/guardrails.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveRenames,
+  removalDeltaCap,
+  adminFloor,
+  requiredAdmins,
+  requireSelf,
+  runGuardrails,
+} from "./guardrails.js";
+import type { ChangeSet } from "./diff.js";
+import type { LiveOrgState } from "./diff.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeChangeSet(entries: ChangeSet["entries"]): ChangeSet {
+  return { org: "test-org", entries };
+}
+
+function emptyLive(): LiveOrgState {
+  return {};
+}
+
+function liveWithAdmins(logins: string[]): LiveOrgState {
+  return {
+    members: logins.map((login) => ({ login, role: "admin" as const })),
+  };
+}
+
+function liveWithMembers(
+  members: Array<{ login: string; role: "admin" | "member" }>,
+): LiveOrgState {
+  return { members };
+}
+
+// ---------------------------------------------------------------------------
+// resolveRenames
+// ---------------------------------------------------------------------------
+
+describe("resolveRenames", () => {
+  it("passes through a change set with no renames", () => {
+    const cs = makeChangeSet([
+      { kind: "create", resourceType: "member", key: "alice", after: { login: "alice", role: "member" } },
+      { kind: "delete", resourceType: "member", key: "bob", before: { login: "bob", role: "member" } },
+    ]);
+    const result = resolveRenames(cs);
+    expect(result.entries).toHaveLength(2);
+  });
+
+  it("collapses delete+create into update when previously alias matches", () => {
+    const cs = makeChangeSet([
+      {
+        kind: "delete",
+        resourceType: "member",
+        key: "old-alice",
+        before: { login: "old-alice", role: "admin" },
+      },
+      {
+        kind: "create",
+        resourceType: "member",
+        key: "alice",
+        after: { login: "alice", role: "admin", previously: "old-alice" },
+      },
+    ]);
+    const result = resolveRenames(cs);
+    expect(result.entries).toHaveLength(1);
+    const e = result.entries[0];
+    expect(e.kind).toBe("update");
+    expect(e.key).toBe("alice");
+    expect(e.before).toMatchObject({ login: "old-alice" });
+    expect(e.after).toMatchObject({ login: "alice" });
+  });
+
+  it("leaves unmatched deletes in place", () => {
+    const cs = makeChangeSet([
+      {
+        kind: "delete",
+        resourceType: "member",
+        key: "unrelated",
+        before: { login: "unrelated", role: "member" },
+      },
+      {
+        kind: "create",
+        resourceType: "member",
+        key: "alice",
+        after: { login: "alice", role: "admin", previously: "old-alice" },
+      },
+    ]);
+    const result = resolveRenames(cs);
+    // unrelated delete remains; create without matching delete also remains
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries.some((e) => e.kind === "delete" && e.key === "unrelated")).toBe(true);
+    expect(result.entries.some((e) => e.kind === "create" && e.key === "alice")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removalDeltaCap
+// ---------------------------------------------------------------------------
+
+describe("removalDeltaCap", () => {
+  it("passes when deletions are within the threshold", () => {
+    // 1 delete out of 10 total = 10%, threshold 25%
+    const cs = makeChangeSet([
+      { kind: "delete", resourceType: "member", key: "a", before: {} },
+      ...Array.from({ length: 9 }, (_, i) => ({
+        kind: "update" as const,
+        resourceType: "member",
+        key: `m${i}`,
+        before: {},
+        after: {},
+      })),
+    ]);
+    expect(removalDeltaCap(cs)).toBeNull();
+  });
+
+  it("trips when deletions exceed the threshold", () => {
+    // 6 deletes out of 8 total = 75%, threshold 25%
+    const cs = makeChangeSet([
+      ...Array.from({ length: 6 }, (_, i) => ({
+        kind: "delete" as const,
+        resourceType: "member",
+        key: `d${i}`,
+        before: {},
+      })),
+      ...Array.from({ length: 2 }, (_, i) => ({
+        kind: "update" as const,
+        resourceType: "member",
+        key: `u${i}`,
+        before: {},
+        after: {},
+      })),
+    ]);
+    const result = removalDeltaCap(cs);
+    expect(result).not.toBeNull();
+    expect(result!.guardrail).toBe("removalDeltaCap");
+    expect(result!.message).toMatch(/75%/);
+  });
+
+  it("respects a custom maxFraction", () => {
+    // 3 deletes out of 4 total = 75%, threshold 80% → should pass
+    const cs = makeChangeSet([
+      ...Array.from({ length: 3 }, (_, i) => ({
+        kind: "delete" as const,
+        resourceType: "member",
+        key: `d${i}`,
+        before: {},
+      })),
+      { kind: "update", resourceType: "member", key: "u0", before: {}, after: {} },
+    ]);
+    expect(removalDeltaCap(cs, { maxFraction: 0.8 })).toBeNull();
+  });
+
+  it("returns null for an empty change set", () => {
+    expect(removalDeltaCap(makeChangeSet([]))).toBeNull();
+  });
+
+  it("does not count a resolved rename as a delete", () => {
+    // Before rename resolution: 1 delete + 1 create (with previously alias)
+    // After resolution: 1 update — delete fraction is 0%, should pass at any threshold
+    const cs = makeChangeSet([
+      {
+        kind: "delete",
+        resourceType: "member",
+        key: "old-name",
+        before: { login: "old-name", role: "admin" },
+      },
+      {
+        kind: "create",
+        resourceType: "member",
+        key: "new-name",
+        after: { login: "new-name", role: "admin", previously: "old-name" },
+      },
+    ]);
+    // With a very low threshold, should still pass because the delete is a rename
+    expect(removalDeltaCap(cs, { maxFraction: 0.01 })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adminFloor
+// ---------------------------------------------------------------------------
+
+describe("adminFloor", () => {
+  it("passes when enough admins remain", () => {
+    const cs = makeChangeSet([]);
+    const live = liveWithAdmins(["alice", "bob", "carol"]);
+    expect(adminFloor(cs, live)).toBeNull();
+  });
+
+  it("trips when a delete reduces admins below the floor", () => {
+    // Live: alice + bob (2 admins). Delete bob → 1 admin, below default floor of 2.
+    const cs = makeChangeSet([
+      { kind: "delete", resourceType: "member", key: "bob", before: { login: "bob", role: "admin" } },
+    ]);
+    const live = liveWithAdmins(["alice", "bob"]);
+    const result = adminFloor(cs, live);
+    expect(result).not.toBeNull();
+    expect(result!.guardrail).toBe("adminFloor");
+    expect(result!.message).toMatch(/1 org admin/);
+  });
+
+  it("trips when a role change demotes the last admin", () => {
+    // Live: alice (admin). Update alice to member → 0 admins.
+    const cs = makeChangeSet([
+      {
+        kind: "update",
+        resourceType: "member",
+        key: "alice",
+        before: { login: "alice", role: "admin" },
+        after: { login: "alice", role: "member" },
+        fields: [{ field: "role", before: "admin", after: "member" }],
+      },
+    ]);
+    const live = liveWithAdmins(["alice"]);
+    const result = adminFloor(cs, live);
+    expect(result).not.toBeNull();
+    expect(result!.guardrail).toBe("adminFloor");
+  });
+
+  it("passes when a new admin is added to compensate", () => {
+    // Live: alice (admin). Delete alice, create carol as admin → still 1 admin.
+    // Default min=2, but with min=1 it should pass.
+    const cs = makeChangeSet([
+      { kind: "delete", resourceType: "member", key: "alice", before: { login: "alice", role: "admin" } },
+      { kind: "create", resourceType: "member", key: "carol", after: { login: "carol", role: "admin" } },
+    ]);
+    const live = liveWithAdmins(["alice"]);
+    expect(adminFloor(cs, live, { min: 1 })).toBeNull();
+  });
+
+  it("respects a custom min", () => {
+    // Live: 5 admins. Delete 4. 1 remains. min=1 → pass.
+    const logins = ["a", "b", "c", "d", "e"];
+    const cs = makeChangeSet(
+      logins.slice(0, 4).map((l) => ({
+        kind: "delete" as const,
+        resourceType: "member",
+        key: l,
+        before: { login: l, role: "admin" },
+      })),
+    );
+    const live = liveWithAdmins(logins);
+    expect(adminFloor(cs, live, { min: 1 })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requiredAdmins
+// ---------------------------------------------------------------------------
+
+describe("requiredAdmins", () => {
+  it("passes when all required admins remain", () => {
+    const cs = makeChangeSet([]);
+    const live = liveWithAdmins(["alice", "bob"]);
+    expect(requiredAdmins(cs, live, { logins: ["alice"] })).toBeNull();
+  });
+
+  it("trips when a required admin is deleted", () => {
+    const cs = makeChangeSet([
+      { kind: "delete", resourceType: "member", key: "alice", before: { login: "alice", role: "admin" } },
+    ]);
+    const live = liveWithAdmins(["alice", "bob"]);
+    const result = requiredAdmins(cs, live, { logins: ["alice"] });
+    expect(result).not.toBeNull();
+    expect(result!.guardrail).toBe("requiredAdmins");
+    expect(result!.message).toMatch(/alice/);
+  });
+
+  it("trips when a required admin is demoted to member", () => {
+    const cs = makeChangeSet([
+      {
+        kind: "update",
+        resourceType: "member",
+        key: "alice",
+        before: { login: "alice", role: "admin" },
+        after: { login: "alice", role: "member" },
+        fields: [{ field: "role", before: "admin", after: "member" }],
+      },
+    ]);
+    const live = liveWithAdmins(["alice", "bob"]);
+    const result = requiredAdmins(cs, live, { logins: ["alice"] });
+    expect(result).not.toBeNull();
+    expect(result!.guardrail).toBe("requiredAdmins");
+  });
+
+  it("passes with an empty logins list", () => {
+    const cs = makeChangeSet([
+      { kind: "delete", resourceType: "member", key: "alice", before: { login: "alice", role: "admin" } },
+    ]);
+    const live = liveWithAdmins(["alice"]);
+    expect(requiredAdmins(cs, live, { logins: [] })).toBeNull();
+  });
+
+  it("reports all missing required admins in one diagnostic", () => {
+    const cs = makeChangeSet([
+      { kind: "delete", resourceType: "member", key: "alice", before: { login: "alice", role: "admin" } },
+      { kind: "delete", resourceType: "member", key: "bob", before: { login: "bob", role: "admin" } },
+    ]);
+    const live = liveWithAdmins(["alice", "bob", "carol"]);
+    const result = requiredAdmins(cs, live, { logins: ["alice", "bob"] });
+    expect(result).not.toBeNull();
+    expect(result!.message).toMatch(/alice/);
+    expect(result!.message).toMatch(/bob/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireSelf
+// ---------------------------------------------------------------------------
+
+describe("requireSelf", () => {
+  it("passes when self login remains as a member", () => {
+    const cs = makeChangeSet([]);
+    const live = liveWithMembers([{ login: "bot", role: "admin" }]);
+    expect(requireSelf(cs, live, { selfLogin: "bot" })).toBeNull();
+  });
+
+  it("trips when self login is deleted from the org", () => {
+    const cs = makeChangeSet([
+      { kind: "delete", resourceType: "member", key: "bot", before: { login: "bot", role: "admin" } },
+    ]);
+    const live = liveWithMembers([{ login: "bot", role: "admin" }]);
+    const result = requireSelf(cs, live, { selfLogin: "bot" });
+    expect(result).not.toBeNull();
+    expect(result!.guardrail).toBe("requireSelf");
+    expect(result!.message).toMatch(/bot/);
+  });
+
+  it("passes when self login is updated (role change but not removed)", () => {
+    const cs = makeChangeSet([
+      {
+        kind: "update",
+        resourceType: "member",
+        key: "bot",
+        before: { login: "bot", role: "admin" },
+        after: { login: "bot", role: "member" },
+        fields: [{ field: "role", before: "admin", after: "member" }],
+      },
+    ]);
+    const live = liveWithMembers([{ login: "bot", role: "admin" }]);
+    // requireSelf only checks org membership, not role
+    expect(requireSelf(cs, live, { selfLogin: "bot" })).toBeNull();
+  });
+
+  it("trips when self does not exist in live and a delete is added", () => {
+    // Edge case: self not in live at all, and a create+delete pair removes it
+    const cs = makeChangeSet([
+      { kind: "create", resourceType: "member", key: "bot", after: { login: "bot", role: "admin" } },
+      { kind: "delete", resourceType: "member", key: "bot", before: { login: "bot", role: "admin" } },
+    ]);
+    const live = emptyLive();
+    // Two entries for "bot": create then delete. Net result: deleted.
+    // Our implementation processes entries in order, so role ends up null.
+    const result = requireSelf(cs, live, { selfLogin: "bot" });
+    expect(result).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runGuardrails — aggregate
+// ---------------------------------------------------------------------------
+
+describe("runGuardrails", () => {
+  it("returns ok when no guardrails trip", () => {
+    const cs = makeChangeSet([]);
+    const live = liveWithAdmins(["alice", "bob"]);
+    const result = runGuardrails(cs, live, {
+      requireSelf: { selfLogin: "alice" },
+      requiredAdmins: { logins: ["alice"] },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("aggregates all tripped guardrails in one result", () => {
+    // Mass deletion (trips cap) + wipes self (trips requireSelf)
+    const entries = Array.from({ length: 10 }, (_, i) => ({
+      kind: "delete" as const,
+      resourceType: "member",
+      key: `user${i}`,
+      before: { login: `user${i}`, role: "member" },
+    }));
+    // Also delete the self-login
+    entries.push({
+      kind: "delete" as const,
+      resourceType: "member",
+      key: "bot",
+      before: { login: "bot", role: "admin" },
+    });
+    const cs = makeChangeSet(entries);
+    const live: LiveOrgState = {
+      members: [
+        ...Array.from({ length: 10 }, (_, i) => ({ login: `user${i}`, role: "member" as const })),
+        { login: "bot", role: "admin" as const },
+      ],
+    };
+
+    const result = runGuardrails(cs, live, {
+      requireSelf: { selfLogin: "bot" },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const guardrailNames = result.diagnostics.map((d) => d.guardrail);
+      // Should trip at least removalDeltaCap and requireSelf
+      expect(guardrailNames).toContain("removalDeltaCap");
+      expect(guardrailNames).toContain("requireSelf");
+    }
+  });
+
+  it("runs with no config (only default-threshold guardrails)", () => {
+    const cs = makeChangeSet([]);
+    const live = liveWithAdmins(["alice", "bob"]);
+    const result = runGuardrails(cs, live);
+    expect(result.ok).toBe(true);
+  });
+
+  it("resolves renames before running guardrails", () => {
+    // Rename old-alice → alice. Without resolution, this looks like 1 delete
+    // out of 1 entry = 100%, which would trip the cap.
+    const cs = makeChangeSet([
+      {
+        kind: "delete",
+        resourceType: "member",
+        key: "old-alice",
+        before: { login: "old-alice", role: "admin" },
+      },
+      {
+        kind: "create",
+        resourceType: "member",
+        key: "alice",
+        after: { login: "alice", role: "admin", previously: "old-alice" },
+      },
+    ]);
+    const live = liveWithAdmins(["old-alice", "bob"]);
+    // maxFraction 0.01 would trip if the rename were counted as a delete
+    const result = runGuardrails(cs, live, {
+      removalDeltaCap: { maxFraction: 0.01 },
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/lexicons/github-org/src/reconcile/guardrails.test.ts
+++ b/lexicons/github-org/src/reconcile/guardrails.test.ts
@@ -156,6 +156,29 @@ describe("removalDeltaCap", () => {
     expect(removalDeltaCap(makeChangeSet([]))).toBeNull();
   });
 
+  it("trips when deletes are diluted by many creates", () => {
+    // 5 deletes + 100 creates. If creates were in the denominator, the fraction
+    // would be 5/105 ≈ 4.7% and pass a 25% cap. Excluding creates, the only
+    // pre-existing entries are the 5 deletes → 100% → must TRIP.
+    const cs = makeChangeSet([
+      ...Array.from({ length: 5 }, (_, i) => ({
+        kind: "delete" as const,
+        resourceType: "member",
+        key: `d${i}`,
+        before: { login: `d${i}`, role: "member" },
+      })),
+      ...Array.from({ length: 100 }, (_, i) => ({
+        kind: "create" as const,
+        resourceType: "member",
+        key: `c${i}`,
+        after: { login: `c${i}`, role: "member" },
+      })),
+    ]);
+    const result = removalDeltaCap(cs);
+    expect(result).not.toBeNull();
+    expect(result!.guardrail).toBe("removalDeltaCap");
+  });
+
   it("does not count a resolved rename as a delete", () => {
     // Before rename resolution: 1 delete + 1 create (with previously alias)
     // After resolution: 1 update — delete fraction is 0%, should pass at any threshold
@@ -230,6 +253,40 @@ describe("adminFloor", () => {
     expect(adminFloor(cs, live, { min: 1 })).toBeNull();
   });
 
+  it("trips when a rename removes the only other admin (ghost fix)", () => {
+    // Live: alice + bob (2 admins). Rename bob → bob-new. The renamed admin must
+    // not double-count: surviving admins are alice + bob-new = 2... but we also
+    // delete alice, leaving only bob-new. Without the ghost fix, bob would also
+    // linger as a surviving admin, masking the drop below the floor.
+    const cs = makeChangeSet([
+      {
+        kind: "delete",
+        resourceType: "member",
+        key: "alice",
+        before: { login: "alice", role: "admin" },
+      },
+      {
+        kind: "delete",
+        resourceType: "member",
+        key: "bob",
+        before: { login: "bob", role: "admin" },
+      },
+      {
+        kind: "create",
+        resourceType: "member",
+        key: "bob-new",
+        after: { login: "bob-new", role: "admin", previously: "bob" },
+      },
+    ]);
+    const live = liveWithAdmins(["alice", "bob"]);
+    // After resolution: delete alice, update bob→bob-new (admin). Surviving
+    // admins = { bob-new } = 1, below default floor of 2 → TRIP.
+    const result = adminFloor(cs, live);
+    expect(result).not.toBeNull();
+    expect(result!.guardrail).toBe("adminFloor");
+    expect(result!.message).toMatch(/1 org admin/);
+  });
+
   it("respects a custom min", () => {
     // Live: 5 admins. Delete 4. 1 remains. min=1 → pass.
     const logins = ["a", "b", "c", "d", "e"];
@@ -285,6 +342,31 @@ describe("requiredAdmins", () => {
     expect(result!.guardrail).toBe("requiredAdmins");
   });
 
+  it("trips when a required admin is renamed away (ghost fix)", () => {
+    // alice is required. Rename alice → alice-new. The required login "alice" no
+    // longer survives. Without the ghost fix, alice would linger as a surviving
+    // admin and this would fail-open.
+    const cs = makeChangeSet([
+      {
+        kind: "delete",
+        resourceType: "member",
+        key: "alice",
+        before: { login: "alice", role: "admin" },
+      },
+      {
+        kind: "create",
+        resourceType: "member",
+        key: "alice-new",
+        after: { login: "alice-new", role: "admin", previously: "alice" },
+      },
+    ]);
+    const live = liveWithAdmins(["alice", "bob"]);
+    const result = requiredAdmins(cs, live, { logins: ["alice"] });
+    expect(result).not.toBeNull();
+    expect(result!.guardrail).toBe("requiredAdmins");
+    expect(result!.message).toMatch(/alice/);
+  });
+
   it("passes with an empty logins list", () => {
     const cs = makeChangeSet([
       { kind: "delete", resourceType: "member", key: "alice", before: { login: "alice", role: "admin" } },
@@ -328,7 +410,7 @@ describe("requireSelf", () => {
     expect(result!.message).toMatch(/bot/);
   });
 
-  it("passes when self login is updated (role change but not removed)", () => {
+  it("trips when self login is demoted out of admin", () => {
     const cs = makeChangeSet([
       {
         kind: "update",
@@ -340,8 +422,10 @@ describe("requireSelf", () => {
       },
     ]);
     const live = liveWithMembers([{ login: "bot", role: "admin" }]);
-    // requireSelf only checks org membership, not role
-    expect(requireSelf(cs, live, { selfLogin: "bot" })).toBeNull();
+    // requireSelf refuses membership loss AND admin demotion
+    const result = requireSelf(cs, live, { selfLogin: "bot" });
+    expect(result).not.toBeNull();
+    expect(result!.guardrail).toBe("requireSelf");
   });
 
   it("trips when self does not exist in live and a delete is added", () => {
@@ -406,6 +490,39 @@ describe("runGuardrails", () => {
       // Should trip at least removalDeltaCap and requireSelf
       expect(guardrailNames).toContain("removalDeltaCap");
       expect(guardrailNames).toContain("requireSelf");
+    }
+  });
+
+  it("reports an admin-floor trip caused by a rename plus a delete (ghost fix)", () => {
+    // Live: alice + bob (2 admins). Rename bob → bob-new and delete alice.
+    // Surviving admins = { bob-new } = 1, below the default floor of 2.
+    // The ghost fix ensures bob is not double-counted, so the trip is reported.
+    const cs = makeChangeSet([
+      {
+        kind: "delete",
+        resourceType: "member",
+        key: "alice",
+        before: { login: "alice", role: "admin" },
+      },
+      {
+        kind: "delete",
+        resourceType: "member",
+        key: "bob",
+        before: { login: "bob", role: "admin" },
+      },
+      {
+        kind: "create",
+        resourceType: "member",
+        key: "bob-new",
+        after: { login: "bob-new", role: "admin", previously: "bob" },
+      },
+    ]);
+    const live = liveWithAdmins(["alice", "bob"]);
+    const result = runGuardrails(cs, live);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const names = result.diagnostics.map((d) => d.guardrail);
+      expect(names).toContain("adminFloor");
     }
   });
 

--- a/lexicons/github-org/src/reconcile/guardrails.ts
+++ b/lexicons/github-org/src/reconcile/guardrails.ts
@@ -1,0 +1,360 @@
+/**
+ * Reconcile guardrails.
+ *
+ * Pure functions that inspect a computed ChangeSet and reject dangerous applies
+ * before any mutation. Run between diff and apply; if any trips, the apply is
+ * refused with a structured result.
+ *
+ * None of these functions throw. Every check returns structured diagnostics.
+ *
+ * ## Rename-without-loss
+ * A member or resource may carry a `previously` alias field in the desired
+ * config. When a delete+create pair is found where the created entry's
+ * `previously` matches the deleted entry's key, the pair is treated as a
+ * rename (update) rather than a mass-deletion signal.
+ *
+ * ## Configurable thresholds (defaults)
+ * - `removalDeltaCap.maxFraction` — 0.25 (25 % of managed entries)
+ * - `adminFloor.min`              — 2 (at least 2 admins must remain)
+ */
+
+import type { ChangeSet, ChangeSetEntry, LiveMemberConfig, LiveOrgState } from "./diff.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A single tripped guardrail with a human-readable message. */
+export interface GuardrailDiagnostic {
+  /** Short identifier for the guardrail, e.g. "removalDeltaCap". */
+  guardrail: string;
+  /** Clear, actionable description of why the apply was refused. */
+  message: string;
+}
+
+/** Aggregated result from `runGuardrails`. */
+export type GuardrailResult =
+  | { ok: true }
+  | { ok: false; diagnostics: GuardrailDiagnostic[] };
+
+/** Config for `removalDeltaCap`. */
+export interface RemovalDeltaCapOptions {
+  /**
+   * Maximum fraction of managed entries that may be deleted in a single apply.
+   * Must be in (0, 1]. Default: 0.25.
+   */
+  maxFraction?: number;
+}
+
+/** Config for `adminFloor`. */
+export interface AdminFloorOptions {
+  /**
+   * Minimum number of org admins that must remain after the apply.
+   * Default: 2.
+   */
+  min?: number;
+}
+
+/** Config for `requiredAdmins`. */
+export interface RequiredAdminsOptions {
+  /**
+   * Logins that must remain as admins after the apply.
+   */
+  logins: string[];
+}
+
+/** Config for `requireSelf`. */
+export interface RequireSelfOptions {
+  /**
+   * Login of the managing identity. The apply is refused if this user would
+   * lose org membership or admin role.
+   */
+  selfLogin: string;
+}
+
+/** Full guardrail config passed to `runGuardrails`. */
+export interface GuardrailConfig {
+  removalDeltaCap?: RemovalDeltaCapOptions;
+  adminFloor?: AdminFloorOptions;
+  requiredAdmins?: RequiredAdminsOptions;
+  requireSelf?: RequireSelfOptions;
+}
+
+// ---------------------------------------------------------------------------
+// Rename-without-loss helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve rename aliases before running guardrails.
+ *
+ * Desired config entries may include a `previously` field indicating a former
+ * key. When the ChangeSet contains a delete whose key matches `previously` on
+ * a create entry, the pair is collapsed into an update and removed from the
+ * effective delete list.
+ *
+ * Returns a new ChangeSet with renames resolved as updates.
+ */
+export function resolveRenames(changeSet: ChangeSet): ChangeSet {
+  // Build a map of delete keys
+  const deleteEntries = new Map<string, ChangeSetEntry>();
+  for (const e of changeSet.entries) {
+    if (e.kind === "delete") deleteEntries.set(e.key, e);
+  }
+
+  // Find creates that carry a `previously` alias
+  const resolvedDeletes = new Set<string>();
+  const resolvedCreates = new Set<string>();
+  const syntheticUpdates: ChangeSetEntry[] = [];
+
+  for (const e of changeSet.entries) {
+    if (e.kind !== "create") continue;
+    const after = e.after as Record<string, unknown> | undefined;
+    if (!after) continue;
+    const previously = after["previously"];
+    if (typeof previously !== "string") continue;
+
+    const deleted = deleteEntries.get(previously);
+    if (!deleted) continue;
+
+    // Collapse delete(previously) + create(key) → update
+    resolvedDeletes.add(previously);
+    resolvedCreates.add(e.key);
+    syntheticUpdates.push({
+      kind: "update",
+      resourceType: e.resourceType,
+      key: e.key,
+      before: deleted.before,
+      after: e.after,
+      fields: [{ field: "key", before: previously, after: e.key }],
+    });
+  }
+
+  if (resolvedDeletes.size === 0) return changeSet;
+
+  const filteredEntries = changeSet.entries.filter(
+    (e) =>
+      !(e.kind === "delete" && resolvedDeletes.has(e.key)) &&
+      !(e.kind === "create" && resolvedCreates.has(e.key)),
+  );
+
+  return {
+    org: changeSet.org,
+    entries: [...filteredEntries, ...syntheticUpdates],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Individual guardrails
+// ---------------------------------------------------------------------------
+
+/**
+ * Refuse if deletes exceed `maxFraction` of the total managed entries.
+ *
+ * Managed entries = total entries in the ChangeSet after rename resolution.
+ * This guards against a typo wiping the entire config in one apply.
+ *
+ * Default `maxFraction`: 0.25 (25 %).
+ */
+export function removalDeltaCap(
+  changeSet: ChangeSet,
+  opts: RemovalDeltaCapOptions = {},
+): GuardrailDiagnostic | null {
+  const maxFraction = opts.maxFraction ?? 0.25;
+  const resolved = resolveRenames(changeSet);
+
+  const total = resolved.entries.length;
+  if (total === 0) return null;
+
+  const deletes = resolved.entries.filter((e) => e.kind === "delete").length;
+  const fraction = deletes / total;
+
+  if (fraction > maxFraction) {
+    return {
+      guardrail: "removalDeltaCap",
+      message:
+        `${deletes} of ${total} managed entries (${Math.round(fraction * 100)}%) would be deleted, ` +
+        `exceeding the ${Math.round(maxFraction * 100)}% threshold. ` +
+        `Check for typos in config or raise maxFraction to proceed.`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Refuse if the apply would leave fewer than `min` org admins.
+ *
+ * Computes the post-apply admin count from the live snapshot and the ChangeSet.
+ *
+ * Default `min`: 2.
+ */
+export function adminFloor(
+  changeSet: ChangeSet,
+  live: LiveOrgState,
+  opts: AdminFloorOptions = {},
+): GuardrailDiagnostic | null {
+  const min = opts.min ?? 2;
+  const liveMembers = live.members ?? [];
+
+  // Build effective post-apply admin set
+  const postApplyAdmins = computePostApplyAdmins(changeSet, liveMembers);
+  const count = postApplyAdmins.size;
+
+  if (count < min) {
+    return {
+      guardrail: "adminFloor",
+      message:
+        `Apply would leave ${count} org admin(s), below the required minimum of ${min}. ` +
+        `Ensure at least ${min} admin(s) remain in the desired config.`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Refuse if any of the required admin logins would be removed or demoted.
+ */
+export function requiredAdmins(
+  changeSet: ChangeSet,
+  live: LiveOrgState,
+  opts: RequiredAdminsOptions,
+): GuardrailDiagnostic | null {
+  if (opts.logins.length === 0) return null;
+
+  const liveMembers = live.members ?? [];
+  const postApplyAdmins = computePostApplyAdmins(changeSet, liveMembers);
+
+  const missing = opts.logins.filter((login) => !postApplyAdmins.has(login));
+
+  if (missing.length > 0) {
+    return {
+      guardrail: "requiredAdmins",
+      message:
+        `The following required admin(s) would be removed or demoted: ${missing.join(", ")}. ` +
+        `These logins must remain as org admins after the apply.`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Refuse if the managing identity (`selfLogin`) would lose org access.
+ *
+ * Trips when the ChangeSet would delete or demote the self login from any org
+ * member role. The managing bot must not lock itself out.
+ */
+export function requireSelf(
+  changeSet: ChangeSet,
+  live: LiveOrgState,
+  opts: RequireSelfOptions,
+): GuardrailDiagnostic | null {
+  const { selfLogin } = opts;
+  const liveMembers = live.members ?? [];
+
+  // Compute post-apply membership (any role) for selfLogin
+  const liveByLogin = new Map(liveMembers.map((m) => [m.login, m]));
+  let role: string | null = liveByLogin.get(selfLogin)?.role ?? null;
+
+  for (const e of changeSet.entries) {
+    if (e.resourceType !== "member" || e.key !== selfLogin) continue;
+    if (e.kind === "delete") {
+      role = null;
+    } else if (e.kind === "create" || e.kind === "update") {
+      const after = e.after as { role?: string } | undefined;
+      role = after?.role ?? role;
+    }
+  }
+
+  if (role === null) {
+    return {
+      guardrail: "requireSelf",
+      message:
+        `The managing identity "${selfLogin}" would be removed from the org. ` +
+        `Self-lockout is not allowed. Add "${selfLogin}" back to the desired config.`,
+    };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run all configured guardrails against the ChangeSet and live snapshot.
+ *
+ * Returns `{ ok: true }` when no guardrail trips, or
+ * `{ ok: false, diagnostics }` with every tripped guardrail's message.
+ *
+ * Rename aliases are resolved before guardrails run so that a rename is not
+ * counted as a deletion.
+ */
+export function runGuardrails(
+  changeSet: ChangeSet,
+  live: LiveOrgState,
+  config: GuardrailConfig = {},
+): GuardrailResult {
+  // Resolve renames once; individual checks get the resolved set
+  const resolved = resolveRenames(changeSet);
+
+  const diagnostics: GuardrailDiagnostic[] = [];
+
+  const cap = removalDeltaCap(resolved, config.removalDeltaCap);
+  if (cap) diagnostics.push(cap);
+
+  const floor = adminFloor(resolved, live, config.adminFloor);
+  if (floor) diagnostics.push(floor);
+
+  if (config.requiredAdmins) {
+    const req = requiredAdmins(resolved, live, config.requiredAdmins);
+    if (req) diagnostics.push(req);
+  }
+
+  if (config.requireSelf) {
+    const self = requireSelf(resolved, live, config.requireSelf);
+    if (self) diagnostics.push(self);
+  }
+
+  if (diagnostics.length > 0) return { ok: false, diagnostics };
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the set of admin logins that would exist after applying the ChangeSet.
+ */
+function computePostApplyAdmins(
+  changeSet: ChangeSet,
+  liveMembers: LiveMemberConfig[],
+): Set<string> {
+  const liveAdmins = new Map<string, string>(
+    liveMembers.filter((m) => m.role === "admin").map((m) => [m.login, m.role]),
+  );
+
+  const result = new Set(liveAdmins.keys());
+
+  for (const e of changeSet.entries) {
+    if (e.resourceType !== "member") continue;
+
+    if (e.kind === "delete") {
+      result.delete(e.key);
+    } else if (e.kind === "create" || e.kind === "update") {
+      const after = e.after as { login?: string; role?: string } | undefined;
+      const login = after?.login ?? e.key;
+      if (after?.role === "admin") {
+        result.add(login);
+      } else {
+        // create/update to member role → not an admin
+        result.delete(login);
+      }
+    }
+  }
+
+  return result;
+}

--- a/lexicons/github-org/src/reconcile/guardrails.ts
+++ b/lexicons/github-org/src/reconcile/guardrails.ts
@@ -148,9 +148,14 @@ export function resolveRenames(changeSet: ChangeSet): ChangeSet {
 // ---------------------------------------------------------------------------
 
 /**
- * Refuse if deletes exceed `maxFraction` of the total managed entries.
+ * Refuse if deletes exceed `maxFraction` of the pre-existing managed entries.
  *
- * Managed entries = total entries in the ChangeSet after rename resolution.
+ * The denominator is the count of pre-existing entries (deletes + updates),
+ * deliberately EXCLUDING creates. Including creates would let a flood of new
+ * entries dilute the delete fraction (e.g. 5 deletes + 100 creates ≈ 4.7%,
+ * which would sneak under a 25% cap and defeat a mass-deletion typo). Measuring
+ * deletes against only what already exists keeps the cap meaningful.
+ *
  * This guards against a typo wiping the entire config in one apply.
  *
  * Default `maxFraction`: 0.25 (25 %).
@@ -162,7 +167,9 @@ export function removalDeltaCap(
   const maxFraction = opts.maxFraction ?? 0.25;
   const resolved = resolveRenames(changeSet);
 
-  const total = resolved.entries.length;
+  // Pre-existing entries only (deletes + updates); creates excluded. If nothing
+  // pre-exists, no deletes are possible → pass (also avoids divide-by-zero/NaN).
+  const total = resolved.entries.filter((e) => e.kind !== "create").length;
   if (total === 0) return null;
 
   const deletes = resolved.entries.filter((e) => e.kind === "delete").length;
@@ -276,6 +283,17 @@ export function requireSelf(
     };
   }
 
+  // Stricter than membership alone: also refuse if self would be demoted out of
+  // admin. The managing bot must keep admin access, not merely org membership.
+  if (role !== "admin") {
+    return {
+      guardrail: "requireSelf",
+      message:
+        `The managing identity "${selfLogin}" would be demoted from admin to "${role}". ` +
+        `Self-lockout is not allowed. Keep "${selfLogin}" as an org admin in the desired config.`,
+    };
+  }
+
   return null;
 }
 
@@ -347,6 +365,17 @@ function computePostApplyAdmins(
     } else if (e.kind === "create" || e.kind === "update") {
       const after = e.after as { login?: string; role?: string } | undefined;
       const login = after?.login ?? e.key;
+
+      // A rename is collapsed into an update whose resulting login differs from
+      // the prior login (carried in `before`/`key`). Drop the prior login so a
+      // renamed-away admin no longer counts as surviving — otherwise the ghost
+      // would keep adminFloor/requiredAdmins fail-open.
+      if (e.kind === "update") {
+        const before = e.before as { login?: string } | undefined;
+        const priorLogin = before?.login ?? e.key;
+        if (priorLogin !== login) result.delete(priorLogin);
+      }
+
       if (after?.role === "admin") {
         result.add(login);
       } else {


### PR DESCRIPTION
Closes #451.

## Summary

- `resolveRenames` — collapses delete+create pairs where the create carries a `previously` alias into a single update, preventing renames from triggering deletion guardrails
- `removalDeltaCap(changeSet, opts)` — trips if deletes exceed a configured fraction of total managed entries (default 25%); runs after rename resolution
- `adminFloor(changeSet, live, opts)` — trips if the post-apply admin count would drop below a minimum (default 2); accounts for creates, updates, and deletes in the ChangeSet
- `requiredAdmins(changeSet, live, opts)` — trips if any named admin login would be removed or demoted
- `requireSelf(changeSet, live, opts)` — trips if the managing identity would lose org membership (self-lockout guard)
- `runGuardrails(changeSet, live, config)` — aggregates all checks; returns `{ ok: true }` or `{ ok: false, diagnostics[] }` with every tripped guardrail; never throws

All thresholds are configurable with sane defaults documented in JSDoc. All functions are pure over ChangeSet + live snapshot data.

## Test plan

- [ ] `npx tsc --noEmit -p lexicons/github-org/tsconfig.json` — clean (no output)
- [ ] `npx vitest run lexicons/github-org` — 97 tests pass (26 new guardrail tests, each guardrail has trip + pass cases)