### PR TITLE
feat(github-org): emit governance reconcile pipeline via github lexicon builders

### DIFF
--- a/lexicons/github-org/package.json
+++ b/lexicons/github-org/package.json
@@ -45,10 +45,12 @@
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && find dist -type f \\( -name \"*.js\" -o -name \"*.js.map\" \\) -delete"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1"
+    "@intentius/chant": "^0.8.1",
+    "@intentius/chant-lexicon-github": "^0.8.1"
   },
   "devDependencies": {
     "@intentius/chant": "*",
+    "@intentius/chant-lexicon-github": "*",
     "typescript": "^5.9.3"
   }
 }

--- a/lexicons/github-org/src/emit/pipeline.test.ts
+++ b/lexicons/github-org/src/emit/pipeline.test.ts
@@ -1,0 +1,192 @@
+import { describe, test, expect } from "vitest";
+import { governancePipeline } from "./pipeline.js";
+import { githubSerializer } from "@intentius/chant-lexicon-github";
+
+// ── Shape tests ────────────────────────────────────────────────────
+
+describe("governancePipeline", () => {
+  test("returns workflow, dryRunJob, and applyJob", () => {
+    const { workflow, dryRunJob, applyJob } = governancePipeline();
+    expect(workflow).toBeDefined();
+    expect(dryRunJob).toBeDefined();
+    expect(applyJob).toBeDefined();
+  });
+
+  test("workflow is a GitHub::Actions::Workflow resource", () => {
+    const { workflow } = governancePipeline();
+    expect(workflow.entityType).toBe("GitHub::Actions::Workflow");
+    expect(workflow.kind).toBe("resource");
+    expect(workflow.lexicon).toBe("github");
+  });
+
+  test("workflow has schedule, pull_request, and workflow_dispatch triggers", () => {
+    const { workflow } = governancePipeline();
+    const on = workflow.props.on as Record<string, unknown>;
+    expect(on.schedule).toBeDefined();
+    expect(on.pull_request).toBeDefined();
+    expect(on.workflow_dispatch).toBeDefined();
+  });
+
+  test("default cron is 0 2 * * *", () => {
+    const { workflow } = governancePipeline();
+    const on = workflow.props.on as Record<string, unknown>;
+    const schedule = on.schedule as Array<{ cron: string }>;
+    expect(schedule[0].cron).toBe("0 2 * * *");
+  });
+
+  test("custom cron is respected", () => {
+    const { workflow } = governancePipeline({ cron: "0 6 * * 1" });
+    const on = workflow.props.on as Record<string, unknown>;
+    const schedule = on.schedule as Array<{ cron: string }>;
+    expect(schedule[0].cron).toBe("0 6 * * 1");
+  });
+
+  test("workflow has least-privilege permissions (contents: read only)", () => {
+    const { workflow } = governancePipeline();
+    const perms = workflow.props.permissions as Record<string, string>;
+    expect(perms.contents).toBe("read");
+    // write scopes must NOT be at the workflow level
+    expect(perms["pull-requests"]).toBeUndefined();
+    expect(perms.pullRequests).toBeUndefined();
+  });
+
+  // ── Dry-run / apply split ──────────────────────────────────────
+
+  test("dry-run job has pull_request conditional", () => {
+    const { dryRunJob } = governancePipeline();
+    expect(dryRunJob.props.if).toContain("pull_request");
+  });
+
+  test("apply job skips pull_request events", () => {
+    const { applyJob } = governancePipeline();
+    expect(applyJob.props.if).toContain("pull_request");
+    // must be a negation
+    expect(applyJob.props.if).toContain("!=");
+  });
+
+  test("dry-run job steps include dry-run mode", () => {
+    const { dryRunJob } = governancePipeline();
+    const steps = dryRunJob.props.steps as Array<{ props: Record<string, unknown> }>;
+    const runSteps = steps.filter((s) => typeof s.props.run === "string");
+    const dryRunScript = runSteps.find((s) => (s.props.run as string).includes("dry-run"));
+    expect(dryRunScript).toBeDefined();
+  });
+
+  test("apply job steps include apply mode", () => {
+    const { applyJob } = governancePipeline();
+    const steps = applyJob.props.steps as Array<{ props: Record<string, unknown> }>;
+    const runSteps = steps.filter((s) => typeof s.props.run === "string");
+    const applyScript = runSteps.find((s) => (s.props.run as string).includes("--mode apply"));
+    expect(applyScript).toBeDefined();
+  });
+
+  // ── Security constraints ───────────────────────────────────────
+
+  test("private key is sourced from a secret (not a var)", () => {
+    const { dryRunJob, applyJob } = governancePipeline();
+    // The mint-token step uses `with.private-key: ${{ secrets.XYZ }}`
+    for (const job of [dryRunJob, applyJob]) {
+      const steps = job.props.steps as Array<{ props: Record<string, unknown> }>;
+      const mintStep = steps.find(
+        (s) => typeof s.props.uses === "string" && (s.props.uses as string).includes("create-github-app-token"),
+      );
+      expect(mintStep).toBeDefined();
+      const withBlock = mintStep!.props.with as Record<string, string>;
+      const privateKey = withBlock["private-key"];
+      // Must reference secrets.* not vars.*
+      expect(privateKey).toMatch(/\$\{\{\s*secrets\./);
+      expect(privateKey).not.toMatch(/\$\{\{\s*vars\./);
+    }
+  });
+
+  test("all external actions are SHA-pinned", () => {
+    const { dryRunJob, applyJob } = governancePipeline();
+    const SHA_RE = /^[a-z0-9]{40}$/;
+    for (const job of [dryRunJob, applyJob]) {
+      const steps = job.props.steps as Array<{ props: Record<string, unknown> }>;
+      const useSteps = steps.filter((s) => typeof s.props.uses === "string");
+      for (const step of useSteps) {
+        const uses = step.props.uses as string;
+        const [, ref] = uses.split("@");
+        expect(ref, `Action "${uses}" must be pinned to a SHA`).toMatch(SHA_RE);
+      }
+    }
+  });
+
+  test("every job has timeout-minutes set", () => {
+    const { dryRunJob, applyJob } = governancePipeline();
+    expect(dryRunJob.props["timeout-minutes"]).toBeTypeOf("number");
+    expect(applyJob.props["timeout-minutes"]).toBeTypeOf("number");
+  });
+
+  test("dry-run job has pull-requests write permission for PR comment", () => {
+    const { dryRunJob } = governancePipeline();
+    const perms = dryRunJob.props.permissions as Record<string, string>;
+    expect(perms["pull-requests"]).toBe("write");
+    expect(perms.contents).toBe("read");
+  });
+
+  test("apply job has only contents: read permission", () => {
+    const { applyJob } = governancePipeline();
+    const perms = applyJob.props.permissions as Record<string, string>;
+    expect(perms.contents).toBe("read");
+    expect(perms["pull-requests"]).toBeUndefined();
+  });
+
+  // ── Parameterization ──────────────────────────────────────────
+
+  test("configPath is used in PR trigger path filter", () => {
+    const configPath = ".github/my-org-config.yml";
+    const { workflow } = governancePipeline({ configPath });
+    const on = workflow.props.on as Record<string, unknown>;
+    const pr = on.pull_request as Record<string, unknown>;
+    const paths = pr.paths as string[];
+    expect(paths).toContain(configPath);
+  });
+
+  test("cycles flag is forwarded to reconcile command", () => {
+    const { dryRunJob, applyJob } = governancePipeline({ cycles: ["branch-protection", "team-sync"] });
+    for (const job of [dryRunJob, applyJob]) {
+      const steps = job.props.steps as Array<{ props: Record<string, unknown> }>;
+      const runSteps = steps.filter((s) => typeof s.props.run === "string");
+      const hasFlag = runSteps.some((s) =>
+        (s.props.run as string).includes("--cycles branch-protection,team-sync"),
+      );
+      expect(hasFlag, "Expected --cycles flag in job steps").toBe(true);
+    }
+  });
+
+  test("custom appIdVar is referenced in mint-token step", () => {
+    const { dryRunJob } = governancePipeline({ appIdVar: "MY_APP_ID" });
+    const steps = dryRunJob.props.steps as Array<{ props: Record<string, unknown> }>;
+    const mintStep = steps.find(
+      (s) => typeof s.props.uses === "string" && (s.props.uses as string).includes("create-github-app-token"),
+    )!;
+    const withBlock = mintStep.props.with as Record<string, string>;
+    expect(withBlock["app-id"]).toContain("MY_APP_ID");
+  });
+
+  test("custom privateKeySecret is used (secret, not var)", () => {
+    const { dryRunJob } = governancePipeline({ privateKeySecret: "MY_PRIVATE_KEY" });
+    const steps = dryRunJob.props.steps as Array<{ props: Record<string, unknown> }>;
+    const mintStep = steps.find(
+      (s) => typeof s.props.uses === "string" && (s.props.uses as string).includes("create-github-app-token"),
+    )!;
+    const withBlock = mintStep.props.with as Record<string, string>;
+    expect(withBlock["private-key"]).toContain("secrets.MY_PRIVATE_KEY");
+  });
+
+  // ── Serialization ──────────────────────────────────────────────
+
+  test("serializes to YAML without error", () => {
+    const { workflow } = governancePipeline();
+    const entities = new Map([["governance", workflow]]);
+    const yaml = githubSerializer.serialize(entities) as string;
+    expect(yaml).toContain("name: Governance reconcile");
+    expect(yaml).toContain("schedule:");
+    expect(yaml).toContain("pull_request:");
+    expect(yaml).toContain("workflow_dispatch:");
+    expect(yaml).toContain("permissions:");
+    expect(yaml).toContain("contents: read");
+  });
+});

--- a/lexicons/github-org/src/emit/pipeline.ts
+++ b/lexicons/github-org/src/emit/pipeline.ts
@@ -1,0 +1,291 @@
+/**
+ * Governance pipeline emitter.
+ *
+ * Generates the `.github/workflows/governance.yml` workflow via the github
+ * lexicon builders so it is auditable by the same post-synth checks that chant
+ * runs on user-authored workflows — dogfood.
+ *
+ * The emitted workflow:
+ *   - Runs on a schedule (parameterized cron) and on `workflow_dispatch`.
+ *   - Runs on PRs that touch the config file (dry-run only).
+ *   - Mints a short-lived GitHub App installation token from vars + a secret.
+ *   - On PRs: dry-run, posts the change-set summary as a PR comment.
+ *   - On the default branch / schedule / dispatch: apply.
+ *   - All actions pinned to commit SHAs (GHA021/GHA029).
+ *   - Least-privilege permissions: read-only at workflow level; write scopes
+ *     scoped to the single job that needs them (GHA017/GHA034).
+ *   - `timeout-minutes` on every job (GHA022).
+ *   - Private key sourced from a secret via `with:` on the token-minting action,
+ *     never interpolated directly into a `run:` script (GHA045).
+ *
+ * Follow-up: a durable Ops-schedule variant (issue to be filed) will drive the
+ * reconcile loop from a Temporal workflow rather than raw cron, giving pause /
+ * resume / retry semantics across long-running org operations.
+ */
+
+import { Step, Job, Workflow } from "@intentius/chant-lexicon-github";
+
+// ── Pinned action SHAs ─────────────────────────────────────────────
+//
+// Pin to commit SHA so a tag repoint cannot introduce malicious code.
+// See GHA021 (checkout) and GHA029 (all other external actions).
+
+/**
+ * actions/checkout v4.2.2
+ * https://github.com/actions/checkout/releases/tag/v4.2.2
+ */
+const CHECKOUT_SHA = "11bd71901bbe5b1630ceea73d27597364c9af683";
+
+/**
+ * actions/create-github-app-token v1.11.6
+ * https://github.com/actions/create-github-app-token/releases/tag/v1.11.6
+ */
+const CREATE_APP_TOKEN_SHA = "df432ceedc7162edd81cf1e418309514dbf04a74";
+
+/**
+ * actions/setup-node v4.4.0
+ * https://github.com/actions/setup-node/releases/tag/v4.4.0
+ */
+const SETUP_NODE_SHA = "49933ea5288caeca8642d1e84afbd3f7d6820020";
+
+// ── Public types ───────────────────────────────────────────────────
+
+/** Which reconcile cycles to include (empty array = all registered cycles). */
+export type CycleFilter = string[];
+
+export interface GovernancePipelineOptions {
+  /**
+   * Cron schedule expression for the recurring reconcile.
+   * Default: `"0 2 * * *"` (02:00 UTC daily).
+   */
+  cron?: string;
+
+  /**
+   * Path to the governance config file in the repo.
+   * Default: `".github/governance.yml"`.
+   */
+  configPath?: string;
+
+  /**
+   * Names of cycles to run (forwarded as `--cycles` to the CLI).
+   * When omitted the CLI runs all registered cycles.
+   */
+  cycles?: CycleFilter;
+
+  /**
+   * Name of the GitHub Actions variable holding the App ID.
+   * Default: `"GOVERNANCE_APP_ID"`.
+   */
+  appIdVar?: string;
+
+  /**
+   * Name of the GitHub Actions variable holding the installation ID.
+   * Default: `"GOVERNANCE_INSTALLATION_ID"`.
+   */
+  installationIdVar?: string;
+
+  /**
+   * Name of the GitHub Actions secret holding the App private key (PEM).
+   * Default: `"GOVERNANCE_APP_PRIVATE_KEY"`.
+   * MUST be a secret, not a var — private key material must never be stored
+   * in a workflow var (vars are visible to all repo collaborators).
+   */
+  privateKeySecret?: string;
+
+  /**
+   * Node.js version to use when running the reconcile.
+   * Default: `"22"`.
+   */
+  nodeVersion?: string;
+
+  /**
+   * Runner label.
+   * Default: `"ubuntu-latest"`.
+   */
+  runsOn?: string;
+
+  /**
+   * Job timeout in minutes (GHA022).
+   * Default: `30`.
+   */
+  timeoutMinutes?: number;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function buildCycleArgs(cycles?: CycleFilter): string {
+  if (!cycles || cycles.length === 0) return "";
+  return ` --cycles ${cycles.join(",")}`;
+}
+
+// ── Composite ─────────────────────────────────────────────────────
+
+/**
+ * Build the governance reconcile workflow.
+ *
+ * Returns a `Workflow` resource (with inline jobs) that can be passed to
+ * `githubSerializer.serialize` to produce `.github/workflows/governance.yml`.
+ *
+ * Example:
+ * ```ts
+ * import { governancePipeline } from "@intentius/chant-lexicon-github-org/emit/pipeline";
+ * import { githubSerializer } from "@intentius/chant-lexicon-github";
+ *
+ * const { workflow } = governancePipeline({ cron: "0 6 * * 1" });
+ * const yaml = githubSerializer.serialize(new Map([["governance", workflow]]));
+ * ```
+ */
+export function governancePipeline(opts: GovernancePipelineOptions = {}) {
+  const {
+    cron = "0 2 * * *",
+    configPath = ".github/governance.yml",
+    cycles,
+    appIdVar = "GOVERNANCE_APP_ID",
+    installationIdVar = "GOVERNANCE_INSTALLATION_ID",
+    privateKeySecret = "GOVERNANCE_APP_PRIVATE_KEY",
+    nodeVersion = "22",
+    runsOn = "ubuntu-latest",
+    timeoutMinutes = 30,
+  } = opts;
+
+  const cycleFlag = buildCycleArgs(cycles);
+
+  // ── Shared steps (used in both jobs) ───────────────────────────
+
+  const checkoutStep = new Step({
+    name: "Checkout",
+    // SHA-pinned to satisfy GHA021.
+    uses: `actions/checkout@${CHECKOUT_SHA}`,
+    with: {
+      // Sparse checkout: only the config file is needed.
+      "sparse-checkout": configPath,
+      "sparse-checkout-cone-mode": false,
+    },
+  });
+
+  const mintTokenStep = new Step({
+    name: "Mint GitHub App token",
+    id: "app-token",
+    // SHA-pinned to satisfy GHA029. The private key is supplied via `with:` on
+    // a `uses:` step — it is never interpolated into a `run:` script (GHA045).
+    uses: `actions/create-github-app-token@${CREATE_APP_TOKEN_SHA}`,
+    with: {
+      "app-id": `\${{ vars.${appIdVar} }}`,
+      "private-key": `\${{ secrets.${privateKeySecret} }}`,
+    },
+  });
+
+  const setupNodeStep = new Step({
+    name: "Setup Node.js",
+    // SHA-pinned to satisfy GHA029.
+    uses: `actions/setup-node@${SETUP_NODE_SHA}`,
+    with: { "node-version": nodeVersion },
+  });
+
+  const installStep = new Step({
+    name: "Install governance CLI",
+    run: "npm install --global @intentius/chant-lexicon-github-org",
+  });
+
+  // ── Dry-run job (PR) ────────────────────────────────────────────
+  //
+  // Fires only on `pull_request` events that touch the config file.
+  // Computes the change-set and posts the plan as a PR comment.
+
+  const dryRunStep = new Step({
+    name: "Dry-run reconcile + post PR comment",
+    // GHA045: secrets never appear inside `run:`. The minted token is an
+    // ephemeral installation token (not the private key) passed via env.
+    env: {
+      GH_TOKEN: "${{ steps.app-token.outputs.token }}",
+      GOVERNANCE_INSTALLATION_ID: `\${{ vars.${installationIdVar} }}`,
+    },
+    run: [
+      `OUTPUT=$(npx chant-governance reconcile \\`,
+      `  --config "${configPath}" \\`,
+      `  --token-env GH_TOKEN \\`,
+      `  --installation-id-env GOVERNANCE_INSTALLATION_ID \\`,
+      `  --mode dry-run${cycleFlag} 2>&1) || true`,
+      ``,
+      `gh pr comment "\${{ github.event.pull_request.number }}" \\`,
+      `  --repo "\${{ github.repository }}" \\`,
+      `  --body "## Governance dry-run plan\\n\\n\`\`\`\\n\${OUTPUT}\\n\`\`\`"`,
+    ].join("\n"),
+  });
+
+  const dryRunJob = new Job({
+    name: "governance-dry-run",
+    "runs-on": runsOn,
+    "timeout-minutes": timeoutMinutes,
+    // GHA034: write scope is on this job only, not the whole workflow.
+    permissions: {
+      contents: "read",
+      "pull-requests": "write",
+    },
+    // Only run on PR events — the apply job handles schedule and dispatch.
+    if: "${{ github.event_name == 'pull_request' }}",
+    steps: [checkoutStep, mintTokenStep, setupNodeStep, installStep, dryRunStep],
+  });
+
+  // ── Apply job (schedule / dispatch) ─────────────────────────────
+  //
+  // Fires on schedule and on `workflow_dispatch`. Applies the change-set after
+  // guardrails pass. Does not run on `pull_request` events.
+
+  const applyStep = new Step({
+    name: "Apply reconcile",
+    env: {
+      GH_TOKEN: "${{ steps.app-token.outputs.token }}",
+      GOVERNANCE_INSTALLATION_ID: `\${{ vars.${installationIdVar} }}`,
+    },
+    run: [
+      `npx chant-governance reconcile \\`,
+      `  --config "${configPath}" \\`,
+      `  --token-env GH_TOKEN \\`,
+      `  --installation-id-env GOVERNANCE_INSTALLATION_ID \\`,
+      `  --mode apply${cycleFlag}`,
+    ].join("\n"),
+  });
+
+  const applyJob = new Job({
+    name: "governance-apply",
+    "runs-on": runsOn,
+    "timeout-minutes": timeoutMinutes,
+    permissions: {
+      contents: "read",
+    },
+    // Skip on PR events — the dry-run job handles those.
+    if: "${{ github.event_name != 'pull_request' }}",
+    steps: [checkoutStep, mintTokenStep, setupNodeStep, installStep, applyStep],
+  });
+
+  // ── Workflow ────────────────────────────────────────────────────
+
+  const workflow = new Workflow({
+    name: "Governance reconcile",
+    on: {
+      // Daily (or custom) scheduled reconcile — apply mode.
+      schedule: [{ cron }],
+
+      // PR dry-run: fires when a PR touches the config file.
+      pull_request: {
+        branches: ["main"],
+        paths: [configPath],
+      },
+
+      // Manual dispatch: allows on-demand apply.
+      workflow_dispatch: {},
+    },
+    // GHA017: explicit permissions block present.
+    // GHA034: only `contents: read` at workflow level; write scopes are per-job.
+    permissions: {
+      contents: "read",
+    },
+    jobs: {
+      "governance-dry-run": dryRunJob,
+      "governance-apply": applyJob,
+    },
+  });
+
+  return { workflow, dryRunJob, applyJob };
+}

--- a/lexicons/github-org/src/index.ts
+++ b/lexicons/github-org/src/index.ts
@@ -75,3 +75,7 @@ export { branchProtectionCycle, fetchLiveForOrg } from "./cycles/branch-protecti
 // Reconcile: dump (export live state to desired-state config)
 export type { DumpOrgOptions, DumpResult } from "./reconcile/dump.js";
 export { dumpOrg, serializeToYaml } from "./reconcile/dump.js";
+
+// Pipeline emitter: governance CI workflow generator
+export type { GovernancePipelineOptions, CycleFilter } from "./emit/pipeline.js";
+export { governancePipeline } from "./emit/pipeline.js";

--- a/lexicons/github-org/tsconfig.json
+++ b/lexicons/github-org/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/dist/**", "**/docs/**"]
 }


### PR DESCRIPTION
Closes #453. (Branch/agent mislabeled it 454; this implements #453 — the emitted governance pipeline.)

## Summary

- Adds `governancePipeline(opts): { workflow, dryRunJob, applyJob }` to `lexicons/github-org/src/emit/pipeline.ts`, generating `.github/workflows/governance.yml` using the `@intentius/chant-lexicon-github` builders (`Step`, `Job`, `Workflow`) — dogfood.
- PR events: dry-run mode, posts change-set summary as a PR comment. Schedule/dispatch events: apply mode. Jobs are conditionally gated with `if:`.
- All security audit rules satisfied: SHA-pinned actions (GHA021/GHA029), explicit permissions block (GHA017), per-job write scopes (GHA034), `timeout-minutes` on every job (GHA022), private key sourced via `with:` secret never in a `run:` script (GHA045).
- Adds `@intentius/chant-lexicon-github` as peer+dev dep; removes `rootDir` from `tsconfig.json` (keeping it in `tsconfig.build.json` only, matching the forgejo pattern).
- Re-exports `governancePipeline`, `GovernancePipelineOptions`, and `CycleFilter` from `src/index.ts`.
- 20 unit tests cover: workflow shape, trigger configuration, dry-run/apply split, SHA pinning, permissions, secret-vs-var constraint, parameterization, and serialization round-trip.

## Verification

- `npx tsc --noEmit -p lexicons/github-org/tsconfig.json` — clean
- `npx vitest run lexicons/github-org` — 174 passed (8 test files)
- `npx vitest run packages/core/src/meta/peer-deps.test.ts` — 11 passed

## Follow-up

A durable Ops-schedule variant (to be filed as a separate issue) will drive the reconcile loop from a Temporal workflow rather than raw cron, giving pause/resume/retry semantics across long-running org operations.