### PR TITLE
feat(github-org): reconcile runner

### DIFF
--- a/lexicons/github-org/src/index.ts
+++ b/lexicons/github-org/src/index.ts
@@ -57,3 +57,14 @@ export {
   requireSelf,
   runGuardrails,
 } from "./reconcile/guardrails.js";
+
+// Reconcile: runner (orchestrator)
+export type {
+  Cycle,
+  RateBudget,
+  CycleResult,
+  DeferredWork,
+  ReconcileResult,
+  RunReconcileOptions,
+} from "./reconcile/runner.js";
+export { runReconcile, BudgetExhaustedError } from "./reconcile/runner.js";

--- a/lexicons/github-org/src/reconcile/runner.test.ts
+++ b/lexicons/github-org/src/reconcile/runner.test.ts
@@ -314,6 +314,41 @@ describe("runReconcile — rate budget", () => {
     expect(result.cycles).toHaveLength(0);
   });
 
+  it("records a cycle as errored and continues when fetchLive throws a generic error", async () => {
+    const client = makeMockClient();
+    // First cycle's fetchLive throws a non-budget error (e.g. a 403). It must
+    // be recorded as errored, and the second cycle must still run.
+    const boomCycle = makeFakeCycle({
+      name: "boom",
+      onFetch: () => {
+        throw new Error("403 Forbidden");
+      },
+    });
+    const okCycle = makeFakeCycle({
+      name: "ok",
+      desired: { members: [{ login: "alice", role: "member" }] },
+    });
+
+    const result = await runReconcile({
+      config: configWithMembers([]),
+      client,
+      cycles: [boomCycle, okCycle],
+    });
+
+    // The run resolves rather than rejecting.
+    expect(result.completed).toBe(false);
+    // The failing cycle is captured as errored, not as a normal cycle result.
+    expect(result.errored).toHaveLength(1);
+    expect(result.errored[0]!.name).toBe("boom");
+    expect(result.errored[0]!.org).toBe("test-org");
+    expect(result.errored[0]!.stage).toBe("fetchLive");
+    expect(result.errored[0]!.error).toBe("403 Forbidden");
+    // The other cycle still ran to completion.
+    expect(okCycle.fetchCount).toBe(1);
+    expect(result.cycles.map((c) => c.name)).toEqual(["ok"]);
+    expect(result.cycles[0]!.counts.create).toBe(1);
+  });
+
   it("defers unapplied entries when budget runs out mid-apply", async () => {
     const client = makeMockClient();
     // Three safe creates; budget allows exactly one apply.

--- a/lexicons/github-org/src/reconcile/runner.test.ts
+++ b/lexicons/github-org/src/reconcile/runner.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect } from "vitest";
+import { runReconcile, BudgetExhaustedError } from "./runner.js";
+import type { Cycle, RateBudget } from "./runner.js";
+import type { AppClient } from "../auth/app-client.js";
+import type { ChangeSetEntry, LiveOrgState } from "./diff.js";
+import type { GovernanceConfig, OrgConfig } from "../config/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock client — records every request; the runner itself never calls request,
+// only cycles do. A bare mock proves the runner performs zero network I/O on
+// its own.
+// ---------------------------------------------------------------------------
+
+interface MockClient extends AppClient {
+  calls: Array<{ method: string; path: string; body?: unknown }>;
+}
+
+function makeMockClient(): MockClient {
+  const calls: MockClient["calls"] = [];
+  return {
+    calls,
+    async request<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
+      calls.push({ method, path, body });
+      return undefined as T;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fake cycle factory — fully synthetic, no network. `live` and `desired` are
+// injected so each test controls the diff. `onApply` records applied entries.
+// ---------------------------------------------------------------------------
+
+interface FakeCycleOptions {
+  name?: string;
+  live?: LiveOrgState;
+  desired?: OrgConfig;
+  /** Hook invoked inside fetchLive (e.g. to consume budget). */
+  onFetch?: (budget: RateBudget) => void;
+  /** Hook invoked inside apply (e.g. to consume budget or throw). */
+  onApply?: (entry: ChangeSetEntry, budget: RateBudget) => void;
+}
+
+function makeFakeCycle(opts: FakeCycleOptions = {}): Cycle & {
+  fetchCount: number;
+  applied: ChangeSetEntry[];
+} {
+  const state = {
+    fetchCount: 0,
+    applied: [] as ChangeSetEntry[],
+    name: opts.name ?? "fake",
+    async fetchLive(_client: AppClient, _scope: unknown, budget: RateBudget): Promise<LiveOrgState> {
+      state.fetchCount++;
+      opts.onFetch?.(budget);
+      return opts.live ?? {};
+    },
+    buildDesired(config: OrgConfig): OrgConfig {
+      // Default: use the org config as-is unless an override is provided.
+      return opts.desired ?? config;
+    },
+    async apply(_client: AppClient, entry: ChangeSetEntry, _scope: unknown, budget: RateBudget): Promise<void> {
+      opts.onApply?.(entry, budget);
+      state.applied.push(entry);
+    },
+  };
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
+
+function configWithMembers(
+  members: Array<{ login: string; role?: "admin" | "member" }>,
+): GovernanceConfig {
+  return { orgs: { "test-org": { members } } };
+}
+
+// ---------------------------------------------------------------------------
+// dry-run
+// ---------------------------------------------------------------------------
+
+describe("runReconcile — dry-run (default)", () => {
+  it("defaults to dry-run and performs zero mutations", async () => {
+    const client = makeMockClient();
+    // Desired adds 3 members that don't exist live → 3 creates.
+    const cycle = makeFakeCycle({
+      live: { members: [{ login: "keeper", role: "admin" }] },
+      desired: {
+        members: [
+          { login: "keeper", role: "admin" },
+          { login: "alice", role: "member" },
+          { login: "bob", role: "member" },
+        ],
+      },
+    });
+
+    const result = await runReconcile({
+      config: configWithMembers([{ login: "keeper", role: "admin" }]),
+      client,
+      cycles: [cycle],
+      // mode omitted → dry-run
+    });
+
+    expect(result.mode).toBe("dry-run");
+    expect(result.completed).toBe(true);
+    // No apply ever called.
+    expect(cycle.applied).toHaveLength(0);
+    expect(client.calls).toHaveLength(0);
+    // Plan still computed.
+    expect(result.cycles).toHaveLength(1);
+    expect(result.cycles[0]!.counts.create).toBe(2);
+    expect(result.cycles[0]!.applied).toHaveLength(0);
+    expect(result.cycles[0]!.plan).toContain("Plan for test-org");
+  });
+
+  it("explicit dry-run mode also mutates nothing", async () => {
+    const client = makeMockClient();
+    const cycle = makeFakeCycle({
+      desired: { members: [{ login: "alice", role: "member" }] },
+    });
+
+    const result = await runReconcile({
+      config: configWithMembers([]),
+      client,
+      cycles: [cycle],
+      mode: "dry-run",
+    });
+
+    expect(cycle.applied).toHaveLength(0);
+    expect(client.calls).toHaveLength(0);
+    expect(result.cycles[0]!.counts.create).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apply — guardrails pass
+// ---------------------------------------------------------------------------
+
+describe("runReconcile — apply", () => {
+  it("applies entries when guardrails pass", async () => {
+    const client = makeMockClient();
+    // Two safe creates (no deletes → removalDeltaCap passes; admins preserved).
+    const cycle = makeFakeCycle({
+      live: { members: [{ login: "admin1", role: "admin" }, { login: "admin2", role: "admin" }] },
+      desired: {
+        members: [
+          { login: "admin1", role: "admin" },
+          { login: "admin2", role: "admin" },
+          { login: "newbie", role: "member" },
+        ],
+      },
+    });
+
+    const result = await runReconcile({
+      config: configWithMembers([]),
+      client,
+      cycles: [cycle],
+      mode: "apply",
+    });
+
+    expect(result.mode).toBe("apply");
+    expect(result.completed).toBe(true);
+    expect(result.cycles[0]!.guardrailBlocked).toBe(false);
+    // The one create was applied.
+    expect(cycle.applied).toHaveLength(1);
+    expect(cycle.applied[0]!.key).toBe("newbie");
+    expect(result.cycles[0]!.applied).toHaveLength(1);
+    expect(result.cycles[0]!.failed).toHaveLength(0);
+  });
+
+  it("records failed entries without aborting the run", async () => {
+    const client = makeMockClient();
+    const cycle = makeFakeCycle({
+      live: { members: [{ login: "admin1", role: "admin" }, { login: "admin2", role: "admin" }] },
+      desired: {
+        members: [
+          { login: "admin1", role: "admin" },
+          { login: "admin2", role: "admin" },
+          { login: "boom", role: "member" },
+          { login: "ok", role: "member" },
+        ],
+      },
+      onApply: (entry) => {
+        if (entry.key === "boom") throw new Error("apply failed");
+      },
+    });
+
+    const result = await runReconcile({
+      config: configWithMembers([]),
+      client,
+      cycles: [cycle],
+      mode: "apply",
+    });
+
+    const cr = result.cycles[0]!;
+    expect(cr.applied.map((e) => e.key)).toEqual(["ok"]);
+    expect(cr.failed).toHaveLength(1);
+    expect(cr.failed[0]!.entry.key).toBe("boom");
+    expect(cr.failed[0]!.error).toBe("apply failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apply — guardrail-blocked
+// ---------------------------------------------------------------------------
+
+describe("runReconcile — guardrail-blocked apply", () => {
+  it("blocks apply when guardrails trip and override is not set", async () => {
+    const client = makeMockClient();
+    // Live has 2 admins; desired drops both to member → adminFloor trips.
+    const cycle = makeFakeCycle({
+      live: { members: [{ login: "admin1", role: "admin" }, { login: "admin2", role: "admin" }] },
+      desired: {
+        members: [
+          { login: "admin1", role: "member" },
+          { login: "admin2", role: "member" },
+        ],
+      },
+    });
+
+    const result = await runReconcile({
+      config: configWithMembers([]),
+      client,
+      cycles: [cycle],
+      mode: "apply",
+    });
+
+    const cr = result.cycles[0]!;
+    expect(cr.guardrails.ok).toBe(false);
+    expect(cr.guardrailBlocked).toBe(true);
+    // Nothing applied.
+    expect(cycle.applied).toHaveLength(0);
+    expect(cr.applied).toHaveLength(0);
+  });
+
+  it("applies anyway when allowGuardrailOverride is set", async () => {
+    const client = makeMockClient();
+    const cycle = makeFakeCycle({
+      live: { members: [{ login: "admin1", role: "admin" }, { login: "admin2", role: "admin" }] },
+      desired: {
+        members: [
+          { login: "admin1", role: "member" },
+          { login: "admin2", role: "member" },
+        ],
+      },
+    });
+
+    const result = await runReconcile({
+      config: configWithMembers([]),
+      client,
+      cycles: [cycle],
+      mode: "apply",
+      allowGuardrailOverride: true,
+    });
+
+    const cr = result.cycles[0]!;
+    expect(cr.guardrails.ok).toBe(false);
+    expect(cr.guardrailBlocked).toBe(false);
+    // Both demotions applied despite the tripped guardrail.
+    expect(cr.applied).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// budget exhaustion
+// ---------------------------------------------------------------------------
+
+describe("runReconcile — rate budget", () => {
+  it("reports deferred cycles when budget is exhausted before fetch", async () => {
+    const client = makeMockClient();
+    // Each fetch consumes the entire budget. With two cycles, the second is
+    // deferred because the budget is exhausted before it starts.
+    const cycleA = makeFakeCycle({
+      name: "cycle-a",
+      onFetch: (budget) => budget.use(1),
+    });
+    const cycleB = makeFakeCycle({ name: "cycle-b" });
+
+    const result = await runReconcile({
+      config: configWithMembers([]),
+      client,
+      cycles: [cycleA, cycleB],
+      requestBudget: 1,
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.budgetRemaining).toBe(0);
+    // cycle-a ran, cycle-b deferred.
+    expect(cycleA.fetchCount).toBe(1);
+    expect(cycleB.fetchCount).toBe(0);
+    expect(result.deferred.skippedCycles).toContain("cycle-b@test-org");
+    expect(result.cycles.map((c) => c.name)).toEqual(["cycle-a"]);
+  });
+
+  it("records a deferred cycle when fetchLive throws BudgetExhaustedError", async () => {
+    const client = makeMockClient();
+    const cycle = makeFakeCycle({
+      name: "greedy",
+      onFetch: () => {
+        throw new BudgetExhaustedError();
+      },
+    });
+
+    const result = await runReconcile({
+      config: configWithMembers([]),
+      client,
+      cycles: [cycle],
+      requestBudget: 5,
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.deferred.skippedCycles).toContain("greedy@test-org");
+    expect(result.cycles).toHaveLength(0);
+  });
+
+  it("defers unapplied entries when budget runs out mid-apply", async () => {
+    const client = makeMockClient();
+    // Three safe creates; budget allows exactly one apply.
+    const cycle = makeFakeCycle({
+      live: { members: [{ login: "admin1", role: "admin" }, { login: "admin2", role: "admin" }] },
+      desired: {
+        members: [
+          { login: "admin1", role: "admin" },
+          { login: "admin2", role: "admin" },
+          { login: "a", role: "member" },
+          { login: "b", role: "member" },
+          { login: "c", role: "member" },
+        ],
+      },
+      onApply: (_entry, budget) => budget.use(1),
+    });
+
+    const result = await runReconcile({
+      config: configWithMembers([]),
+      client,
+      cycles: [cycle],
+      mode: "apply",
+      requestBudget: 1,
+    });
+
+    const cr = result.cycles[0]!;
+    expect(cr.applied).toHaveLength(1);
+    // The remaining two creates are deferred, not silently dropped.
+    expect(result.deferred.skippedEntries).toHaveLength(2);
+    expect(result.deferred.skippedEntries.map((s) => s.cycleName)).toEqual(["fake", "fake"]);
+    expect(result.completed).toBe(false);
+  });
+
+  it("completes cleanly within budget", async () => {
+    const client = makeMockClient();
+    const cycle = makeFakeCycle({
+      desired: { members: [{ login: "alice", role: "member" }] },
+      onFetch: (budget) => budget.use(1),
+    });
+
+    const result = await runReconcile({
+      config: configWithMembers([]),
+      client,
+      cycles: [cycle],
+      requestBudget: 100,
+    });
+
+    expect(result.completed).toBe(true);
+    expect(result.deferred.skippedCycles).toHaveLength(0);
+    expect(result.deferred.skippedEntries).toHaveLength(0);
+    expect(result.budgetRemaining).toBe(99);
+  });
+});

--- a/lexicons/github-org/src/reconcile/runner.ts
+++ b/lexicons/github-org/src/reconcile/runner.ts
@@ -1,0 +1,368 @@
+/**
+ * Governance reconcile runner.
+ *
+ * Ties the primitives together into one reconcile run:
+ *   load config → fetch live → diff → guardrails → dry-run or apply
+ *
+ * Dry-run is the default. In dry-run mode, no mutations are performed; the
+ * computed ChangeSet is returned with a rendered summary. In apply mode, each
+ * ChangeSet entry is forwarded to the cycle's `apply` handler, but only when
+ * all guardrails pass (or `allowGuardrailOverride` is set).
+ *
+ * Rate budgeting: every API call (fetchLive + each apply) decrements a shared
+ * request counter. When the counter hits zero the run stops cleanly and
+ * records deferred cycles in the result. No silent truncation.
+ */
+
+import type { AppClient } from "../auth/app-client.js";
+import type { GovernanceConfig, OrgConfig } from "../config/types.js";
+import { diff, renderChangeSet } from "./diff.js";
+import type { ChangeSet, ChangeSetEntry, LiveOrgState, DiffOptions } from "./diff.js";
+import { runGuardrails } from "./guardrails.js";
+import type { GuardrailConfig, GuardrailResult } from "./guardrails.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A governance cycle: knows how to fetch live state for one resource domain
+ * (e.g. branch protection), build desired state from config, and apply a
+ * single ChangeSet entry back to GitHub.
+ *
+ * Concrete cycle implementations live in separate modules (#455 onwards).
+ * The runner is agnostic to what a cycle manages — it only drives the loop.
+ */
+export interface Cycle<TScope = unknown> {
+  /** Human-readable name, e.g. "branch-protection". Used in run output. */
+  name: string;
+
+  /**
+   * Fetch the live state for the given org + scope.
+   *
+   * Each GitHub API page call made inside this method MUST count against the
+   * shared rate budget: call `budget.use(n)` (where `n` is the number of
+   * requests consumed) and check `budget.exhausted` before paginating further.
+   * When the budget is exhausted mid-fetch a cycle may either return the
+   * partial state it has gathered or throw `BudgetExhaustedError`; either way
+   * the runner records the cycle as deferred so nothing is silently truncated.
+   */
+  fetchLive(client: AppClient, scope: TScope, budget: RateBudget): Promise<LiveOrgState>;
+
+  /**
+   * Build the desired state from the governance config + scope.
+   * Pure — must not perform any I/O.
+   */
+  buildDesired(config: OrgConfig, scope: TScope): OrgConfig;
+
+  /**
+   * Apply a single ChangeSet entry to GitHub.
+   *
+   * Called once per entry when mode is "apply" and guardrails pass.
+   * Each network call made inside `apply` MUST count against the budget via
+   * `budget.use(n)`.
+   */
+  apply(
+    client: AppClient,
+    entry: ChangeSetEntry,
+    scope: TScope,
+    budget: RateBudget,
+  ): Promise<void>;
+}
+
+/** Controls how a Cycle tracks its API usage against the shared budget. */
+export interface RateBudget {
+  /** Remaining request capacity for this run. */
+  readonly remaining: number;
+  /** True once `remaining` has reached zero. */
+  readonly exhausted: boolean;
+  /**
+   * Decrement the budget by `n` (default: 1).
+   * Throws `BudgetExhaustedError` if the budget has already been exhausted.
+   */
+  use(n?: number): void;
+}
+
+/** Thrown when a cycle or apply step attempts to use an exhausted budget. */
+export class BudgetExhaustedError extends Error {
+  constructor(message = "rate budget exhausted") {
+    super(message);
+    this.name = "BudgetExhaustedError";
+  }
+}
+
+/** Per-cycle outcome recorded in the run result. */
+export interface CycleResult {
+  /** Cycle name. */
+  name: string;
+  /** Org this result is for. */
+  org: string;
+  /** Number of entries per change kind in the ChangeSet. */
+  counts: { create: number; update: number; delete: number };
+  /** Guardrail outcome. */
+  guardrails: GuardrailResult;
+  /** Entries successfully applied (only populated in apply mode). */
+  applied: ChangeSetEntry[];
+  /** Entries that failed to apply with their error. */
+  failed: Array<{ entry: ChangeSetEntry; error: string }>;
+  /** Human-readable plan summary (always present). */
+  plan: string;
+  /** Whether this cycle was skipped because guardrails tripped and override was not set. */
+  guardrailBlocked: boolean;
+}
+
+/** Summary of work that could not be completed due to rate budget exhaustion. */
+export interface DeferredWork {
+  /**
+   * Cycles (by name) that were never started because the budget was exhausted
+   * before they could run.
+   */
+  skippedCycles: string[];
+  /**
+   * In apply mode: entries that were not applied because the budget was
+   * exhausted mid-cycle.
+   */
+  skippedEntries: Array<{ cycleName: string; entry: ChangeSetEntry }>;
+}
+
+/** Structured result from a single `runReconcile` call. */
+export interface ReconcileResult {
+  /** Run mode used. */
+  mode: "dry-run" | "apply";
+  /** Whether the full run completed (false when budget was exhausted early). */
+  completed: boolean;
+  /** Per-cycle outcomes (only for cycles that were started). */
+  cycles: CycleResult[];
+  /** Work deferred due to budget exhaustion (empty when `completed` is true). */
+  deferred: DeferredWork;
+  /** Remaining budget at the end of the run. */
+  budgetRemaining: number;
+}
+
+/** Options for `runReconcile`. */
+export interface RunReconcileOptions<TScope = unknown> {
+  /**
+   * Loaded governance config.
+   */
+  config: GovernanceConfig;
+
+  /**
+   * Authed GitHub App client (created by `createAppClient`).
+   */
+  client: AppClient;
+
+  /**
+   * Cycles to run. Each cycle is run against every org in `config.orgs`.
+   */
+  cycles: Cycle<TScope>[];
+
+  /**
+   * Scope forwarded to each cycle's `fetchLive`, `buildDesired`, and `apply`.
+   * Typically an org-level filter or pagination cursor.
+   * Defaults to `undefined` when omitted.
+   */
+  scope?: TScope;
+
+  /**
+   * Run mode. Defaults to "dry-run".
+   * - "dry-run": compute + report the change set, mutate nothing.
+   * - "apply": apply each entry after guardrails pass.
+   */
+  mode?: "dry-run" | "apply";
+
+  /**
+   * Guardrail configuration forwarded to `runGuardrails`.
+   */
+  guardrails?: GuardrailConfig;
+
+  /**
+   * Diff options forwarded to `diff()` (ownership predicate, etc.).
+   */
+  diffOptions?: DiffOptions;
+
+  /**
+   * When true, apply proceeds even when guardrails have tripped.
+   * Use with caution — bypasses all safety checks.
+   * Defaults to false.
+   */
+  allowGuardrailOverride?: boolean;
+
+  /**
+   * Maximum number of GitHub API requests for this run (across all cycles).
+   *
+   * GitHub App installations are subject to a per-installation rate ceiling.
+   * The runner stops cleanly when the budget is exhausted and records deferred
+   * work in the result so callers can resume or alert. No silent truncation.
+   *
+   * Defaults to 1000 (a conservative floor well under typical ceilings).
+   */
+  requestBudget?: number;
+}
+
+// ---------------------------------------------------------------------------
+// RateBudget implementation
+// ---------------------------------------------------------------------------
+
+class MutableRateBudget implements RateBudget {
+  private _remaining: number;
+
+  constructor(initial: number) {
+    this._remaining = initial;
+  }
+
+  get remaining(): number {
+    return this._remaining;
+  }
+
+  get exhausted(): boolean {
+    return this._remaining <= 0;
+  }
+
+  use(n = 1): void {
+    if (this.exhausted) {
+      throw new BudgetExhaustedError();
+    }
+    this._remaining = Math.max(0, this._remaining - n);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// runReconcile
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the governance reconcile loop.
+ *
+ * For each org in `config.orgs` and each cycle in `cycles`:
+ *   1. `fetchLive` — fetch live state from GitHub (counts against budget).
+ *   2. `buildDesired` — build desired state from config (pure).
+ *   3. `diff()` — compute the ChangeSet.
+ *   4. `runGuardrails()` — check safety rules.
+ *   5a. dry-run: render the plan, return without mutating.
+ *   5b. apply: call `cycle.apply` for each entry (if guardrails pass or override).
+ *
+ * Returns a structured `ReconcileResult` with per-cycle outcomes and any
+ * deferred work.
+ */
+export async function runReconcile<TScope = unknown>(
+  opts: RunReconcileOptions<TScope>,
+): Promise<ReconcileResult> {
+  const {
+    config,
+    client,
+    cycles,
+    scope,
+    mode = "dry-run",
+    guardrails: guardrailConfig = {},
+    diffOptions = {},
+    allowGuardrailOverride = false,
+    requestBudget = 1000,
+  } = opts;
+
+  const budget = new MutableRateBudget(requestBudget);
+  const cycleResults: CycleResult[] = [];
+  const deferred: DeferredWork = { skippedCycles: [], skippedEntries: [] };
+
+  const orgs = Object.entries(config.orgs);
+
+  for (const cycle of cycles) {
+    for (const [orgLogin, orgConfig] of orgs) {
+      // Stop entirely if budget is exhausted before we start a new cycle.
+      if (budget.exhausted) {
+        deferred.skippedCycles.push(`${cycle.name}@${orgLogin}`);
+        continue;
+      }
+
+      // Step 1: fetchLive — the cycle itself tracks budget usage internally.
+      // We wrap in a try/catch so a BudgetExhaustedError mid-fetch is recorded
+      // as a deferred skip rather than a hard crash.
+      let live: LiveOrgState;
+      try {
+        live = await cycle.fetchLive(client, scope as TScope, budget);
+      } catch (err) {
+        if (err instanceof BudgetExhaustedError) {
+          deferred.skippedCycles.push(`${cycle.name}@${orgLogin}`);
+          continue;
+        }
+        throw err;
+      }
+
+      // Step 2: buildDesired (pure).
+      const desired = cycle.buildDesired(orgConfig, scope as TScope);
+
+      // Step 3: diff.
+      const changeSet: ChangeSet = diff(orgLogin, desired, live, diffOptions);
+
+      // Step 4: guardrails.
+      const guardrailResult = runGuardrails(changeSet, live, guardrailConfig);
+
+      // Counts.
+      const counts = { create: 0, update: 0, delete: 0 };
+      for (const e of changeSet.entries) counts[e.kind]++;
+
+      // Plan summary.
+      const plan = renderChangeSet(changeSet);
+
+      const cycleResult: CycleResult = {
+        name: cycle.name,
+        org: orgLogin,
+        counts,
+        guardrails: guardrailResult,
+        applied: [],
+        failed: [],
+        plan,
+        guardrailBlocked: false,
+      };
+
+      // Step 5a: dry-run — nothing more to do.
+      if (mode === "dry-run") {
+        cycleResults.push(cycleResult);
+        continue;
+      }
+
+      // Step 5b: apply.
+
+      // If guardrails failed and override is not set, block the apply.
+      if (!guardrailResult.ok && !allowGuardrailOverride) {
+        cycleResult.guardrailBlocked = true;
+        cycleResults.push(cycleResult);
+        continue;
+      }
+
+      // Apply each entry.
+      for (const entry of changeSet.entries) {
+        if (budget.exhausted) {
+          deferred.skippedEntries.push({ cycleName: cycle.name, entry });
+          continue;
+        }
+
+        try {
+          await cycle.apply(client, entry, scope as TScope, budget);
+          cycleResult.applied.push(entry);
+        } catch (err) {
+          if (err instanceof BudgetExhaustedError) {
+            deferred.skippedEntries.push({ cycleName: cycle.name, entry });
+            continue;
+          }
+          cycleResult.failed.push({
+            entry,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      cycleResults.push(cycleResult);
+    }
+  }
+
+  const completed =
+    deferred.skippedCycles.length === 0 && deferred.skippedEntries.length === 0;
+
+  return {
+    mode,
+    completed,
+    cycles: cycleResults,
+    deferred,
+    budgetRemaining: budget.remaining,
+  };
+}

--- a/lexicons/github-org/src/reconcile/runner.ts
+++ b/lexicons/github-org/src/reconcile/runner.ts
@@ -111,6 +111,22 @@ export interface CycleResult {
   guardrailBlocked: boolean;
 }
 
+/**
+ * A cycle that could not run because `fetchLive` or `buildDesired` threw a
+ * non-budget error. Recorded per-cycle so the run can continue rather than
+ * rejecting the whole `runReconcile` call.
+ */
+export interface CycleError {
+  /** Cycle name. */
+  name: string;
+  /** Org this error is for. */
+  org: string;
+  /** The stage at which the cycle failed. */
+  stage: "fetchLive" | "buildDesired";
+  /** Error message. */
+  error: string;
+}
+
 /** Summary of work that could not be completed due to rate budget exhaustion. */
 export interface DeferredWork {
   /**
@@ -129,10 +145,18 @@ export interface DeferredWork {
 export interface ReconcileResult {
   /** Run mode used. */
   mode: "dry-run" | "apply";
-  /** Whether the full run completed (false when budget was exhausted early). */
+  /**
+   * Whether the full run completed cleanly (false when budget was exhausted
+   * early or any cycle errored).
+   */
   completed: boolean;
   /** Per-cycle outcomes (only for cycles that were started). */
   cycles: CycleResult[];
+  /**
+   * Cycles that errored during `fetchLive`/`buildDesired` with a non-budget
+   * error. The run continues past these; they are not silently dropped.
+   */
+  errored: CycleError[];
   /** Work deferred due to budget exhaustion (empty when `completed` is true). */
   deferred: DeferredWork;
   /** Remaining budget at the end of the run. */
@@ -261,6 +285,7 @@ export async function runReconcile<TScope = unknown>(
 
   const budget = new MutableRateBudget(requestBudget);
   const cycleResults: CycleResult[] = [];
+  const erroredCycles: CycleError[] = [];
   const deferred: DeferredWork = { skippedCycles: [], skippedEntries: [] };
 
   const orgs = Object.entries(config.orgs);
@@ -284,11 +309,30 @@ export async function runReconcile<TScope = unknown>(
           deferred.skippedCycles.push(`${cycle.name}@${orgLogin}`);
           continue;
         }
-        throw err;
+        // Any other error: record this cycle as errored and move on so the
+        // run isn't abandoned and remaining cycles/orgs still execute.
+        erroredCycles.push({
+          name: cycle.name,
+          org: orgLogin,
+          stage: "fetchLive",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        continue;
       }
 
       // Step 2: buildDesired (pure).
-      const desired = cycle.buildDesired(orgConfig, scope as TScope);
+      let desired: OrgConfig;
+      try {
+        desired = cycle.buildDesired(orgConfig, scope as TScope);
+      } catch (err) {
+        erroredCycles.push({
+          name: cycle.name,
+          org: orgLogin,
+          stage: "buildDesired",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        continue;
+      }
 
       // Step 3: diff.
       const changeSet: ChangeSet = diff(orgLogin, desired, live, diffOptions);
@@ -356,12 +400,15 @@ export async function runReconcile<TScope = unknown>(
   }
 
   const completed =
-    deferred.skippedCycles.length === 0 && deferred.skippedEntries.length === 0;
+    deferred.skippedCycles.length === 0 &&
+    deferred.skippedEntries.length === 0 &&
+    erroredCycles.length === 0;
 
   return {
     mode,
     completed,
     cycles: cycleResults,
+    errored: erroredCycles,
     deferred,
     budgetRemaining: budget.remaining,
   };


### PR DESCRIPTION
Closes #452.

Adds the governance reconcile orchestrator (`lexicons/github-org/src/reconcile/runner.ts`) that ties config, diff (#450), and guardrails (#451) into one run.

## What it does
- `Cycle` interface: `{ name, fetchLive(client, scope, budget), buildDesired(config, scope), apply(client, entry, scope, budget) }`.
- `runReconcile({ config, client, cycles, mode })` drives, per org and cycle: `fetchLive` -> `buildDesired` -> `diff()` -> `runGuardrails()`.
  - `mode: 'dry-run'` (default) computes and reports the change set, mutates nothing.
  - `mode: 'apply'` applies each entry only when guardrails pass, or when `allowGuardrailOverride` is set.
- Configurable per-run request budget (`requestBudget`, default 1000) threaded into each cycle's `fetchLive`/`apply` via a `RateBudget`. The run stops cleanly when exhausted and reports deferred cycles/entries — no silent truncation.
- Structured `ReconcileResult`: per-cycle counts, guardrail trips, applied/failed entries, deferred work, remaining budget.

Public API re-exported from `src/index.ts`.

## Tests
Colocated `runner.test.ts` with a mock client and fake cycles (no network): dry-run mutates nothing, apply mutates only when guardrails pass, guardrail-blocked apply, override flag, and budget-exhausted reporting deferred work (both pre-fetch and mid-apply).

## Verification
- `npx tsc --noEmit -p lexicons/github-org/tsconfig.json` — clean.
- `npx vitest run lexicons/github-org` — 111 passed (10 new).

Out of scope: concrete cycles (#455), emitted pipeline (#453), dump (#454).