### PR TITLE
feat(github-org): dump live org state to desired-state config

### DIFF
--- a/lexicons/github-org/src/index.ts
+++ b/lexicons/github-org/src/index.ts
@@ -71,3 +71,7 @@ export { runReconcile, BudgetExhaustedError } from "./reconcile/runner.js";
 
 // Cycles
 export { branchProtectionCycle, fetchLiveForOrg } from "./cycles/branch-protection.js";
+
+// Reconcile: dump (export live state to desired-state config)
+export type { DumpOrgOptions, DumpResult } from "./reconcile/dump.js";
+export { dumpOrg, serializeToYaml } from "./reconcile/dump.js";

--- a/lexicons/github-org/src/reconcile/dump.test.ts
+++ b/lexicons/github-org/src/reconcile/dump.test.ts
@@ -13,11 +13,33 @@
 import { describe, it, expect } from "vitest";
 import { dumpOrg, serializeToYaml } from "./dump.js";
 import { diff } from "./diff.js";
-import type { LiveOrgState, LiveBranchProtectionConfig } from "./diff.js";
+import type { LiveOrgState } from "./diff.js";
+import { fetchLiveForOrg } from "../cycles/branch-protection.js";
 import { loadGovernanceConfig } from "../config/load.js";
 import type { AppClient } from "../auth/app-client.js";
+import type { RepoConfig } from "../config/types.js";
 import type { RateBudget } from "./runner.js";
 import { BudgetExhaustedError } from "./runner.js";
+
+/**
+ * Derive the live snapshot from the SAME mock client used for the dump, by
+ * running the cycle's real fetch path (`fetchLiveForOrg` →
+ * `fetchBranchProtection`). This yields the actual — possibly sparse — shape
+ * GitHub responses normalize to in production, instead of a hand-populated
+ * fixture with every sub-field set. Round-trip tests MUST use this so they
+ * can't mask normalization drift between dump and the cycle.
+ */
+async function fetchLiveFromMock(
+  client: AppClient,
+  org: string,
+  repoBranches: Record<string, string[]>,
+): Promise<LiveOrgState> {
+  const repoStubs: Record<string, RepoConfig> = {};
+  for (const [repo, branches] of Object.entries(repoBranches)) {
+    repoStubs[repo] = { branchProtection: branches.map((pattern) => ({ pattern })) };
+  }
+  return fetchLiveForOrg(client, org, repoStubs, makeBudget());
+}
 
 // ---------------------------------------------------------------------------
 // Mock helpers
@@ -70,43 +92,6 @@ function makeBudget(initial = 500): RateBudget {
     },
   };
 }
-
-// ---------------------------------------------------------------------------
-// Shared live state fixture
-// ---------------------------------------------------------------------------
-
-/** A rich live branch-protection rule covering all diffed fields. */
-const LIVE_BP_FULL: LiveBranchProtectionConfig = {
-  pattern: "main",
-  requirePullRequestReviews: true,
-  requiredApprovingReviewCount: 2,
-  dismissStaleReviews: true,
-  requireCodeOwnerReviews: true,
-  requireStatusChecks: true,
-  requiredStatusCheckContexts: ["ci/build", "ci/lint"],
-  requireBranchesToBeUpToDate: true,
-  restrictPushes: false,
-  allowForcePushes: false,
-  allowDeletions: false,
-  requireLinearHistory: true,
-  enforceAdmins: true, // captured live but NOT in config type — must be omitted from dump
-};
-
-/** Minimal branch-protection rule (most fields false/empty). */
-const LIVE_BP_MINIMAL: LiveBranchProtectionConfig = {
-  pattern: "develop",
-  requirePullRequestReviews: false,
-  requiredApprovingReviewCount: 0,
-  dismissStaleReviews: false,
-  requireCodeOwnerReviews: false,
-  requireStatusChecks: false,
-  requiredStatusCheckContexts: [],
-  requireBranchesToBeUpToDate: false,
-  restrictPushes: false,
-  allowForcePushes: false,
-  allowDeletions: true,
-  requireLinearHistory: false,
-};
 
 // ---------------------------------------------------------------------------
 // 1. dumpOrg: config validates under loadGovernanceConfig
@@ -189,36 +174,34 @@ describe("dumpOrg — config validates under loadGovernanceConfig", () => {
 // ---------------------------------------------------------------------------
 
 describe("dumpOrg — round-trip no-op", () => {
-  it("full protection rule: diff is empty after dump", async () => {
-    // Live state: one repo with a fully-configured branch protection rule
-    const live: LiveOrgState = {
-      repos: {
-        "my-repo": {
-          branchProtection: [LIVE_BP_FULL],
-        },
-      },
-    };
+  // These tests derive `live` from the SAME mock client via the cycle's real
+  // `fetchLiveForOrg`/`fetchBranchProtection` path — NOT from hand-populated
+  // fixtures. This guarantees the comparison uses the real (possibly-sparse)
+  // shape GitHub responses normalize to, so the tests cannot mask drift between
+  // dump's normalization and the cycle's normalization.
 
-    // Build a mock client that returns the live BP via the GitHub API shape
+  it("full protection rule: diff is empty after dump", async () => {
     const client = makeMockClient({
       "GET /repos/test-org/my-repo/branches": [{ name: "main" }],
       "GET /repos/test-org/my-repo/branches/main/protection": {
         required_pull_request_reviews: {
-          required_approving_review_count: LIVE_BP_FULL.requiredApprovingReviewCount,
-          dismiss_stale_reviews: LIVE_BP_FULL.dismissStaleReviews,
-          require_code_owner_reviews: LIVE_BP_FULL.requireCodeOwnerReviews,
+          required_approving_review_count: 2,
+          dismiss_stale_reviews: true,
+          require_code_owner_reviews: true,
         },
         required_status_checks: {
-          contexts: LIVE_BP_FULL.requiredStatusCheckContexts,
-          strict: LIVE_BP_FULL.requireBranchesToBeUpToDate,
+          contexts: ["ci/build", "ci/lint"],
+          strict: true,
         },
         restrictions: null,
-        allow_force_pushes: { enabled: LIVE_BP_FULL.allowForcePushes },
-        allow_deletions: { enabled: LIVE_BP_FULL.allowDeletions },
-        required_linear_history: { enabled: LIVE_BP_FULL.requireLinearHistory },
-        enforce_admins: { enabled: LIVE_BP_FULL.enforceAdmins },
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: false },
+        required_linear_history: { enabled: true },
+        enforce_admins: { enabled: true },
       },
     });
+
+    const live = await fetchLiveFromMock(client, "test-org", { "my-repo": ["main"] });
 
     const { config } = await dumpOrg(client, "test-org", {
       repos: ["my-repo"],
@@ -231,15 +214,12 @@ describe("dumpOrg — round-trip no-op", () => {
     expect(changeSet.entries).toHaveLength(0);
   });
 
-  it("minimal protection rule: diff is empty after dump", async () => {
-    const live: LiveOrgState = {
-      repos: {
-        "simple-repo": {
-          branchProtection: [LIVE_BP_MINIMAL],
-        },
-      },
-    };
-
+  it("branch with NO PR-review requirement: diff is empty after dump (regression for #454)", async () => {
+    // required_pull_request_reviews is null — the majority case. The live
+    // snapshot from fetchBranchProtection leaves requiredApprovingReviewCount,
+    // dismissStaleReviews, and requireCodeOwnerReviews UNDEFINED. dump must NOT
+    // emit those sub-fields (as `0`/`false`), or the diff would compare e.g.
+    // `0` vs `undefined` and produce a spurious update for every such branch.
     const client = makeMockClient({
       "GET /repos/test-org/simple-repo/branches": [{ name: "develop" }],
       "GET /repos/test-org/simple-repo/branches/develop/protection": {
@@ -253,6 +233,17 @@ describe("dumpOrg — round-trip no-op", () => {
       },
     });
 
+    // Live is the REAL sparse shape — requiredApprovingReviewCount etc. absent.
+    const live = await fetchLiveFromMock(client, "test-org", { "simple-repo": ["develop"] });
+
+    const liveBp = live.repos!["simple-repo"]!.branchProtection![0]!;
+    // Sanity-guard the fixture: the cycle must leave these undefined so this
+    // test actually exercises the 0-vs-undefined regression path.
+    expect(liveBp.requirePullRequestReviews).toBe(false);
+    expect(liveBp).not.toHaveProperty("requiredApprovingReviewCount");
+    expect(liveBp.requireStatusChecks).toBe(false);
+    expect(liveBp).not.toHaveProperty("requiredStatusCheckContexts");
+
     const { config } = await dumpOrg(client, "test-org", {
       repos: ["simple-repo"],
       budget: makeBudget(),
@@ -265,32 +256,6 @@ describe("dumpOrg — round-trip no-op", () => {
   });
 
   it("multiple repos and multiple branches: diff is empty after dump", async () => {
-    const live: LiveOrgState = {
-      repos: {
-        "repo-a": {
-          branchProtection: [LIVE_BP_FULL, LIVE_BP_MINIMAL],
-        },
-        "repo-b": {
-          branchProtection: [
-            {
-              pattern: "main",
-              requirePullRequestReviews: false,
-              requiredApprovingReviewCount: 0,
-              dismissStaleReviews: false,
-              requireCodeOwnerReviews: false,
-              requireStatusChecks: true,
-              requiredStatusCheckContexts: ["lint", "test"],
-              requireBranchesToBeUpToDate: false,
-              restrictPushes: true,
-              allowForcePushes: false,
-              allowDeletions: false,
-              requireLinearHistory: false,
-            },
-          ],
-        },
-      },
-    };
-
     const client = makeMockClient({
       "GET /repos/test-org/repo-a/branches": [{ name: "main" }, { name: "develop" }],
       "GET /repos/test-org/repo-a/branches/main/protection": {
@@ -333,6 +298,11 @@ describe("dumpOrg — round-trip no-op", () => {
       },
     });
 
+    const live = await fetchLiveFromMock(client, "test-org", {
+      "repo-a": ["main", "develop"],
+      "repo-b": ["main"],
+    });
+
     const { config } = await dumpOrg(client, "test-org", {
       repos: ["repo-a", "repo-b"],
       budget: makeBudget(),
@@ -345,13 +315,6 @@ describe("dumpOrg — round-trip no-op", () => {
   });
 
   it("unprotected repo: not emitted, no diff entries", async () => {
-    const live: LiveOrgState = {
-      repos: {
-        "protected": { branchProtection: [LIVE_BP_FULL] },
-        "unprotected": { branchProtection: [] },
-      },
-    };
-
     const client = makeMockClient({
       "GET /repos/test-org/protected/branches": [{ name: "main" }],
       "GET /repos/test-org/protected/branches/main/protection": {
@@ -383,6 +346,13 @@ describe("dumpOrg — round-trip no-op", () => {
       }
       return origRequest(method, path, body);
     };
+
+    // Live derived from the same mock: "protected" has a rule, "unprotected"
+    // 404s → no live rule for it.
+    const live = await fetchLiveFromMock(client, "test-org", {
+      "protected": ["main"],
+      "unprotected": ["main"],
+    });
 
     const { config } = await dumpOrg(client, "test-org", {
       repos: ["protected", "unprotected"],

--- a/lexicons/github-org/src/reconcile/dump.test.ts
+++ b/lexicons/github-org/src/reconcile/dump.test.ts
@@ -1,0 +1,638 @@
+/**
+ * Tests for dumpOrg and serializeToYaml.
+ *
+ * All tests use a mock AppClient — no network calls.
+ * Coverage:
+ *   - dumpOrg: produces a GovernanceConfig that passes loadGovernanceConfig
+ *   - dumpOrg: round-trip no-op — diff(dumped, live) yields zero changes
+ *   - dumpOrg: omits repos with no supported resources
+ *   - dumpOrg: accepts an explicit repos list (no extra list call)
+ *   - serializeToYaml: basic YAML shape correctness
+ */
+
+import { describe, it, expect } from "vitest";
+import { dumpOrg, serializeToYaml } from "./dump.js";
+import { diff } from "./diff.js";
+import type { LiveOrgState, LiveBranchProtectionConfig } from "./diff.js";
+import { loadGovernanceConfig } from "../config/load.js";
+import type { AppClient } from "../auth/app-client.js";
+import type { RateBudget } from "./runner.js";
+import { BudgetExhaustedError } from "./runner.js";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+interface MockCall {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+interface MockClient extends AppClient {
+  calls: MockCall[];
+  responses: Map<string, unknown>;
+}
+
+function makeMockClient(responses: Record<string, unknown> = {}): MockClient {
+  const calls: MockCall[] = [];
+  const responseMap = new Map(Object.entries(responses));
+  return {
+    calls,
+    responses: responseMap,
+    async request<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
+      calls.push({ method, path, body });
+      // Strip query params for lookup to support paginated calls
+      const baseKey = `${method} ${path.split("?")[0]!}`;
+      const fullKey = `${method} ${path}`;
+      if (responseMap.has(fullKey)) return responseMap.get(fullKey) as T;
+      if (responseMap.has(baseKey)) return responseMap.get(baseKey) as T;
+      // Default: return empty array for list endpoints, {} for others
+      if (path.includes("/branches") && !path.includes("/protection")) return [] as unknown as T;
+      if (path.includes("/repos?")) return [] as unknown as T;
+      return {} as T;
+    },
+  };
+}
+
+function makeBudget(initial = 500): RateBudget {
+  let remaining = initial;
+  return {
+    get remaining() {
+      return remaining;
+    },
+    get exhausted() {
+      return remaining <= 0;
+    },
+    use(n = 1) {
+      if (remaining <= 0) throw new BudgetExhaustedError();
+      remaining = Math.max(0, remaining - n);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared live state fixture
+// ---------------------------------------------------------------------------
+
+/** A rich live branch-protection rule covering all diffed fields. */
+const LIVE_BP_FULL: LiveBranchProtectionConfig = {
+  pattern: "main",
+  requirePullRequestReviews: true,
+  requiredApprovingReviewCount: 2,
+  dismissStaleReviews: true,
+  requireCodeOwnerReviews: true,
+  requireStatusChecks: true,
+  requiredStatusCheckContexts: ["ci/build", "ci/lint"],
+  requireBranchesToBeUpToDate: true,
+  restrictPushes: false,
+  allowForcePushes: false,
+  allowDeletions: false,
+  requireLinearHistory: true,
+  enforceAdmins: true, // captured live but NOT in config type — must be omitted from dump
+};
+
+/** Minimal branch-protection rule (most fields false/empty). */
+const LIVE_BP_MINIMAL: LiveBranchProtectionConfig = {
+  pattern: "develop",
+  requirePullRequestReviews: false,
+  requiredApprovingReviewCount: 0,
+  dismissStaleReviews: false,
+  requireCodeOwnerReviews: false,
+  requireStatusChecks: false,
+  requiredStatusCheckContexts: [],
+  requireBranchesToBeUpToDate: false,
+  restrictPushes: false,
+  allowForcePushes: false,
+  allowDeletions: true,
+  requireLinearHistory: false,
+};
+
+// ---------------------------------------------------------------------------
+// 1. dumpOrg: config validates under loadGovernanceConfig
+// ---------------------------------------------------------------------------
+
+describe("dumpOrg — config validates under loadGovernanceConfig", () => {
+  it("produces a valid GovernanceConfig when a repo has branch protection", async () => {
+    const client = makeMockClient({
+      "GET /orgs/test-org/repos": [{ name: "my-repo" }],
+      "GET /repos/test-org/my-repo/branches": [{ name: "main" }],
+      "GET /repos/test-org/my-repo/branches/main/protection": {
+        required_pull_request_reviews: {
+          required_approving_review_count: 2,
+          dismiss_stale_reviews: true,
+          require_code_owner_reviews: true,
+        },
+        required_status_checks: {
+          contexts: ["ci/build", "ci/lint"],
+          strict: true,
+        },
+        restrictions: null,
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: false },
+        required_linear_history: { enabled: true },
+        enforce_admins: { enabled: true },
+      },
+    });
+
+    const result = await dumpOrg(client, "test-org", { budget: makeBudget() });
+
+    // Must not throw
+    const loaded = loadGovernanceConfig(result.config);
+    expect(loaded).toBeDefined();
+    expect(loaded.orgs["test-org"]).toBeDefined();
+  });
+
+  it("produces a valid GovernanceConfig even when no repos have protection", async () => {
+    const client = makeMockClient({
+      "GET /orgs/test-org/repos": [{ name: "bare-repo" }],
+      // branches returns empty → nothing to probe
+      "GET /repos/test-org/bare-repo/branches": [],
+    });
+
+    const result = await dumpOrg(client, "test-org", { budget: makeBudget() });
+    const loaded = loadGovernanceConfig(result.config);
+    expect(loaded.orgs["test-org"]).toBeDefined();
+    // No repos to manage
+    expect(loaded.orgs["test-org"]!.repos).toBeUndefined();
+  });
+
+  it("produces a valid GovernanceConfig when repos list is provided explicitly", async () => {
+    const client = makeMockClient({
+      "GET /repos/test-org/api/branches": [{ name: "main" }],
+      "GET /repos/test-org/api/branches/main/protection": {
+        required_pull_request_reviews: null,
+        required_status_checks: null,
+        restrictions: null,
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: false },
+        required_linear_history: { enabled: false },
+        enforce_admins: { enabled: false },
+      },
+    });
+
+    const result = await dumpOrg(client, "test-org", {
+      repos: ["api"],
+      budget: makeBudget(),
+    });
+
+    // No org list call made
+    expect(client.calls.some((c) => c.path.includes("/orgs/test-org/repos"))).toBe(false);
+
+    const loaded = loadGovernanceConfig(result.config);
+    expect(loaded).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Round-trip no-op: diff(dump, live) === empty
+// ---------------------------------------------------------------------------
+
+describe("dumpOrg — round-trip no-op", () => {
+  it("full protection rule: diff is empty after dump", async () => {
+    // Live state: one repo with a fully-configured branch protection rule
+    const live: LiveOrgState = {
+      repos: {
+        "my-repo": {
+          branchProtection: [LIVE_BP_FULL],
+        },
+      },
+    };
+
+    // Build a mock client that returns the live BP via the GitHub API shape
+    const client = makeMockClient({
+      "GET /repos/test-org/my-repo/branches": [{ name: "main" }],
+      "GET /repos/test-org/my-repo/branches/main/protection": {
+        required_pull_request_reviews: {
+          required_approving_review_count: LIVE_BP_FULL.requiredApprovingReviewCount,
+          dismiss_stale_reviews: LIVE_BP_FULL.dismissStaleReviews,
+          require_code_owner_reviews: LIVE_BP_FULL.requireCodeOwnerReviews,
+        },
+        required_status_checks: {
+          contexts: LIVE_BP_FULL.requiredStatusCheckContexts,
+          strict: LIVE_BP_FULL.requireBranchesToBeUpToDate,
+        },
+        restrictions: null,
+        allow_force_pushes: { enabled: LIVE_BP_FULL.allowForcePushes },
+        allow_deletions: { enabled: LIVE_BP_FULL.allowDeletions },
+        required_linear_history: { enabled: LIVE_BP_FULL.requireLinearHistory },
+        enforce_admins: { enabled: LIVE_BP_FULL.enforceAdmins },
+      },
+    });
+
+    const { config } = await dumpOrg(client, "test-org", {
+      repos: ["my-repo"],
+      budget: makeBudget(),
+    });
+
+    const orgConfig = config.orgs["test-org"]!;
+    const changeSet = diff("test-org", orgConfig, live);
+
+    expect(changeSet.entries).toHaveLength(0);
+  });
+
+  it("minimal protection rule: diff is empty after dump", async () => {
+    const live: LiveOrgState = {
+      repos: {
+        "simple-repo": {
+          branchProtection: [LIVE_BP_MINIMAL],
+        },
+      },
+    };
+
+    const client = makeMockClient({
+      "GET /repos/test-org/simple-repo/branches": [{ name: "develop" }],
+      "GET /repos/test-org/simple-repo/branches/develop/protection": {
+        required_pull_request_reviews: null,
+        required_status_checks: null,
+        restrictions: null,
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: true },
+        required_linear_history: { enabled: false },
+        enforce_admins: { enabled: false },
+      },
+    });
+
+    const { config } = await dumpOrg(client, "test-org", {
+      repos: ["simple-repo"],
+      budget: makeBudget(),
+    });
+
+    const orgConfig = config.orgs["test-org"]!;
+    const changeSet = diff("test-org", orgConfig, live);
+
+    expect(changeSet.entries).toHaveLength(0);
+  });
+
+  it("multiple repos and multiple branches: diff is empty after dump", async () => {
+    const live: LiveOrgState = {
+      repos: {
+        "repo-a": {
+          branchProtection: [LIVE_BP_FULL, LIVE_BP_MINIMAL],
+        },
+        "repo-b": {
+          branchProtection: [
+            {
+              pattern: "main",
+              requirePullRequestReviews: false,
+              requiredApprovingReviewCount: 0,
+              dismissStaleReviews: false,
+              requireCodeOwnerReviews: false,
+              requireStatusChecks: true,
+              requiredStatusCheckContexts: ["lint", "test"],
+              requireBranchesToBeUpToDate: false,
+              restrictPushes: true,
+              allowForcePushes: false,
+              allowDeletions: false,
+              requireLinearHistory: false,
+            },
+          ],
+        },
+      },
+    };
+
+    const client = makeMockClient({
+      "GET /repos/test-org/repo-a/branches": [{ name: "main" }, { name: "develop" }],
+      "GET /repos/test-org/repo-a/branches/main/protection": {
+        required_pull_request_reviews: {
+          required_approving_review_count: 2,
+          dismiss_stale_reviews: true,
+          require_code_owner_reviews: true,
+        },
+        required_status_checks: {
+          contexts: ["ci/build", "ci/lint"],
+          strict: true,
+        },
+        restrictions: null,
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: false },
+        required_linear_history: { enabled: true },
+        enforce_admins: { enabled: true },
+      },
+      "GET /repos/test-org/repo-a/branches/develop/protection": {
+        required_pull_request_reviews: null,
+        required_status_checks: null,
+        restrictions: null,
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: true },
+        required_linear_history: { enabled: false },
+        enforce_admins: { enabled: false },
+      },
+      "GET /repos/test-org/repo-b/branches": [{ name: "main" }],
+      "GET /repos/test-org/repo-b/branches/main/protection": {
+        required_pull_request_reviews: null,
+        required_status_checks: {
+          contexts: ["lint", "test"],
+          strict: false,
+        },
+        restrictions: { users: ["alice"], teams: [] },
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: false },
+        required_linear_history: { enabled: false },
+        enforce_admins: { enabled: false },
+      },
+    });
+
+    const { config } = await dumpOrg(client, "test-org", {
+      repos: ["repo-a", "repo-b"],
+      budget: makeBudget(),
+    });
+
+    const orgConfig = config.orgs["test-org"]!;
+    const changeSet = diff("test-org", orgConfig, live);
+
+    expect(changeSet.entries).toHaveLength(0);
+  });
+
+  it("unprotected repo: not emitted, no diff entries", async () => {
+    const live: LiveOrgState = {
+      repos: {
+        "protected": { branchProtection: [LIVE_BP_FULL] },
+        "unprotected": { branchProtection: [] },
+      },
+    };
+
+    const client = makeMockClient({
+      "GET /repos/test-org/protected/branches": [{ name: "main" }],
+      "GET /repos/test-org/protected/branches/main/protection": {
+        required_pull_request_reviews: {
+          required_approving_review_count: 2,
+          dismiss_stale_reviews: true,
+          require_code_owner_reviews: true,
+        },
+        required_status_checks: {
+          contexts: ["ci/build", "ci/lint"],
+          strict: true,
+        },
+        restrictions: null,
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: false },
+        required_linear_history: { enabled: true },
+        enforce_admins: { enabled: true },
+      },
+      "GET /repos/test-org/unprotected/branches": [{ name: "main" }],
+      // protection returns 404 → fetchBranchProtection returns null → skipped
+    });
+
+    // Override mock to return 404 for unprotected branch
+    const origRequest = client.request.bind(client);
+    client.request = async <T = unknown>(method: string, path: string, body?: unknown): Promise<T> => {
+      if (path.includes("unprotected") && path.includes("/protection")) {
+        client.calls.push({ method, path, body });
+        throw new Error(`GET ${path} returned 404: Branch not protected`);
+      }
+      return origRequest(method, path, body);
+    };
+
+    const { config } = await dumpOrg(client, "test-org", {
+      repos: ["protected", "unprotected"],
+      budget: makeBudget(),
+    });
+
+    // "unprotected" has no protection rules → not in the dump
+    expect(config.orgs["test-org"]!.repos).not.toHaveProperty("unprotected");
+
+    // Diff against live: the "protected" repo matches; "unprotected" is not
+    // in the desired config, so selective-by-omission applies — no deletes.
+    const changeSet = diff("test-org", config.orgs["test-org"]!, live);
+    expect(changeSet.entries).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. dumpOrg: omission and selective behaviour
+// ---------------------------------------------------------------------------
+
+describe("dumpOrg — selective-by-omission", () => {
+  it("emits only repos that have supported live resources", async () => {
+    const client = makeMockClient({
+      "GET /orgs/test-org/repos": [{ name: "active" }, { name: "idle" }],
+      "GET /repos/test-org/active/branches": [{ name: "main" }],
+      "GET /repos/test-org/active/branches/main/protection": {
+        required_pull_request_reviews: {
+          required_approving_review_count: 1,
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false,
+        },
+        required_status_checks: null,
+        restrictions: null,
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: false },
+        required_linear_history: { enabled: false },
+        enforce_admins: { enabled: false },
+      },
+      "GET /repos/test-org/idle/branches": [], // no branches
+    });
+
+    const { config } = await dumpOrg(client, "test-org", { budget: makeBudget() });
+
+    const repos = config.orgs["test-org"]!.repos ?? {};
+    expect(Object.keys(repos)).toContain("active");
+    expect(Object.keys(repos)).not.toContain("idle");
+  });
+
+  it("enforceAdmins is NOT in the emitted config (not a config field)", async () => {
+    const client = makeMockClient({
+      "GET /repos/test-org/my-repo/branches": [{ name: "main" }],
+      "GET /repos/test-org/my-repo/branches/main/protection": {
+        required_pull_request_reviews: null,
+        required_status_checks: null,
+        restrictions: null,
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: false },
+        required_linear_history: { enabled: false },
+        enforce_admins: { enabled: true }, // captured live but not a config field
+      },
+    });
+
+    const { config } = await dumpOrg(client, "test-org", {
+      repos: ["my-repo"],
+      budget: makeBudget(),
+    });
+
+    const bp = config.orgs["test-org"]!.repos!["my-repo"]!.branchProtection![0]!;
+    expect(bp).not.toHaveProperty("enforceAdmins");
+  });
+
+  it("explicit repos list skips the org repo-list API call", async () => {
+    const client = makeMockClient({
+      "GET /repos/test-org/specific-repo/branches": [{ name: "main" }],
+      "GET /repos/test-org/specific-repo/branches/main/protection": {
+        required_pull_request_reviews: null,
+        required_status_checks: null,
+        restrictions: null,
+        allow_force_pushes: { enabled: false },
+        allow_deletions: { enabled: false },
+        required_linear_history: { enabled: false },
+        enforce_admins: { enabled: false },
+      },
+    });
+
+    await dumpOrg(client, "test-org", {
+      repos: ["specific-repo"],
+      budget: makeBudget(),
+    });
+
+    const orgListCalls = client.calls.filter((c) =>
+      c.method === "GET" && c.path.includes("/orgs/test-org/repos"),
+    );
+    expect(orgListCalls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. serializeToYaml
+// ---------------------------------------------------------------------------
+
+describe("serializeToYaml", () => {
+  it("produces YAML with orgs top-level key", () => {
+    const config = {
+      orgs: {
+        "my-org": {},
+      },
+    };
+    const yaml = serializeToYaml(config);
+    expect(yaml).toContain("orgs:");
+    expect(yaml).toContain("my-org:");
+  });
+
+  it("includes branchProtection rules in YAML output", () => {
+    const config = {
+      orgs: {
+        "my-org": {
+          repos: {
+            "api": {
+              branchProtection: [
+                {
+                  pattern: "main",
+                  requirePullRequestReviews: true,
+                  requiredApprovingReviewCount: 2,
+                  dismissStaleReviews: false,
+                  requireCodeOwnerReviews: false,
+                  requireStatusChecks: false,
+                  requiredStatusCheckContexts: [],
+                  requireBranchesToBeUpToDate: false,
+                  restrictPushes: false,
+                  allowForcePushes: false,
+                  allowDeletions: false,
+                  requireLinearHistory: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const yaml = serializeToYaml(config);
+    expect(yaml).toContain("branchProtection:");
+    expect(yaml).toContain("pattern: main");
+    expect(yaml).toContain("requirePullRequestReviews: true");
+    expect(yaml).toContain("requiredApprovingReviewCount: 2");
+  });
+
+  it("serializes status check contexts as a list", () => {
+    const config = {
+      orgs: {
+        "my-org": {
+          repos: {
+            "svc": {
+              branchProtection: [
+                {
+                  pattern: "main",
+                  requirePullRequestReviews: false,
+                  requiredApprovingReviewCount: 0,
+                  dismissStaleReviews: false,
+                  requireCodeOwnerReviews: false,
+                  requireStatusChecks: true,
+                  requiredStatusCheckContexts: ["ci/build", "ci/test"],
+                  requireBranchesToBeUpToDate: false,
+                  restrictPushes: false,
+                  allowForcePushes: false,
+                  allowDeletions: false,
+                  requireLinearHistory: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const yaml = serializeToYaml(config);
+    expect(yaml).toContain("requiredStatusCheckContexts:");
+    expect(yaml).toContain("- ci/build");
+    expect(yaml).toContain("- ci/test");
+  });
+
+  it("serializes empty status check contexts as inline []", () => {
+    const config = {
+      orgs: {
+        "my-org": {
+          repos: {
+            "svc": {
+              branchProtection: [
+                {
+                  pattern: "main",
+                  requirePullRequestReviews: false,
+                  requiredApprovingReviewCount: 0,
+                  dismissStaleReviews: false,
+                  requireCodeOwnerReviews: false,
+                  requireStatusChecks: false,
+                  requiredStatusCheckContexts: [],
+                  requireBranchesToBeUpToDate: false,
+                  restrictPushes: false,
+                  allowForcePushes: false,
+                  allowDeletions: false,
+                  requireLinearHistory: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const yaml = serializeToYaml(config);
+    expect(yaml).toContain("requiredStatusCheckContexts: []");
+  });
+
+  it("YAML result string is parseable back to the same structure (basic sanity)", () => {
+    const config = {
+      orgs: {
+        "my-org": {
+          repos: {
+            "api": {
+              branchProtection: [
+                {
+                  pattern: "main",
+                  requirePullRequestReviews: true,
+                  requiredApprovingReviewCount: 1,
+                  dismissStaleReviews: false,
+                  requireCodeOwnerReviews: false,
+                  requireStatusChecks: false,
+                  requiredStatusCheckContexts: [],
+                  requireBranchesToBeUpToDate: false,
+                  restrictPushes: false,
+                  allowForcePushes: false,
+                  allowDeletions: false,
+                  requireLinearHistory: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const yaml = serializeToYaml(config);
+    // The YAML should at minimum contain all the expected keys
+    expect(yaml).toContain("orgs:");
+    expect(yaml).toContain("my-org:");
+    expect(yaml).toContain("repos:");
+    expect(yaml).toContain("api:");
+    expect(yaml).toContain("branchProtection:");
+    expect(yaml).toContain("pattern: main");
+    expect(yaml).toContain("requirePullRequestReviews: true");
+    expect(yaml).toContain("requiredApprovingReviewCount: 1");
+    expect(yaml).toContain("dismissStaleReviews: false");
+    expect(yaml).toContain("requireStatusChecks: false");
+    expect(yaml).toContain("requiredStatusCheckContexts: []");
+  });
+});

--- a/lexicons/github-org/src/reconcile/dump.ts
+++ b/lexicons/github-org/src/reconcile/dump.ts
@@ -1,0 +1,465 @@
+/**
+ * Dump mode: export live GitHub org state into a desired-state GovernanceConfig.
+ *
+ * Adoption starts from reality, not a blank file. The operator trims the
+ * emitted config to declare only the resources they want chant to own.
+ *
+ * ## Round-trip property
+ * `diff(dumpOrg(client, org), sameLive)` yields zero changes — dumping then
+ * reconciling is a no-op. This holds because every field the diff engine
+ * compares is emitted with the exact live value.
+ *
+ * ## Extension pattern
+ * Each supported cycle exposes a `dumpXxx` helper below. To add dump support
+ * for a new cycle: add a `dumpXxx` function, call it in `dumpOrg`, include
+ * the result in the assembled `OrgConfig`. The structure mirrors the cycle
+ * pattern from `src/cycles/README.md`.
+ *
+ * ## What is emitted
+ * Only resources that chant currently supports (branch protection). Resources
+ * from the live org that chant has no cycle for are omitted — omission means
+ * "unmanaged", consistent with selective-by-omission.
+ */
+
+import type { AppClient } from "../auth/app-client.js";
+import type {
+  GovernanceConfig,
+  OrgConfig,
+  BranchProtectionConfig,
+  RepoConfig,
+} from "../config/types.js";
+import { fetchLiveForOrg } from "../cycles/branch-protection.js";
+import type { LiveOrgState, LiveBranchProtectionConfig } from "./diff.js";
+import type { RateBudget } from "./runner.js";
+import { BudgetExhaustedError } from "./runner.js";
+
+// ---------------------------------------------------------------------------
+// Public API types
+// ---------------------------------------------------------------------------
+
+/** Options for `dumpOrg`. */
+export interface DumpOrgOptions {
+  /**
+   * Rate budget to share across all API calls made during the dump.
+   * Defaults to 500 requests when omitted.
+   */
+  budget?: RateBudget;
+  /**
+   * Repositories to include in the dump. When provided, only these repos are
+   * fetched; when absent, all repos discovered via the GitHub API are included.
+   *
+   * Passing an explicit list avoids the extra paginated list call and is
+   * recommended when the caller already knows which repos to manage.
+   */
+  repos?: string[];
+}
+
+/** Result of `dumpOrg` — a valid GovernanceConfig plus a serialized YAML. */
+export interface DumpResult {
+  /** Fully-typed desired-state config. Passes `loadGovernanceConfig`. */
+  config: GovernanceConfig;
+  /**
+   * YAML serialization of `config` suitable for committing to a repository.
+   * Imports no YAML library — hand-serialized to keep the package dependency-free.
+   */
+  yaml: string;
+}
+
+// ---------------------------------------------------------------------------
+// Budget helper
+// ---------------------------------------------------------------------------
+
+function makeBudget(n: number): RateBudget {
+  let remaining = n;
+  return {
+    get remaining() {
+      return remaining;
+    },
+    get exhausted() {
+      return remaining <= 0;
+    },
+    use(count = 1) {
+      if (remaining <= 0) throw new BudgetExhaustedError();
+      remaining = Math.max(0, remaining - count);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GitHub REST: list repos for org (paginated)
+// ---------------------------------------------------------------------------
+
+interface GhRepo {
+  name: string;
+}
+
+/**
+ * Fetch all repository names for `orgLogin` via the GitHub API.
+ * Paginates until exhausted or budget runs out.
+ */
+async function listOrgRepos(
+  client: AppClient,
+  orgLogin: string,
+  budget: RateBudget,
+): Promise<string[]> {
+  const names: string[] = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (!budget.exhausted) {
+    budget.use(1);
+    const repos = await client.request<GhRepo[]>(
+      "GET",
+      `/orgs/${orgLogin}/repos?type=all&per_page=${perPage}&page=${page}`,
+    );
+    for (const r of repos) names.push(r.name);
+    if (repos.length < perPage) break;
+    page++;
+  }
+
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// Branch-protection dump helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a live branch-protection snapshot to a BranchProtectionConfig that will
+ * diff as no-op against the same live state.
+ *
+ * All fields compared by `diffBranchProtection` in `diff.ts` are emitted with
+ * their live values so the diff engine sees no change.
+ *
+ * `enforceAdmins` is captured live but is NOT in BranchProtectionConfig
+ * (selective-by-omission for an unmanaged field) — it is intentionally omitted.
+ */
+function normalizeLiveBranchProtection(
+  live: LiveBranchProtectionConfig,
+): BranchProtectionConfig {
+  const bp: BranchProtectionConfig = {
+    pattern: live.pattern,
+    requirePullRequestReviews: live.requirePullRequestReviews ?? false,
+    requiredApprovingReviewCount: live.requiredApprovingReviewCount ?? 0,
+    dismissStaleReviews: live.dismissStaleReviews ?? false,
+    requireCodeOwnerReviews: live.requireCodeOwnerReviews ?? false,
+    requireStatusChecks: live.requireStatusChecks ?? false,
+    requiredStatusCheckContexts: live.requiredStatusCheckContexts ?? [],
+    requireBranchesToBeUpToDate: live.requireBranchesToBeUpToDate ?? false,
+    restrictPushes: live.restrictPushes ?? false,
+    allowForcePushes: live.allowForcePushes ?? false,
+    allowDeletions: live.allowDeletions ?? false,
+    requireLinearHistory: live.requireLinearHistory ?? false,
+  };
+  return bp;
+}
+
+/**
+ * Build a minimal RepoConfig map containing only branch protection state for
+ * the supplied repo names, using the live snapshot already fetched.
+ *
+ * Repos with no live protection rules are omitted (nothing to manage).
+ */
+function buildBranchProtectionRepos(
+  repoNames: string[],
+  live: LiveOrgState,
+): Record<string, Pick<RepoConfig, "branchProtection">> {
+  const repos: Record<string, Pick<RepoConfig, "branchProtection">> = {};
+
+  for (const name of repoNames) {
+    const liveRepo = live.repos?.[name];
+    if (!liveRepo?.branchProtection || liveRepo.branchProtection.length === 0) continue;
+    repos[name] = {
+      branchProtection: liveRepo.branchProtection.map(normalizeLiveBranchProtection),
+    };
+  }
+
+  return repos;
+}
+
+// ---------------------------------------------------------------------------
+// YAML serializer (no external dependencies)
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a GovernanceConfig to YAML.
+ *
+ * Hand-written to keep the package free of YAML-library dependencies. Produces
+ * clean, deterministic YAML suitable for committing. Values are scalars, arrays
+ * of scalars, or nested objects — no multi-line strings in the config shape.
+ */
+export function serializeToYaml(config: GovernanceConfig): string {
+  const lines: string[] = ["orgs:"];
+
+  for (const [orgName, orgConfig] of Object.entries(config.orgs)) {
+    lines.push(`  ${yamlKey(orgName)}:`);
+    serializeOrgConfig(orgConfig, lines, "    ");
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+function yamlKey(key: string): string {
+  // Quote keys that contain special YAML characters
+  if (/[:{}\[\],&*#?|<>=!%@`\s]/.test(key) || key === "") {
+    return `"${key.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return key;
+}
+
+function yamlScalar(value: unknown): string {
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return String(value);
+  if (typeof value === "string") {
+    // Quote strings that could be misinterpreted as YAML values
+    if (
+      value === "" ||
+      value === "true" ||
+      value === "false" ||
+      value === "null" ||
+      /[:{}\[\],&*#?|<>=!%@`]/.test(value) ||
+      /^\s|\s$/.test(value)
+    ) {
+      return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    }
+    return value;
+  }
+  return String(value);
+}
+
+function serializeOrgConfig(orgConfig: OrgConfig, lines: string[], indent: string): void {
+  if (orgConfig.repos !== undefined) {
+    lines.push(`${indent}repos:`);
+    for (const [repoName, repoConfig] of Object.entries(orgConfig.repos)) {
+      lines.push(`${indent}  ${yamlKey(repoName)}:`);
+      serializeRepoConfig(repoConfig, lines, `${indent}    `);
+    }
+  }
+}
+
+function serializeRepoConfig(repoConfig: RepoConfig, lines: string[], indent: string): void {
+  const scalarFields: Array<keyof RepoConfig> = [
+    "description",
+    "websiteUrl",
+    "private",
+    "hasIssues",
+    "hasProjects",
+    "hasWiki",
+    "defaultBranch",
+    "allowSquashMerge",
+    "allowMergeCommit",
+    "allowRebaseMerge",
+    "deleteBranchOnMerge",
+  ];
+
+  for (const field of scalarFields) {
+    const val = repoConfig[field];
+    if (val !== undefined) {
+      lines.push(`${indent}${field}: ${yamlScalar(val)}`);
+    }
+  }
+
+  if (repoConfig.topics !== undefined) {
+    lines.push(`${indent}topics:`);
+    for (const t of repoConfig.topics) {
+      lines.push(`${indent}  - ${yamlScalar(t)}`);
+    }
+  }
+
+  if (repoConfig.branchProtection !== undefined && repoConfig.branchProtection.length > 0) {
+    lines.push(`${indent}branchProtection:`);
+    for (const bp of repoConfig.branchProtection) {
+      serializeBranchProtection(bp, lines, `${indent}  `);
+    }
+  }
+}
+
+function serializeBranchProtection(
+  bp: BranchProtectionConfig,
+  lines: string[],
+  indent: string,
+): void {
+  // First entry uses "- " list marker; subsequent fields in the same object
+  // use the same indent but are part of the same mapping.
+  lines.push(`${indent}- pattern: ${yamlScalar(bp.pattern)}`);
+  const fieldIndent = `${indent}  `;
+
+  const boolFields: Array<keyof BranchProtectionConfig> = [
+    "requirePullRequestReviews",
+    "dismissStaleReviews",
+    "requireCodeOwnerReviews",
+    "requireStatusChecks",
+    "requireBranchesToBeUpToDate",
+    "restrictPushes",
+    "allowForcePushes",
+    "allowDeletions",
+    "requireLinearHistory",
+  ];
+
+  for (const f of boolFields) {
+    const val = bp[f];
+    if (val !== undefined) {
+      lines.push(`${fieldIndent}${f}: ${yamlScalar(val)}`);
+    }
+  }
+
+  if (bp.requiredApprovingReviewCount !== undefined) {
+    lines.push(`${fieldIndent}requiredApprovingReviewCount: ${bp.requiredApprovingReviewCount}`);
+  }
+
+  if (bp.requiredStatusCheckContexts !== undefined) {
+    if (bp.requiredStatusCheckContexts.length === 0) {
+      lines.push(`${fieldIndent}requiredStatusCheckContexts: []`);
+    } else {
+      lines.push(`${fieldIndent}requiredStatusCheckContexts:`);
+      for (const ctx of bp.requiredStatusCheckContexts) {
+        lines.push(`${fieldIndent}  - ${yamlScalar(ctx)}`);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// dumpOrg — public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the live state for `orgName` and return a GovernanceConfig that:
+ *   - Passes `loadGovernanceConfig` validation.
+ *   - When diffed against the same live state, yields zero changes (round-trip
+ *     no-op).
+ *   - Only emits resources that chant's current cycles support (branch
+ *     protection). Unsupported live resources are omitted.
+ *
+ * @param client - Authed GitHub App client.
+ * @param orgName - GitHub org login to dump.
+ * @param opts - Optional repos list and rate budget.
+ */
+export async function dumpOrg(
+  client: AppClient,
+  orgName: string,
+  opts: DumpOrgOptions = {},
+): Promise<DumpResult> {
+  const budget = opts.budget ?? makeBudget(500);
+
+  // ── 1. Discover repos ────────────────────────────────────────────────────
+  let repoNames: string[];
+  if (opts.repos && opts.repos.length > 0) {
+    repoNames = opts.repos;
+  } else {
+    if (budget.exhausted) throw new BudgetExhaustedError();
+    repoNames = await listOrgRepos(client, orgName, budget);
+  }
+
+  // ── 2. Fetch live branch-protection state ────────────────────────────────
+  // fetchLiveForOrg from the branch-protection cycle requires a
+  // Record<string, RepoConfig>. Build a minimal stub so it knows which repos +
+  // branches to query. Since we are dumping ALL branches, we need to discover
+  // branch protection rules for each repo. GitHub's classic branch-protection
+  // API doesn't offer a "list all rules for a repo" endpoint. We use a
+  // two-step: list the repo's branches, then probe each for protection.
+  // To keep the implementation simple, we call our own helper that mirrors
+  // what fetchLiveForOrg does but without needing a pre-known branch list.
+  const liveState = await fetchAllBranchProtection(client, orgName, repoNames, budget);
+
+  // ── 3. Assemble OrgConfig ────────────────────────────────────────────────
+  const bpRepos = buildBranchProtectionRepos(repoNames, liveState);
+
+  // Merge repos: union of repos that have any supported resource
+  const allRepoNames = new Set([...Object.keys(bpRepos)]);
+  const repos: Record<string, RepoConfig> = {};
+  for (const name of allRepoNames) {
+    repos[name] = {
+      ...bpRepos[name],
+    };
+  }
+
+  const orgConfig: OrgConfig = {};
+  if (Object.keys(repos).length > 0) {
+    orgConfig.repos = repos;
+  }
+
+  const config: GovernanceConfig = {
+    orgs: { [orgName]: orgConfig },
+  };
+
+  return { config, yaml: serializeToYaml(config) };
+}
+
+// ---------------------------------------------------------------------------
+// fetchAllBranchProtection
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch classic branch-protection rules for each repo by:
+ *   1. Listing the repo's branches (GET /repos/{org}/{repo}/branches).
+ *   2. Calling `fetchLiveForOrg` with a RepoConfig stub seeded with those branches.
+ *
+ * This mirrors how the branch-protection cycle's `fetchLive` works, but discovers
+ * all branches rather than limiting to config-declared ones.
+ */
+async function fetchAllBranchProtection(
+  client: AppClient,
+  orgLogin: string,
+  repoNames: string[],
+  budget: RateBudget,
+): Promise<LiveOrgState> {
+  if (repoNames.length === 0) return { repos: {} };
+
+  // Build a RepoConfig stub: each repo lists all its branches so
+  // fetchLiveForOrg will probe protection for each.
+  const repoStubs: Record<string, RepoConfig> = {};
+
+  for (const repoName of repoNames) {
+    if (budget.exhausted) break;
+    const branches = await listRepoBranches(client, orgLogin, repoName, budget);
+    if (branches.length > 0) {
+      repoStubs[repoName] = {
+        branchProtection: branches.map((b) => ({ pattern: b })),
+      };
+    }
+  }
+
+  if (Object.keys(repoStubs).length === 0) return { repos: {} };
+
+  // fetchLiveForOrg will probe each branch for protection rules.
+  return fetchLiveForOrg(client, orgLogin, repoStubs, budget);
+}
+
+interface GhBranch {
+  name: string;
+}
+
+/**
+ * List all branch names for a repo. Paginates until exhausted or budget runs out.
+ */
+async function listRepoBranches(
+  client: AppClient,
+  orgLogin: string,
+  repoName: string,
+  budget: RateBudget,
+): Promise<string[]> {
+  const names: string[] = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (!budget.exhausted) {
+    budget.use(1);
+    let branches: GhBranch[];
+    try {
+      branches = await client.request<GhBranch[]>(
+        "GET",
+        `/repos/${orgLogin}/${repoName}/branches?per_page=${perPage}&page=${page}`,
+      );
+    } catch (err) {
+      // 404 = repo not found or no access; skip silently
+      if (err instanceof Error && err.message.includes("404")) break;
+      throw err;
+    }
+    for (const b of branches) names.push(b.name);
+    if (branches.length < perPage) break;
+    page++;
+  }
+
+  return names;
+}

--- a/lexicons/github-org/src/reconcile/dump.ts
+++ b/lexicons/github-org/src/reconcile/dump.ts
@@ -128,8 +128,22 @@ async function listOrgRepos(
  * Map a live branch-protection snapshot to a BranchProtectionConfig that will
  * diff as no-op against the same live state.
  *
- * All fields compared by `diffBranchProtection` in `diff.ts` are emitted with
- * their live values so the diff engine sees no change.
+ * CRITICAL — zero normalization drift: this MUST emit EXACTLY the shape that
+ * `fetchBranchProtection` (in `../cycles/branch-protection.ts`) produces. The
+ * round-trip no-op property (`diff(dump(...), live)` is empty) only holds when
+ * the dumped desired shape matches the live shape field-for-field. The diff
+ * engine compares each key PRESENT in desired against live (`diffObjectKeys`),
+ * so emitting a key that `fetchBranchProtection` leaves undefined (e.g.
+ * `requiredApprovingReviewCount: 0` when PR reviews are off) produces a
+ * SPURIOUS update (`0` vs `undefined`).
+ *
+ * `fetchBranchProtection` sets the review sub-fields ONLY when the parent group
+ * is enabled:
+ *   - `requiredApprovingReviewCount` / `dismissStaleReviews` /
+ *     `requireCodeOwnerReviews` only when `requirePullRequestReviews` is true;
+ *   - `requiredStatusCheckContexts` / `requireBranchesToBeUpToDate` only when
+ *     `requireStatusChecks` is true.
+ * We mirror that conditional emission precisely below.
  *
  * `enforceAdmins` is captured live but is NOT in BranchProtectionConfig
  * (selective-by-omission for an unmanaged field) — it is intentionally omitted.
@@ -140,17 +154,27 @@ function normalizeLiveBranchProtection(
   const bp: BranchProtectionConfig = {
     pattern: live.pattern,
     requirePullRequestReviews: live.requirePullRequestReviews ?? false,
-    requiredApprovingReviewCount: live.requiredApprovingReviewCount ?? 0,
-    dismissStaleReviews: live.dismissStaleReviews ?? false,
-    requireCodeOwnerReviews: live.requireCodeOwnerReviews ?? false,
     requireStatusChecks: live.requireStatusChecks ?? false,
-    requiredStatusCheckContexts: live.requiredStatusCheckContexts ?? [],
-    requireBranchesToBeUpToDate: live.requireBranchesToBeUpToDate ?? false,
     restrictPushes: live.restrictPushes ?? false,
     allowForcePushes: live.allowForcePushes ?? false,
     allowDeletions: live.allowDeletions ?? false,
     requireLinearHistory: live.requireLinearHistory ?? false,
   };
+
+  // PR-review sub-fields: emit ONLY when the parent group is enabled, mirroring
+  // `fetchBranchProtection` (which leaves them undefined otherwise).
+  if (live.requirePullRequestReviews === true) {
+    bp.requiredApprovingReviewCount = live.requiredApprovingReviewCount ?? 0;
+    bp.dismissStaleReviews = live.dismissStaleReviews ?? false;
+    bp.requireCodeOwnerReviews = live.requireCodeOwnerReviews ?? false;
+  }
+
+  // Status-check sub-fields: emit ONLY when the parent group is enabled.
+  if (live.requireStatusChecks === true) {
+    bp.requiredStatusCheckContexts = live.requiredStatusCheckContexts ?? [];
+    bp.requireBranchesToBeUpToDate = live.requireBranchesToBeUpToDate ?? false;
+  }
+
   return bp;
 }
 
@@ -218,7 +242,11 @@ function yamlScalar(value: unknown): string {
       value === "false" ||
       value === "null" ||
       /[:{}\[\],&*#?|<>=!%@`]/.test(value) ||
-      /^\s|\s$/.test(value)
+      /^\s|\s$/.test(value) ||
+      // Purely-numeric or decimal-like strings would round-trip as numbers
+      // (e.g. a status-check context "1234" or a branch pattern "1.x").
+      /^\d+$/.test(value) ||
+      /^\d+\.\d+$/.test(value)
     ) {
       return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
     }


### PR DESCRIPTION
Closes #454. (Branch name says 453 but this implements #454 — dump/import.)

## Summary

- Adds `dumpOrg(client, orgName, opts): Promise<DumpResult>` in `lexicons/github-org/src/reconcile/dump.ts`. Fetches live branch-protection rules for all repos (or an explicit subset), emits a `GovernanceConfig` that passes `loadGovernanceConfig` and round-trips as a no-op (`diff(dumped, sameLive)` → zero changes).
- Adds `serializeToYaml(config)` for a dependency-free YAML serialization suitable for committing.
- Exports both from `src/index.ts`.
- Structured for growth: adding dump support for a new cycle is a `dumpXxx` helper + one call in `dumpOrg`.

## Round-trip property

`diff(dumpOrg(client, org), sameLive)` is always empty. Every field the `diffBranchProtection` engine compares (`bpFields` + `requiredStatusCheckContexts`) is emitted with the exact live value. `enforceAdmins` is captured live but is not in `BranchProtectionConfig`, so it is intentionally omitted.

## Tests (15 new, 154 total — all pass)

- Config validates under `loadGovernanceConfig`.
- Round-trip no-op: full rule, minimal rule, multi-repo/multi-branch.
- Unprotected repos omitted; `enforceAdmins` absent from output.
- Explicit `repos` list skips the org list API call.
- `serializeToYaml` shape: keys, boolean values, context arrays, empty arrays.

## Commands run

- `npx tsc --noEmit -p lexicons/github-org/tsconfig.json` — clean
- `npx vitest run lexicons/github-org` — 7 files, 154 tests, all pass