### PR TITLE
feat(github-org): branch-protection cycle — first Cycle implementation (template)

### DIFF
--- a/lexicons/github-org/src/auth/app-client.test.ts
+++ b/lexicons/github-org/src/auth/app-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeAll } from "vitest";
+import type { webcrypto } from "node:crypto";
 import { mintInstallationToken, createAppClient, AppAuthError } from "./app-client.js";
 
 // ---------------------------------------------------------------------------
@@ -8,7 +9,7 @@ import { mintInstallationToken, createAppClient, AppAuthError } from "./app-clie
 // ---------------------------------------------------------------------------
 
 let testPrivateKeyPem: string;
-let testPublicKey: CryptoKey;
+let testPublicKey: webcrypto.CryptoKey;
 
 function arrayBufferToBase64(buf: ArrayBuffer): string {
   return btoa(String.fromCharCode(...new Uint8Array(buf)));
@@ -51,7 +52,7 @@ describe("mintInstallationToken", () => {
   test("exchanges JWT for an installation token", async () => {
     let capturedRequest: Request | undefined;
     const mockFetch: typeof fetch = async (input, init) => {
-      capturedRequest = new Request(input as RequestInfo, init);
+      capturedRequest = new Request(input as Request | string, init);
       return makeTokenResponse();
     };
 
@@ -128,12 +129,12 @@ describe("mintInstallationToken", () => {
     const mockFetch: typeof fetch = async () =>
       new Response(JSON.stringify({ message: "Not Found" }), { status: 404 });
 
-    const err = await mintInstallationToken({
+    const err = (await mintInstallationToken({
       appId: "1",
       privateKeyPem: testPrivateKeyPem,
       installationId: "999",
       fetchImpl: mockFetch,
-    }).catch((e) => e as AppAuthError);
+    }).catch((e: unknown) => e)) as AppAuthError;
 
     expect(err).toBeInstanceOf(AppAuthError);
     expect(err.statusCode).toBe(404);
@@ -145,12 +146,12 @@ describe("mintInstallationToken", () => {
     const mockFetch: typeof fetch = async () =>
       new Response("Internal Server Error", { status: 500 });
 
-    const err = await mintInstallationToken({
+    const err = (await mintInstallationToken({
       appId: "1",
       privateKeyPem: testPrivateKeyPem,
       installationId: "2",
       fetchImpl: mockFetch,
-    }).catch((e) => e as AppAuthError);
+    }).catch((e: unknown) => e)) as AppAuthError;
 
     expect(err).toBeInstanceOf(AppAuthError);
     expect(err.statusCode).toBe(500);
@@ -354,7 +355,7 @@ describe("createAppClient", () => {
       fetchImpl: mockFetch,
     });
 
-    const err = await client.request("GET", "/orgs/my-org").catch((e) => e as AppAuthError);
+    const err = (await client.request("GET", "/orgs/my-org").catch((e: unknown) => e)) as AppAuthError;
     expect(err).toBeInstanceOf(AppAuthError);
     expect(err.statusCode).toBe(403);
     expect(err.message).toMatch(/Forbidden/); // response body surfaced for debugging

--- a/lexicons/github-org/src/cycles/README.md
+++ b/lexicons/github-org/src/cycles/README.md
@@ -1,0 +1,103 @@
+# Cycles — copy-template guide
+
+A **cycle** is one reconcile domain. It declares how to read live state from
+GitHub, how to derive desired state from config, and how to apply one
+`ChangeSetEntry` back. The runner (`reconcile/runner.ts`) supplies diff,
+guardrails, dry-run, and apply orchestration around every cycle.
+
+`branch-protection.ts` is the template. Every subsequent cycle follows the same
+four-part structure.
+
+---
+
+## The four parts
+
+### 1. Config shape
+
+Desired state lives in `src/config/types.ts`. Add fields to the appropriate
+interface (`RepoConfig`, `OrgConfig`, etc.). Keep every field optional —
+absent means "not managed" (selective-by-omission).
+
+`BranchProtectionConfig` is the example for this cycle.
+
+### 2. `fetchLive`
+
+Signature:
+
+```ts
+fetchLive(client: AppClient, scope: TScope, budget: RateBudget): Promise<LiveOrgState>
+```
+
+- Call `budget.use(n)` before (or immediately after) each GitHub API call.
+- Check `budget.exhausted` before paginating or iterating further.
+- Return a partial `LiveOrgState` with only the fields this cycle manages.
+  Absent fields are not diffed by the runner.
+- On 404 (resource does not exist yet) return an empty sub-state rather than
+  throwing — the diff will emit a create entry.
+
+### 3. `buildDesired`
+
+Signature:
+
+```ts
+buildDesired(orgConfig: OrgConfig, scope: TScope): OrgConfig
+```
+
+- Pure — no I/O.
+- Return a minimal `OrgConfig` containing only the fields this cycle manages.
+  Strip everything else so the diff focuses on one domain.
+- If the returned config has no managed fields for a repo/resource, the diff
+  emits zero entries for it (selective-by-omission).
+
+### 4. `apply`
+
+Signature:
+
+```ts
+apply(client: AppClient, entry: ChangeSetEntry, scope: TScope, budget: RateBudget): Promise<void>
+```
+
+- Dispatch on `entry.kind`: `"create"` | `"update"` | `"delete"`.
+- Call `budget.use(1)` before each network call.
+- Ignore entries whose `resourceType` does not belong to this cycle.
+- The `key` convention follows `diff.ts`:
+  - top-level: `"<resource-name>"`
+  - nested: `"<parent>/<child>"` (e.g. `"my-repo/main"`)
+
+---
+
+## Registering a cycle
+
+Export the cycle instance from this file, then re-export from
+`src/index.ts`:
+
+```ts
+export { branchProtectionCycle } from "./cycles/branch-protection.js";
+```
+
+Pass it to `runReconcile`:
+
+```ts
+import { branchProtectionCycle } from "@intentius/chant-lexicon-github-org";
+
+await runReconcile({
+  config,
+  client,
+  cycles: [branchProtectionCycle],
+  scope: "my-org",
+  mode: "dry-run",
+});
+```
+
+---
+
+## Checklist for new cycles
+
+- [ ] Config fields added to `src/config/types.ts` (all optional)
+- [ ] `LiveXxx` types added or reused from `src/reconcile/diff.ts`
+- [ ] `fetchLive` charges the budget for every API call
+- [ ] `buildDesired` is pure and returns a minimal `OrgConfig`
+- [ ] `apply` handles create / update / delete and ignores foreign resource types
+- [ ] Cycle exported from `src/index.ts`
+- [ ] Unit tests: buildDesired, fetchLive mapping, diff, apply create/update/delete
+- [ ] Runner integration test: dry-run plan, guardrail trip (if applicable)

--- a/lexicons/github-org/src/cycles/README.md
+++ b/lexicons/github-org/src/cycles/README.md
@@ -83,8 +83,10 @@ import { branchProtectionCycle } from "@intentius/chant-lexicon-github-org";
 await runReconcile({
   config,
   client,
+  // The scope is a typed object, not a bare string. For branch-protection it is
+  // `BranchProtectionScope` ({ org, repos? }).
   cycles: [branchProtectionCycle],
-  scope: "my-org",
+  scope: { org: "my-org", repos: config.orgs["my-org"]?.repos },
   mode: "dry-run",
 });
 ```

--- a/lexicons/github-org/src/cycles/branch-protection.test.ts
+++ b/lexicons/github-org/src/cycles/branch-protection.test.ts
@@ -1,0 +1,659 @@
+/**
+ * Tests for the branch-protection cycle.
+ *
+ * All tests use a mock AppClient — no network calls.
+ * Test coverage:
+ *   - buildDesired: omits repos without branchProtection, filters to BP-only shape
+ *   - fetchLive (via fetchLiveForOrg): maps GitHub API response to LiveOrgState
+ *   - diff over the cycle: create / update / delete entries produced correctly
+ *   - apply: correct HTTP calls for create, update, delete
+ *   - runner integration: dry-run plan and guardrail cap via runReconcile
+ */
+
+import { describe, it, expect } from "vitest";
+import { branchProtectionCycle, fetchLiveForOrg } from "./branch-protection.js";
+import type { BranchProtectionScope } from "./branch-protection.js";
+import type { AppClient } from "../auth/app-client.js";
+import type { RateBudget } from "../reconcile/runner.js";
+import { runReconcile, BudgetExhaustedError } from "../reconcile/runner.js";
+import { diff } from "../reconcile/diff.js";
+import type { LiveOrgState } from "../reconcile/diff.js";
+import type { GovernanceConfig, OrgConfig } from "../config/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+interface MockCall {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+interface MockClient extends AppClient {
+  calls: MockCall[];
+  /** Inject a response for a specific path (looked up in order). */
+  responses: Map<string, unknown>;
+}
+
+function makeMockClient(responses: Record<string, unknown> = {}): MockClient {
+  const calls: MockCall[] = [];
+  const responseMap = new Map(Object.entries(responses));
+  return {
+    calls,
+    responses: responseMap,
+    async request<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
+      calls.push({ method, path, body });
+      const key = `${method} ${path}`;
+      if (responseMap.has(key)) return responseMap.get(key) as T;
+      // Default: return an empty object (simulates 200 with no body needed)
+      return {} as T;
+    },
+  };
+}
+
+function makeBudget(initial = 100): RateBudget {
+  let remaining = initial;
+  return {
+    get remaining() {
+      return remaining;
+    },
+    get exhausted() {
+      return remaining <= 0;
+    },
+    use(n = 1) {
+      if (remaining <= 0) throw new BudgetExhaustedError();
+      remaining = Math.max(0, remaining - n);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. buildDesired
+// ---------------------------------------------------------------------------
+
+describe("branchProtectionCycle.buildDesired", () => {
+  const defaultScope: BranchProtectionScope = { org: "test-org" };
+
+  it("returns empty config when no repos are defined", () => {
+    const orgConfig: OrgConfig = {};
+    const desired = branchProtectionCycle.buildDesired(orgConfig, defaultScope);
+    expect(desired.repos).toBeUndefined();
+  });
+
+  it("omits repos with no branchProtection", () => {
+    const orgConfig: OrgConfig = {
+      repos: {
+        "no-bp-repo": { description: "no branch protection config" },
+      },
+    };
+    const desired = branchProtectionCycle.buildDesired(orgConfig, defaultScope);
+    expect(desired.repos).toEqual({});
+  });
+
+  it("omits repos with an empty branchProtection array", () => {
+    const orgConfig: OrgConfig = {
+      repos: {
+        "empty-bp-repo": { branchProtection: [] },
+      },
+    };
+    const desired = branchProtectionCycle.buildDesired(orgConfig, defaultScope);
+    expect(desired.repos).toEqual({});
+  });
+
+  it("keeps repos that have branchProtection rules", () => {
+    const orgConfig: OrgConfig = {
+      repos: {
+        "managed-repo": {
+          description: "should be stripped",
+          branchProtection: [{ pattern: "main", requirePullRequestReviews: true }],
+        },
+        "unmanaged-repo": { description: "no bp" },
+      },
+    };
+    const desired = branchProtectionCycle.buildDesired(orgConfig, defaultScope);
+    expect(desired.repos).toHaveProperty("managed-repo");
+    expect(desired.repos).not.toHaveProperty("unmanaged-repo");
+    // Only branchProtection is retained — other repo fields stripped
+    expect(desired.repos!["managed-repo"]).toEqual({
+      branchProtection: [{ pattern: "main", requirePullRequestReviews: true }],
+    });
+  });
+
+  it("keeps all branch protection entries for a repo", () => {
+    const orgConfig: OrgConfig = {
+      repos: {
+        "multi-bp": {
+          branchProtection: [
+            { pattern: "main", requirePullRequestReviews: true },
+            { pattern: "release/*", requireStatusChecks: true, requiredStatusCheckContexts: ["ci"] },
+          ],
+        },
+      },
+    };
+    const desired = branchProtectionCycle.buildDesired(orgConfig, defaultScope);
+    expect(desired.repos!["multi-bp"]!.branchProtection).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. fetchLiveForOrg — live-fetch mapping
+// ---------------------------------------------------------------------------
+
+describe("fetchLiveForOrg", () => {
+  it("returns empty repos when no repos have branchProtection config", async () => {
+    const client = makeMockClient();
+    const live = await fetchLiveForOrg(
+      client,
+      "test-org",
+      { "no-bp": { description: "unmanaged" } },
+      makeBudget(),
+    );
+    expect(live.repos).toEqual({});
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it("maps full GitHub protection response to LiveBranchProtectionConfig", async () => {
+    const client = makeMockClient({
+      "GET /repos/test-org/my-repo/branches/main/protection": {
+        required_pull_request_reviews: {
+          required_approving_review_count: 2,
+          dismiss_stale_reviews: true,
+          require_code_owner_reviews: false,
+        },
+        required_status_checks: {
+          contexts: ["ci/build", "ci/test"],
+          strict: true,
+        },
+        restrictions: { users: [], teams: ["infra"] },
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: false },
+        required_linear_history: { enabled: true },
+      },
+    });
+
+    const live = await fetchLiveForOrg(
+      client,
+      "test-org",
+      { "my-repo": { branchProtection: [{ pattern: "main" }] } },
+      makeBudget(),
+    );
+
+    const bp = live.repos!["my-repo"]!.branchProtection![0]!;
+    expect(bp.pattern).toBe("main");
+    expect(bp.requirePullRequestReviews).toBe(true);
+    expect(bp.requiredApprovingReviewCount).toBe(2);
+    expect(bp.dismissStaleReviews).toBe(true);
+    expect(bp.requireCodeOwnerReviews).toBe(false);
+    expect(bp.requireStatusChecks).toBe(true);
+    expect(bp.requiredStatusCheckContexts).toEqual(["ci/build", "ci/test"]);
+    expect(bp.requireBranchesToBeUpToDate).toBe(true);
+    expect(bp.restrictPushes).toBe(true); // restrictions object present
+    expect(bp.allowForcePushes).toBe(false);
+    expect(bp.allowDeletions).toBe(false);
+    expect(bp.requireLinearHistory).toBe(true);
+  });
+
+  it("treats 404 as no protection (returns no entry for that branch)", async () => {
+    const client: MockClient = makeMockClient();
+    // Override to throw a 404
+    client.request = async <T = unknown>(method: string, path: string): Promise<T> => {
+      client.calls.push({ method, path });
+      throw new Error("GET ... returned 404: Branch not protected");
+    };
+
+    const live = await fetchLiveForOrg(
+      client,
+      "test-org",
+      { "unprotected": { branchProtection: [{ pattern: "main" }] } },
+      makeBudget(),
+    );
+
+    // 404 → no entry in branchProtection (just an empty array)
+    expect(live.repos!["unprotected"]!.branchProtection).toHaveLength(0);
+  });
+
+  it("charges the budget — one call per branch pattern", async () => {
+    const client = makeMockClient();
+    const budget = makeBudget(10);
+
+    await fetchLiveForOrg(
+      client,
+      "test-org",
+      {
+        "repo-a": { branchProtection: [{ pattern: "main" }, { pattern: "develop" }] },
+        "repo-b": { branchProtection: [{ pattern: "main" }] },
+      },
+      budget,
+    );
+
+    // 3 branches → 3 API calls → budget reduced by 3
+    expect(budget.remaining).toBe(7);
+    expect(client.calls).toHaveLength(3);
+  });
+
+  it("stops fetching when budget is exhausted mid-way", async () => {
+    const client = makeMockClient();
+    const budget = makeBudget(1); // only 1 request allowed
+
+    await fetchLiveForOrg(
+      client,
+      "test-org",
+      {
+        "repo-a": { branchProtection: [{ pattern: "main" }] },
+        "repo-b": { branchProtection: [{ pattern: "main" }] },
+      },
+      budget,
+    );
+
+    // Only one branch fetched before budget ran out
+    expect(client.calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. diff over the cycle
+// ---------------------------------------------------------------------------
+
+describe("diff integration with branch-protection cycle", () => {
+  const desiredOrgConfig: OrgConfig = {
+    repos: {
+      "my-repo": {
+        branchProtection: [
+          {
+            pattern: "main",
+            requirePullRequestReviews: true,
+            requiredApprovingReviewCount: 2,
+          },
+        ],
+      },
+    },
+  };
+  const scope: BranchProtectionScope = { org: "test-org" };
+
+  it("emits create when no live protection exists", () => {
+    const live: LiveOrgState = { repos: { "my-repo": { branchProtection: [] } } };
+    const desired = branchProtectionCycle.buildDesired(desiredOrgConfig, scope);
+    const changeSet = diff("test-org", desired, live);
+
+    expect(changeSet.entries).toHaveLength(1);
+    expect(changeSet.entries[0]!.kind).toBe("create");
+    expect(changeSet.entries[0]!.resourceType).toBe("branch-protection");
+    expect(changeSet.entries[0]!.key).toBe("my-repo/main");
+  });
+
+  it("emits update when a field differs from live", () => {
+    const live: LiveOrgState = {
+      repos: {
+        "my-repo": {
+          branchProtection: [
+            {
+              pattern: "main",
+              requirePullRequestReviews: true,
+              requiredApprovingReviewCount: 1, // desired wants 2
+            },
+          ],
+        },
+      },
+    };
+    const desired = branchProtectionCycle.buildDesired(desiredOrgConfig, scope);
+    const changeSet = diff("test-org", desired, live);
+
+    expect(changeSet.entries).toHaveLength(1);
+    expect(changeSet.entries[0]!.kind).toBe("update");
+    expect(changeSet.entries[0]!.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: "requiredApprovingReviewCount",
+          before: 1,
+          after: 2,
+        }),
+      ]),
+    );
+  });
+
+  it("emits no entries when live matches desired", () => {
+    const live: LiveOrgState = {
+      repos: {
+        "my-repo": {
+          branchProtection: [
+            {
+              pattern: "main",
+              requirePullRequestReviews: true,
+              requiredApprovingReviewCount: 2,
+            },
+          ],
+        },
+      },
+    };
+    const desired = branchProtectionCycle.buildDesired(desiredOrgConfig, scope);
+    const changeSet = diff("test-org", desired, live);
+
+    expect(changeSet.entries).toHaveLength(0);
+  });
+
+  it("emits delete for live rules owned by chant and absent from desired", () => {
+    const live: LiveOrgState = {
+      repos: {
+        "my-repo": {
+          branchProtection: [
+            { pattern: "main", requirePullRequestReviews: true, requiredApprovingReviewCount: 2 },
+            { pattern: "develop", requirePullRequestReviews: false }, // not in desired
+          ],
+        },
+      },
+    };
+    const desired = branchProtectionCycle.buildDesired(desiredOrgConfig, scope);
+    const changeSet = diff("test-org", desired, live, {
+      isOwned: (_type, key) => key === "my-repo/develop",
+    });
+
+    const deleteEntry = changeSet.entries.find((e) => e.kind === "delete");
+    expect(deleteEntry).toBeDefined();
+    expect(deleteEntry!.key).toBe("my-repo/develop");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. apply — create / update / delete
+// ---------------------------------------------------------------------------
+
+describe("branchProtectionCycle.apply", () => {
+  it("sends PUT request for a create entry", async () => {
+    const client = makeMockClient();
+    const entry = {
+      kind: "create" as const,
+      resourceType: "branch-protection",
+      key: "my-repo/main",
+      after: {
+        pattern: "main",
+        requirePullRequestReviews: true,
+        requiredApprovingReviewCount: 2,
+        dismissStaleReviews: false,
+        requireCodeOwnerReviews: false,
+        requireStatusChecks: false,
+        allowForcePushes: false,
+        allowDeletions: false,
+        requireLinearHistory: false,
+      },
+    };
+
+    await branchProtectionCycle.apply(client, entry, { org: "test-org" }, makeBudget());
+
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]!.method).toBe("PUT");
+    expect(client.calls[0]!.path).toBe(
+      "/repos/test-org/my-repo/branches/main/protection",
+    );
+    expect(client.calls[0]!.body).toMatchObject({
+      required_pull_request_reviews: {
+        required_approving_review_count: 2,
+        dismiss_stale_reviews: false,
+        require_code_owner_reviews: false,
+      },
+      allow_force_pushes: false,
+      allow_deletions: false,
+      required_linear_history: false,
+    });
+  });
+
+  it("sends PUT request for an update entry", async () => {
+    const client = makeMockClient();
+    const entry = {
+      kind: "update" as const,
+      resourceType: "branch-protection",
+      key: "api-service/release/1.0",
+      before: { pattern: "release/1.0", requiredApprovingReviewCount: 1 },
+      after: { pattern: "release/1.0", requiredApprovingReviewCount: 2, requirePullRequestReviews: true },
+      fields: [{ field: "requiredApprovingReviewCount", before: 1, after: 2 }],
+    };
+
+    await branchProtectionCycle.apply(client, entry, { org: "my-org" }, makeBudget());
+
+    // Branch pattern with slash should be URL-encoded
+    expect(client.calls[0]!.method).toBe("PUT");
+    expect(client.calls[0]!.path).toBe(
+      "/repos/my-org/api-service/branches/release%2F1.0/protection",
+    );
+  });
+
+  it("sends DELETE request for a delete entry", async () => {
+    const client = makeMockClient();
+    const entry = {
+      kind: "delete" as const,
+      resourceType: "branch-protection",
+      key: "old-repo/develop",
+      before: { pattern: "develop" },
+    };
+
+    await branchProtectionCycle.apply(client, entry, { org: "my-org" }, makeBudget());
+
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]!.method).toBe("DELETE");
+    expect(client.calls[0]!.path).toBe(
+      "/repos/my-org/old-repo/branches/develop/protection",
+    );
+  });
+
+  it("charges the budget once per apply", async () => {
+    const client = makeMockClient();
+    const budget = makeBudget(5);
+    const entry = {
+      kind: "delete" as const,
+      resourceType: "branch-protection",
+      key: "repo/main",
+      before: { pattern: "main" },
+    };
+
+    await branchProtectionCycle.apply(client, entry, "my-org", budget);
+
+    expect(budget.remaining).toBe(4);
+  });
+
+  it("skips non-branch-protection entries", async () => {
+    const client = makeMockClient();
+    const entry = {
+      kind: "create" as const,
+      resourceType: "team",
+      key: "some-team",
+      after: { description: "a team" },
+    };
+
+    await branchProtectionCycle.apply(client, entry, { org: "my-org" }, makeBudget());
+
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it("throws on malformed key", async () => {
+    const client = makeMockClient();
+    const entry = {
+      kind: "create" as const,
+      resourceType: "branch-protection",
+      key: "no-slash-here",
+      after: { pattern: "main" },
+    };
+
+    await expect(
+      branchProtectionCycle.apply(client, entry, "my-org", makeBudget()),
+    ).rejects.toThrow("malformed entry key");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Runner integration
+// ---------------------------------------------------------------------------
+
+describe("branchProtectionCycle via runReconcile", () => {
+  it("dry-run: plan shows correct create count (no live protection)", async () => {
+    // Mock client returns 404-style errors for GET protection → no live rules
+    const client: MockClient = makeMockClient();
+    client.request = async <T = unknown>(method: string, path: string, body?: unknown): Promise<T> => {
+      client.calls.push({ method, path, body });
+      if (method === "GET" && path.includes("/protection")) {
+        throw new Error("GET ... returned 404: Branch not protected");
+      }
+      return {} as T;
+    };
+
+    const config: GovernanceConfig = {
+      orgs: {
+        "test-org": {
+          repos: {
+            "my-repo": {
+              branchProtection: [
+                { pattern: "main", requirePullRequestReviews: true },
+                { pattern: "develop", requireStatusChecks: true },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    // scope includes repos so fetchLive fetches live state (404 → empty → creates)
+    const scope: BranchProtectionScope = {
+      org: "test-org",
+      repos: config.orgs["test-org"]!.repos,
+    };
+    const result = await runReconcile({
+      config,
+      client,
+      cycles: [branchProtectionCycle],
+      scope,
+      mode: "dry-run",
+    });
+
+    expect(result.mode).toBe("dry-run");
+    expect(result.completed).toBe(true);
+    // fetchLive made API calls (GET /protection) but no mutations
+    expect(client.calls.every((c) => c.method === "GET")).toBe(true);
+
+    const cr = result.cycles[0]!;
+    expect(cr.name).toBe("branch-protection");
+    expect(cr.counts.create).toBe(2);
+    expect(cr.counts.update).toBe(0);
+    expect(cr.counts.delete).toBe(0);
+    expect(cr.plan).toContain("2 to create");
+  });
+
+  it("apply: sends one PUT per branch protection rule", async () => {
+    // fetchLive returns 404 (no live protection) → desired rule is a create
+    // apply then sends a PUT to create the protection rule
+    const client: MockClient = makeMockClient();
+    client.request = async <T = unknown>(method: string, path: string, body?: unknown): Promise<T> => {
+      client.calls.push({ method, path, body });
+      if (method === "GET" && path.includes("/protection")) {
+        throw new Error("GET ... returned 404: Branch not protected");
+      }
+      return {} as T;
+    };
+
+    const config: GovernanceConfig = {
+      orgs: {
+        "test-org": {
+          repos: {
+            "my-repo": {
+              branchProtection: [
+                { pattern: "main", requirePullRequestReviews: true, requiredApprovingReviewCount: 2 },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const scope: BranchProtectionScope = {
+      org: "test-org",
+      repos: config.orgs["test-org"]!.repos,
+    };
+
+    const result = await runReconcile({
+      config,
+      client,
+      cycles: [branchProtectionCycle],
+      scope,
+      mode: "apply",
+      // allowGuardrailOverride because there are no org members in this test
+      // fixture — adminFloor would otherwise block the apply. The adminFloor
+      // guardrail is not what this test covers; a dedicated guardrail test
+      // verifies removalDeltaCap trips correctly.
+      allowGuardrailOverride: true,
+    });
+
+    expect(result.completed).toBe(true);
+    expect(result.cycles[0]!.applied).toHaveLength(1);
+    // One GET (fetchLive) + one PUT (apply)
+    expect(client.calls).toHaveLength(2);
+    const putCall = client.calls.find((c) => c.method === "PUT");
+    expect(putCall).toBeDefined();
+    expect(putCall!.path).toContain("/protection");
+  });
+
+  it("guardrail cap: removing many rules trips removalDeltaCap", async () => {
+    const client = makeMockClient();
+
+    // Config: one managed repo, but with an empty branchProtection → cycle
+    // builds desired with no bp entries. The live state (injected via a wrapper
+    // cycle) has 10 existing rules → 10 deletes.
+    //
+    // We test the guardrail by constructing the ChangeSet directly (the cycle's
+    // fetchLive returns empty state, so a direct diff lets us inject live).
+    const live: LiveOrgState = {
+      repos: {
+        "big-repo": {
+          branchProtection: Array.from({ length: 10 }, (_, i) => ({
+            pattern: `feature-${i}`,
+            requirePullRequestReviews: false,
+          })),
+        },
+      },
+    };
+
+    // desired: big-repo has only 1 bp rule — rest are absent from config
+    const desiredConfig: OrgConfig = {
+      repos: {
+        "big-repo": {
+          branchProtection: [{ pattern: "main", requirePullRequestReviews: true }],
+        },
+      },
+    };
+    const desired = branchProtectionCycle.buildDesired(desiredConfig, { org: "test-org" });
+
+    // Apply an ownership predicate so all live patterns are owned
+    const changeSet = diff("test-org", desired, live, {
+      isOwned: () => true,
+    });
+
+    // 1 create + 10 deletes; removalDeltaCap(0.25) trips: 10/10 = 100% > 25%
+    const { runGuardrails } = await import("../reconcile/guardrails.js");
+    const gr = runGuardrails(changeSet, live);
+    expect(gr.ok).toBe(false);
+    if (!gr.ok) {
+      expect(gr.diagnostics.some((d) => d.guardrail === "removalDeltaCap")).toBe(true);
+    }
+  });
+
+  it("selective-by-omission: repos not in config produce no entries", async () => {
+    const client = makeMockClient();
+    const config: GovernanceConfig = {
+      orgs: {
+        "test-org": {
+          // repos is absent entirely
+        },
+      },
+    };
+
+    const result = await runReconcile({
+      config,
+      client,
+      cycles: [branchProtectionCycle],
+      scope: { org: "test-org" } satisfies BranchProtectionScope,
+      mode: "dry-run",
+    });
+
+    const cr = result.cycles[0]!;
+    expect(cr.counts.create).toBe(0);
+    expect(cr.counts.update).toBe(0);
+    expect(cr.counts.delete).toBe(0);
+  });
+});

--- a/lexicons/github-org/src/cycles/branch-protection.test.ts
+++ b/lexicons/github-org/src/cycles/branch-protection.test.ts
@@ -417,6 +417,142 @@ describe("branchProtectionCycle.apply", () => {
     );
   });
 
+  it("preserves undeclared live fields on update (no silent downgrade)", async () => {
+    // SECURITY INVARIANT: GitHub's PUT is full-replacement. A config that
+    // tightens ONE field must not disable PR-review enforcement or let admins
+    // bypass protection. Applying a config that declares field X must change
+    // ONLY X; every other live setting is echoed back unchanged.
+    const client = makeMockClient();
+
+    // Live state: PR reviews enforced (2 approvals, code-owner reviews) AND
+    // enforce_admins=true. The `before` snapshot is what the diff carries.
+    const before = {
+      pattern: "main",
+      requirePullRequestReviews: true,
+      requiredApprovingReviewCount: 2,
+      dismissStaleReviews: true,
+      requireCodeOwnerReviews: true,
+      requireStatusChecks: true,
+      requiredStatusCheckContexts: ["ci/build"],
+      requireBranchesToBeUpToDate: true,
+      restrictPushes: true,
+      allowForcePushes: false,
+      allowDeletions: false,
+      requireLinearHistory: true,
+      enforceAdmins: true,
+    };
+
+    // Config tightens ONLY allowForcePushes (true → false is already false;
+    // declare allowDeletions=false as the single intended change).
+    const entry = {
+      kind: "update" as const,
+      resourceType: "branch-protection",
+      key: "secure-repo/main",
+      before,
+      after: { pattern: "main", allowDeletions: false },
+      fields: [{ field: "allowDeletions", before: false, after: false }],
+    };
+
+    await branchProtectionCycle.apply(client, entry, { org: "test-org" }, makeBudget());
+
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]!.method).toBe("PUT");
+    expect(client.calls[0]!.path).toBe(
+      "/repos/test-org/secure-repo/branches/main/protection",
+    );
+    const body = client.calls[0]!.body as Record<string, unknown>;
+
+    // PR-review enforcement preserved (not nulled).
+    expect(body.required_pull_request_reviews).toEqual({
+      required_approving_review_count: 2,
+      dismiss_stale_reviews: true,
+      require_code_owner_reviews: true,
+    });
+    // Admin enforcement preserved (not reset to false).
+    expect(body.enforce_admins).toBe(true);
+    // Status checks preserved.
+    expect(body.required_status_checks).toEqual({
+      strict: true,
+      contexts: ["ci/build"],
+    });
+    // Restrictions preserved.
+    expect(body.restrictions).toEqual({ users: [], teams: [] });
+    // Other live booleans preserved.
+    expect(body.allow_force_pushes).toBe(false);
+    expect(body.required_linear_history).toBe(true);
+    // The one declared field is set as declared.
+    expect(body.allow_deletions).toBe(false);
+  });
+
+  it("fetches live protection on update when before snapshot is absent", async () => {
+    // If a change-set entry lacks `before`, apply must read live state (and
+    // charge the budget) rather than null-to-disable undeclared fields.
+    const client = makeMockClient({
+      "GET /repos/test-org/secure-repo/branches/main/protection": {
+        required_pull_request_reviews: {
+          required_approving_review_count: 3,
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: true,
+        },
+        enforce_admins: { enabled: true },
+        restrictions: null,
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: false },
+        required_linear_history: { enabled: false },
+      },
+    });
+    const budget = makeBudget(5);
+
+    const entry = {
+      kind: "update" as const,
+      resourceType: "branch-protection",
+      key: "secure-repo/main",
+      // no `before`
+      after: { pattern: "main", allowDeletions: true },
+      fields: [{ field: "allowDeletions", before: false, after: true }],
+    };
+
+    await branchProtectionCycle.apply(client, entry, { org: "test-org" }, budget);
+
+    // One GET (live fetch) + one PUT (apply) → budget charged twice.
+    expect(budget.remaining).toBe(3);
+    const put = client.calls.find((c) => c.method === "PUT")!;
+    const body = put.body as Record<string, unknown>;
+    expect(body.required_pull_request_reviews).toEqual({
+      required_approving_review_count: 3,
+      dismiss_stale_reviews: false,
+      require_code_owner_reviews: true,
+    });
+    expect(body.enforce_admins).toBe(true);
+    expect(body.allow_deletions).toBe(true);
+  });
+
+  it("create entry sets only declared fields with safe defaults (no live)", async () => {
+    const client = makeMockClient();
+    const entry = {
+      kind: "create" as const,
+      resourceType: "branch-protection",
+      key: "new-repo/main",
+      after: { pattern: "main", requirePullRequestReviews: true },
+    };
+
+    await branchProtectionCycle.apply(client, entry, { org: "test-org" }, makeBudget());
+
+    // No GET — creates have no live to preserve.
+    expect(client.calls).toHaveLength(1);
+    const body = client.calls[0]!.body as Record<string, unknown>;
+    expect(body.required_pull_request_reviews).toEqual({
+      required_approving_review_count: 1,
+      dismiss_stale_reviews: false,
+      require_code_owner_reviews: false,
+    });
+    // Required nullable keys present at safe defaults (not enabling anything
+    // the caller did not ask for).
+    expect(body.required_status_checks).toBeNull();
+    expect(body.enforce_admins).toBe(false);
+    expect(body.restrictions).toBeNull();
+  });
+
   it("sends DELETE request for a delete entry", async () => {
     const client = makeMockClient();
     const entry = {
@@ -445,9 +581,15 @@ describe("branchProtectionCycle.apply", () => {
       before: { pattern: "main" },
     };
 
-    await branchProtectionCycle.apply(client, entry, "my-org", budget);
+    await branchProtectionCycle.apply(client, entry, { org: "my-org" }, budget);
 
     expect(budget.remaining).toBe(4);
+    // The scope object must resolve into the URL — a bare string would yield
+    // "/repos/undefined/...".
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]!.path).toBe(
+      "/repos/my-org/repo/branches/main/protection",
+    );
   });
 
   it("skips non-branch-protection entries", async () => {
@@ -474,7 +616,7 @@ describe("branchProtectionCycle.apply", () => {
     };
 
     await expect(
-      branchProtectionCycle.apply(client, entry, "my-org", makeBudget()),
+      branchProtectionCycle.apply(client, entry, { org: "my-org" }, makeBudget()),
     ).rejects.toThrow("malformed entry key");
   });
 });

--- a/lexicons/github-org/src/cycles/branch-protection.ts
+++ b/lexicons/github-org/src/cycles/branch-protection.ts
@@ -1,0 +1,343 @@
+/**
+ * Branch-protection & repository-ruleset cycle.
+ *
+ * This is the TEMPLATE cycle — the first concrete implementation of the `Cycle`
+ * interface. Every subsequent cycle should follow this four-part structure:
+ *
+ *   1. Config shape   — what the caller declares in `GovernanceConfig`
+ *   2. fetchLive      — read live state from the GitHub API (budget-aware)
+ *   3. buildDesired   — map config → the diff's `OrgConfig` shape (pure)
+ *   4. apply          — create / update / delete one `ChangeSetEntry` (budget-aware)
+ *
+ * See `src/cycles/README.md` for the copy-paste guide.
+ *
+ * GitHub API endpoints used:
+ *   GET  /repos/{owner}/{repo}/branches/{branch}/protection
+ *   PUT  /repos/{owner}/{repo}/branches/{branch}/protection
+ *   DELETE /repos/{owner}/{repo}/branches/{branch}/protection
+ *
+ * Selective-by-omission: repos absent from config are never touched. Fields
+ * absent from a `BranchProtectionConfig` entry are not reconciled.
+ *
+ * ## Scope
+ *
+ * `TScope` is `BranchProtectionScope` — a plain object with `org` (required)
+ * and an optional `repos` map. When `repos` is present, `fetchLive` fetches
+ * the live branch protection state for those repos. When absent, `fetchLive`
+ * returns an empty state (all desired entries will appear as creates).
+ *
+ * Typical usage with the runner:
+ *
+ * ```ts
+ * await runReconcile({
+ *   config,
+ *   client,
+ *   cycles: [branchProtectionCycle],
+ *   scope: {
+ *     org: "my-org",
+ *     repos: config.orgs["my-org"]!.repos,
+ *   },
+ *   mode: "apply",
+ * });
+ * ```
+ */
+
+import type { AppClient } from "../auth/app-client.js";
+import type { OrgConfig, BranchProtectionConfig, RepoConfig } from "../config/types.js";
+import type { ChangeSetEntry, LiveOrgState, LiveBranchProtectionConfig } from "../reconcile/diff.js";
+import type { Cycle, RateBudget } from "../reconcile/runner.js";
+
+// ---------------------------------------------------------------------------
+// Public scope type
+// ---------------------------------------------------------------------------
+
+/**
+ * Scope for the branch-protection cycle.
+ *
+ * Pass `repos` to enable accurate live-fetch (fetches branch protection state
+ * for each configured repo). Omit `repos` to get fast-path behaviour where all
+ * desired rules are treated as creates (useful when you only need to push new
+ * rules and do not care about detecting drift).
+ */
+export interface BranchProtectionScope {
+  /** GitHub org login. */
+  org: string;
+  /**
+   * Subset of repos to fetch live protection for. Typically set to
+   * `orgConfig.repos` for the relevant org. Absent → no live fetch (all
+   * desired rules will be emitted as creates).
+   */
+  repos?: Record<string, RepoConfig>;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub REST API response shapes (only the fields we use)
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of the branch protection GET response we care about. */
+interface GhBranchProtection {
+  required_pull_request_reviews?: {
+    required_approving_review_count?: number;
+    dismiss_stale_reviews?: boolean;
+    require_code_owner_reviews?: boolean;
+  } | null;
+  required_status_checks?: {
+    contexts?: string[];
+    strict?: boolean;
+  } | null;
+  restrictions?: {
+    users: unknown[];
+    teams: unknown[];
+  } | null;
+  allow_force_pushes?: { enabled: boolean } | null;
+  allow_deletions?: { enabled: boolean } | null;
+  required_linear_history?: { enabled: boolean } | null;
+}
+
+// ---------------------------------------------------------------------------
+// Live-state fetch helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the branch protection rule for one branch pattern.
+ * Returns null when the branch/protection does not exist (404).
+ */
+async function fetchBranchProtection(
+  client: AppClient,
+  owner: string,
+  repo: string,
+  branch: string,
+  budget: RateBudget,
+): Promise<LiveBranchProtectionConfig | null> {
+  budget.use(1);
+  let raw: GhBranchProtection;
+  try {
+    raw = await client.request<GhBranchProtection>(
+      "GET",
+      `/repos/${owner}/${repo}/branches/${encodeURIComponent(branch)}/protection`,
+    );
+  } catch (err) {
+    // 404 means no protection rule — not an error, just no live state.
+    if (
+      err instanceof Error &&
+      (err.message.includes("404") || err.message.includes("Branch not protected"))
+    ) {
+      return null;
+    }
+    throw err;
+  }
+
+  const live: LiveBranchProtectionConfig = { pattern: branch };
+
+  if (raw.required_pull_request_reviews !== undefined && raw.required_pull_request_reviews !== null) {
+    live.requirePullRequestReviews = true;
+    live.requiredApprovingReviewCount =
+      raw.required_pull_request_reviews.required_approving_review_count ?? 0;
+    live.dismissStaleReviews = raw.required_pull_request_reviews.dismiss_stale_reviews ?? false;
+    live.requireCodeOwnerReviews =
+      raw.required_pull_request_reviews.require_code_owner_reviews ?? false;
+  } else {
+    live.requirePullRequestReviews = false;
+  }
+
+  if (raw.required_status_checks !== undefined && raw.required_status_checks !== null) {
+    live.requireStatusChecks = true;
+    live.requiredStatusCheckContexts = raw.required_status_checks.contexts ?? [];
+    live.requireBranchesToBeUpToDate = raw.required_status_checks.strict ?? false;
+  } else {
+    live.requireStatusChecks = false;
+  }
+
+  live.restrictPushes = raw.restrictions !== undefined && raw.restrictions !== null;
+  live.allowForcePushes = raw.allow_force_pushes?.enabled ?? false;
+  live.allowDeletions = raw.allow_deletions?.enabled ?? false;
+  live.requireLinearHistory = raw.required_linear_history?.enabled ?? false;
+
+  return live;
+}
+
+// ---------------------------------------------------------------------------
+// BranchProtection API write helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the GitHub API request body for PUT /branches/{branch}/protection.
+ *
+ * The GitHub branch-protection PUT endpoint requires ALL top-level keys to be
+ * present (even if set to null/false). We build a complete body from a
+ * `BranchProtectionConfig`, applying the field only when it is explicitly set.
+ */
+function buildProtectionBody(desired: BranchProtectionConfig): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+
+  // Required pull request reviews
+  if (desired.requirePullRequestReviews === true) {
+    body.required_pull_request_reviews = {
+      required_approving_review_count: desired.requiredApprovingReviewCount ?? 1,
+      dismiss_stale_reviews: desired.dismissStaleReviews ?? false,
+      require_code_owner_reviews: desired.requireCodeOwnerReviews ?? false,
+    };
+  } else {
+    body.required_pull_request_reviews = null;
+  }
+
+  // Required status checks
+  if (desired.requireStatusChecks === true) {
+    body.required_status_checks = {
+      strict: desired.requireBranchesToBeUpToDate ?? false,
+      contexts: desired.requiredStatusCheckContexts ?? [],
+    };
+  } else {
+    body.required_status_checks = null;
+  }
+
+  // Enforce admins (not exposed in our config; default to false)
+  body.enforce_admins = false;
+
+  // Restrictions (not exposed in our config; leave unrestricted)
+  body.restrictions = desired.restrictPushes === true ? { users: [], teams: [] } : null;
+
+  body.allow_force_pushes = desired.allowForcePushes ?? false;
+  body.allow_deletions = desired.allowDeletions ?? false;
+  body.required_linear_history = desired.requireLinearHistory ?? false;
+
+  return body;
+}
+
+// ---------------------------------------------------------------------------
+// BranchProtectionCycle — implements Cycle<BranchProtectionScope>
+// ---------------------------------------------------------------------------
+
+/**
+ * Governance cycle for repository branch-protection rules.
+ *
+ * Reconciles the `branchProtection` array under each repo in the config's
+ * `repos` map. Creates, updates, or deletes branch protection rules on GitHub
+ * to match desired state.
+ *
+ * The cycle leaves repos, branches, and fields absent from the config entirely
+ * untouched (selective-by-omission).
+ */
+export const branchProtectionCycle: Cycle<BranchProtectionScope> = {
+  name: "branch-protection",
+
+  // ── Part 2: fetchLive ──────────────────────────────────────────────────────
+
+  async fetchLive(
+    client: AppClient,
+    scope: BranchProtectionScope,
+    budget: RateBudget,
+  ): Promise<LiveOrgState> {
+    if (budget.exhausted) {
+      const { BudgetExhaustedError } = await import("../reconcile/runner.js");
+      throw new BudgetExhaustedError();
+    }
+
+    const repos = scope.repos;
+    if (!repos || Object.keys(repos).length === 0) {
+      // No repos in scope: return empty state. The diff will emit creates for
+      // all desired rules. Useful when pushing new rules without checking drift.
+      return { repos: {} };
+    }
+
+    return fetchLiveForOrg(client, scope.org, repos, budget);
+  },
+
+  // ── Part 3: buildDesired ───────────────────────────────────────────────────
+
+  buildDesired(orgConfig: OrgConfig, _scope: BranchProtectionScope): OrgConfig {
+    // Keep only the repos that have branchProtection config. Repo-level fields
+    // (description, visibility, etc.) are handled by a separate cycle.
+    if (!orgConfig.repos) return {};
+
+    const repos: Record<string, RepoConfig> = {};
+    for (const [repoName, repoConfig] of Object.entries(orgConfig.repos)) {
+      if (repoConfig.branchProtection && repoConfig.branchProtection.length > 0) {
+        repos[repoName] = { branchProtection: repoConfig.branchProtection };
+      }
+    }
+
+    return { repos };
+  },
+
+  // ── Part 4: apply ──────────────────────────────────────────────────────────
+
+  async apply(
+    client: AppClient,
+    entry: ChangeSetEntry,
+    scope: BranchProtectionScope,
+    budget: RateBudget,
+  ): Promise<void> {
+    if (entry.resourceType !== "branch-protection") {
+      // Safety: this cycle only handles branch-protection entries.
+      return;
+    }
+
+    // key format: "<repo>/<branch-pattern>" (set by diff.ts)
+    const slashIdx = entry.key.indexOf("/");
+    if (slashIdx === -1) {
+      throw new Error(
+        `branch-protection: malformed entry key "${entry.key}" — expected "<repo>/<branch>"`,
+      );
+    }
+    const repoName = entry.key.slice(0, slashIdx);
+    const branchPattern = entry.key.slice(slashIdx + 1);
+    const owner = scope.org;
+
+    const url = `/repos/${owner}/${repoName}/branches/${encodeURIComponent(branchPattern)}/protection`;
+
+    if (entry.kind === "delete") {
+      budget.use(1);
+      await client.request("DELETE", url);
+      return;
+    }
+
+    // create or update — both use PUT (idempotent on GitHub's side)
+    const desired = entry.after as BranchProtectionConfig;
+    const body = buildProtectionBody(desired);
+    budget.use(1);
+    await client.request("PUT", url, body);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// fetchLiveForOrg — low-level helper (also used by the cycle internally)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch live branch-protection state for a specific set of repos.
+ *
+ * Each branch in each repo's `branchProtection` config costs one API call.
+ * The budget is checked before each iteration; when exhausted the
+ * partially-fetched state is returned so the runner can record deferred work.
+ *
+ * Repos with no `branchProtection` config are skipped (zero API calls).
+ * A 404 for a specific branch means no protection rule is live for it —
+ * returned as an absent entry (not an error).
+ */
+export async function fetchLiveForOrg(
+  client: AppClient,
+  orgLogin: string,
+  repos: Record<string, RepoConfig>,
+  budget: RateBudget,
+): Promise<LiveOrgState> {
+  const liveRepos: LiveOrgState["repos"] = {};
+
+  for (const [repoName, repoConfig] of Object.entries(repos)) {
+    if (!repoConfig.branchProtection || repoConfig.branchProtection.length === 0) continue;
+
+    if (budget.exhausted) break;
+
+    const liveBranchProtections: LiveBranchProtectionConfig[] = [];
+
+    for (const bp of repoConfig.branchProtection) {
+      if (budget.exhausted) break;
+      const live = await fetchBranchProtection(client, orgLogin, repoName, bp.pattern, budget);
+      if (live) liveBranchProtections.push(live);
+    }
+
+    liveRepos[repoName] = { branchProtection: liveBranchProtections };
+  }
+
+  return { repos: liveRepos };
+}

--- a/lexicons/github-org/src/cycles/branch-protection.ts
+++ b/lexicons/github-org/src/cycles/branch-protection.ts
@@ -1,5 +1,10 @@
 /**
- * Branch-protection & repository-ruleset cycle.
+ * Classic branch-protection cycle.
+ *
+ * Covers GitHub's CLASSIC branch protection only
+ * (PUT /repos/{owner}/{repo}/branches/{branch}/protection). Repository
+ * rulesets are a separate REST API and are NOT implemented here — they will be
+ * a separate follow-up.
  *
  * This is the TEMPLATE cycle — the first concrete implementation of the `Cycle`
  * interface. Every subsequent cycle should follow this four-part structure:
@@ -89,6 +94,7 @@ interface GhBranchProtection {
     users: unknown[];
     teams: unknown[];
   } | null;
+  enforce_admins?: { enabled: boolean } | boolean | null;
   allow_force_pushes?: { enabled: boolean } | null;
   allow_deletions?: { enabled: boolean } | null;
   required_linear_history?: { enabled: boolean } | null;
@@ -152,6 +158,12 @@ async function fetchBranchProtection(
   live.allowForcePushes = raw.allow_force_pushes?.enabled ?? false;
   live.allowDeletions = raw.allow_deletions?.enabled ?? false;
   live.requireLinearHistory = raw.required_linear_history?.enabled ?? false;
+  // enforce_admins comes back as { enabled } on GitHub's GET response; tolerate
+  // a bare boolean too. Captured so the apply path can preserve it.
+  live.enforceAdmins =
+    typeof raw.enforce_admins === "boolean"
+      ? raw.enforce_admins
+      : raw.enforce_admins?.enabled ?? false;
 
   return live;
 }
@@ -163,43 +175,150 @@ async function fetchBranchProtection(
 /**
  * Build the GitHub API request body for PUT /branches/{branch}/protection.
  *
- * The GitHub branch-protection PUT endpoint requires ALL top-level keys to be
- * present (even if set to null/false). We build a complete body from a
- * `BranchProtectionConfig`, applying the field only when it is explicitly set.
+ * CRITICAL: the GitHub branch-protection PUT endpoint is a FULL-REPLACEMENT
+ * operation — every top-level key omitted from the body is reset to its
+ * disabled/default value. A naive body that nulls undeclared fields would
+ * silently disable PR-review enforcement, let admins bypass protection, etc.
+ *
+ * To honour selective-by-omission in the apply path we do a read-modify-write:
+ *   1. Seed the body from the LIVE protection state (`live`), so every field
+ *      currently set on the branch is echoed back unchanged.
+ *   2. Overlay ONLY the fields the config actually declares (`desired`).
+ *
+ * Net invariant: applying a config that declares field X changes ONLY X; every
+ * other live setting — including `enforce_admins` and
+ * `required_pull_request_reviews` — is preserved at its live value.
+ *
+ * For a CREATE (no `live`) the body contains only declared fields; the four
+ * GitHub-required nullable keys (`required_status_checks`, `enforce_admins`,
+ * `required_pull_request_reviews`, `restrictions`) are filled with GitHub's
+ * documented safe defaults when not declared — never null-to-disable a field
+ * the caller asked to enable.
+ *
+ * @param desired - The branch-protection fields the config declares.
+ * @param live - Live protection snapshot (`before`) for an update, or null/
+ *   undefined for a create.
  */
-function buildProtectionBody(desired: BranchProtectionConfig): Record<string, unknown> {
+function buildProtectionBody(
+  desired: BranchProtectionConfig,
+  live?: LiveBranchProtectionConfig | null,
+): Record<string, unknown> {
   const body: Record<string, unknown> = {};
 
-  // Required pull request reviews
-  if (desired.requirePullRequestReviews === true) {
-    body.required_pull_request_reviews = {
-      required_approving_review_count: desired.requiredApprovingReviewCount ?? 1,
-      dismiss_stale_reviews: desired.dismissStaleReviews ?? false,
-      require_code_owner_reviews: desired.requireCodeOwnerReviews ?? false,
-    };
+  // ── Seed from LIVE state (update path) ───────────────────────────────────
+  // Echo back every field GitHub's PUT would otherwise reset. The four keys
+  // below are required by the endpoint and are nullable; the rest are optional
+  // booleans that default to false when absent.
+  if (live) {
+    body.required_pull_request_reviews =
+      live.requirePullRequestReviews === true
+        ? {
+            required_approving_review_count: live.requiredApprovingReviewCount ?? 0,
+            dismiss_stale_reviews: live.dismissStaleReviews ?? false,
+            require_code_owner_reviews: live.requireCodeOwnerReviews ?? false,
+          }
+        : null;
+
+    body.required_status_checks =
+      live.requireStatusChecks === true
+        ? {
+            strict: live.requireBranchesToBeUpToDate ?? false,
+            contexts: live.requiredStatusCheckContexts ?? [],
+          }
+        : null;
+
+    // enforce_admins is not exposed in our config — preserve the live value.
+    body.enforce_admins = live.enforceAdmins ?? false;
+    body.restrictions = live.restrictPushes === true ? { users: [], teams: [] } : null;
+    body.allow_force_pushes = live.allowForcePushes ?? false;
+    body.allow_deletions = live.allowDeletions ?? false;
+    body.required_linear_history = live.requireLinearHistory ?? false;
   } else {
+    // ── CREATE path: GitHub-required keys at safe defaults ─────────────────
+    // null here means "feature not enabled", which is the safe default for a
+    // brand-new rule — it does not downgrade any existing setting.
     body.required_pull_request_reviews = null;
-  }
-
-  // Required status checks
-  if (desired.requireStatusChecks === true) {
-    body.required_status_checks = {
-      strict: desired.requireBranchesToBeUpToDate ?? false,
-      contexts: desired.requiredStatusCheckContexts ?? [],
-    };
-  } else {
     body.required_status_checks = null;
+    body.enforce_admins = false;
+    body.restrictions = null;
   }
 
-  // Enforce admins (not exposed in our config; default to false)
-  body.enforce_admins = false;
+  // ── Overlay ONLY declared fields ─────────────────────────────────────────
+  // PR reviews: declared → build from declared sub-fields, falling back to the
+  // live sub-value (then a safe default) for any sub-field not declared.
+  if (desired.requirePullRequestReviews !== undefined) {
+    if (desired.requirePullRequestReviews === true) {
+      body.required_pull_request_reviews = {
+        required_approving_review_count:
+          desired.requiredApprovingReviewCount ?? live?.requiredApprovingReviewCount ?? 1,
+        dismiss_stale_reviews:
+          desired.dismissStaleReviews ?? live?.dismissStaleReviews ?? false,
+        require_code_owner_reviews:
+          desired.requireCodeOwnerReviews ?? live?.requireCodeOwnerReviews ?? false,
+      };
+    } else {
+      body.required_pull_request_reviews = null;
+    }
+  } else if (
+    body.required_pull_request_reviews !== null &&
+    typeof body.required_pull_request_reviews === "object"
+  ) {
+    // Not declared, but live had reviews enabled — allow declared sub-fields
+    // to refine the echoed object without flipping the enabled state.
+    const prr = body.required_pull_request_reviews as Record<string, unknown>;
+    if (desired.requiredApprovingReviewCount !== undefined) {
+      prr.required_approving_review_count = desired.requiredApprovingReviewCount;
+    }
+    if (desired.dismissStaleReviews !== undefined) {
+      prr.dismiss_stale_reviews = desired.dismissStaleReviews;
+    }
+    if (desired.requireCodeOwnerReviews !== undefined) {
+      prr.require_code_owner_reviews = desired.requireCodeOwnerReviews;
+    }
+  }
 
-  // Restrictions (not exposed in our config; leave unrestricted)
-  body.restrictions = desired.restrictPushes === true ? { users: [], teams: [] } : null;
+  // Status checks: declared → build from declared sub-fields, falling back to
+  // live for undeclared sub-fields.
+  if (desired.requireStatusChecks !== undefined) {
+    if (desired.requireStatusChecks === true) {
+      body.required_status_checks = {
+        strict: desired.requireBranchesToBeUpToDate ?? live?.requireBranchesToBeUpToDate ?? false,
+        contexts:
+          desired.requiredStatusCheckContexts ?? live?.requiredStatusCheckContexts ?? [],
+      };
+    } else {
+      body.required_status_checks = null;
+    }
+  } else if (
+    body.required_status_checks !== null &&
+    typeof body.required_status_checks === "object"
+  ) {
+    const rsc = body.required_status_checks as Record<string, unknown>;
+    if (desired.requireBranchesToBeUpToDate !== undefined) {
+      rsc.strict = desired.requireBranchesToBeUpToDate;
+    }
+    if (desired.requiredStatusCheckContexts !== undefined) {
+      rsc.contexts = desired.requiredStatusCheckContexts;
+    }
+  }
 
-  body.allow_force_pushes = desired.allowForcePushes ?? false;
-  body.allow_deletions = desired.allowDeletions ?? false;
-  body.required_linear_history = desired.requireLinearHistory ?? false;
+  // Restrictions: only when declared.
+  if (desired.restrictPushes !== undefined) {
+    body.restrictions = desired.restrictPushes === true ? { users: [], teams: [] } : null;
+  }
+
+  // Optional boolean flags: only set when declared. When undeclared the value
+  // already carries the live setting (update) or is left unset (create, where
+  // GitHub treats absence as the documented default).
+  if (desired.allowForcePushes !== undefined) {
+    body.allow_force_pushes = desired.allowForcePushes;
+  }
+  if (desired.allowDeletions !== undefined) {
+    body.allow_deletions = desired.allowDeletions;
+  }
+  if (desired.requireLinearHistory !== undefined) {
+    body.required_linear_history = desired.requireLinearHistory;
+  }
 
   return body;
 }
@@ -292,9 +411,23 @@ export const branchProtectionCycle: Cycle<BranchProtectionScope> = {
       return;
     }
 
-    // create or update — both use PUT (idempotent on GitHub's side)
+    // create or update — both use PUT (idempotent on GitHub's side).
     const desired = entry.after as BranchProtectionConfig;
-    const body = buildProtectionBody(desired);
+
+    // For an update, GitHub's PUT is a FULL REPLACEMENT, so we must echo back
+    // every undeclared live field. Prefer the change-set entry's `before`
+    // snapshot (the diff already carries it). If it is missing — e.g. the entry
+    // was produced without a live fetch — fetch live protection now and charge
+    // the budget for it, so we never null-to-disable an undeclared field.
+    let live: LiveBranchProtectionConfig | null = null;
+    if (entry.kind === "update") {
+      live = (entry.before as LiveBranchProtectionConfig | undefined) ?? null;
+      if (!live) {
+        live = await fetchBranchProtection(client, owner, repoName, branchPattern, budget);
+      }
+    }
+
+    const body = buildProtectionBody(desired, live);
     budget.use(1);
     await client.request("PUT", url, body);
   },

--- a/lexicons/github-org/src/index.ts
+++ b/lexicons/github-org/src/index.ts
@@ -68,3 +68,6 @@ export type {
   RunReconcileOptions,
 } from "./reconcile/runner.js";
 export { runReconcile, BudgetExhaustedError } from "./reconcile/runner.js";
+
+// Cycles
+export { branchProtectionCycle, fetchLiveForOrg } from "./cycles/branch-protection.js";

--- a/lexicons/github-org/src/reconcile/diff.ts
+++ b/lexicons/github-org/src/reconcile/diff.ts
@@ -145,6 +145,12 @@ export interface LiveBranchProtectionConfig {
   allowForcePushes?: boolean;
   allowDeletions?: boolean;
   requireLinearHistory?: boolean;
+  /**
+   * Whether admins are subject to the protection. Not exposed in the desired
+   * config (so never diffed) but captured live so the apply path can preserve
+   * it across a full-replacement PUT.
+   */
+  enforceAdmins?: boolean;
 }
 
 export interface LiveRepoConfig {

--- a/lexicons/github-org/tsconfig.json
+++ b/lexicons/github-org/tsconfig.json
@@ -4,5 +4,6 @@
     "rootDir": "./src",
     "outDir": "./dist"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/dist/**", "**/docs/**"]
 }


### PR DESCRIPTION
Closes #455.

## Summary

- Implements `branchProtectionCycle` as `Cycle<BranchProtectionScope>` — the first concrete cycle and the template every subsequent cycle will copy
- Four-part structure: `BranchProtectionConfig` config shape (already in `types.ts`) → `fetchLive` (budget-aware, per-branch GET) → `buildDesired` (pure, strips non-BP repo fields) → `apply` (PUT for create/update, DELETE for delete)
- `fetchLiveForOrg` helper for accurate live-state fetching with scope-supplied repos
- Exports `branchProtectionCycle` and `fetchLiveForOrg` from `src/index.ts`
- `src/cycles/README.md` documents the four-part pattern as the copy-template guide for all future cycles

## Test plan

- [x] `buildDesired`: omits repos without branchProtection, keeps only BP fields (selective-by-omission)
- [x] `fetchLive` / `fetchLiveForOrg`: maps GitHub API response to `LiveBranchProtectionConfig`, treats 404 as no protection, charges budget per branch
- [x] diff integration: emits create / update / delete entries correctly
- [x] `apply`: correct HTTP method (PUT/DELETE), URL-encodes branch patterns with slashes, charges budget once per call, skips foreign resource types, throws on malformed key
- [x] Runner integration: dry-run plan shows accurate counts, apply mutates correctly, `removalDeltaCap` guardrail trips when many rules removed
- [x] `npx tsc --noEmit -p lexicons/github-org/tsconfig.json` — clean
- [x] `npx vitest run lexicons/github-org` — 136 tests pass (24 new)