### PR TITLE
Release 0.8.2 + publish github-org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       - run: npm run --prefix lexicons/gitlab prepack
       - run: npm run --prefix lexicons/github prepack
       - run: npm run --prefix lexicons/forgejo prepack
+      - run: npm run --prefix lexicons/github-org prepack
       - run: npm run --prefix lexicons/k8s prepack
       - run: npm run --prefix lexicons/gcp prepack
       - run: npm run --prefix lexicons/helm prepack
@@ -93,6 +94,13 @@ jobs:
         run: |
           V=$(node -e "process.stdout.write(require('./package.json').version)")
           P=$(npm view @intentius/chant-lexicon-forgejo version 2>/dev/null || echo "none")
+          [ "$V" = "$P" ] && echo "Already at $V, skipping" || npm publish --access public --provenance
+
+      - name: Publish @intentius/chant-lexicon-github-org
+        working-directory: lexicons/github-org
+        run: |
+          V=$(node -e "process.stdout.write(require('./package.json').version)")
+          P=$(npm view @intentius/chant-lexicon-github-org version 2>/dev/null || echo "none")
           [ "$V" = "$P" ] && echo "Already at $V, skipping" || npm publish --access public --provenance
 
       - name: Publish @intentius/chant-lexicon-k8s

--- a/lexicons/aws/package.json
+++ b/lexicons/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-aws",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "AWS CloudFormation lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -70,6 +70,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1"
+    "@intentius/chant": "^0.8.2"
   }
 }

--- a/lexicons/azure/package.json
+++ b/lexicons/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-azure",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Azure lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -69,6 +69,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1"
+    "@intentius/chant": "^0.8.2"
   }
 }

--- a/lexicons/docker/package.json
+++ b/lexicons/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-docker",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Docker lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -67,6 +67,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1"
+    "@intentius/chant": "^0.8.2"
   }
 }

--- a/lexicons/forgejo/package.json
+++ b/lexicons/forgejo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-forgejo",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Forgejo / Codeberg / Gitea Actions lexicon for chant — a thin GitHub Actions dialect",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -53,8 +53,8 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1",
-    "@intentius/chant-lexicon-github": "^0.8.1"
+    "@intentius/chant": "^0.8.2",
+    "@intentius/chant-lexicon-github": "^0.8.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && find dist -type f \\( -name \"*.js\" -o -name \"*.js.map\" \\) -delete",

--- a/lexicons/gcp/package.json
+++ b/lexicons/gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-gcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Google Cloud lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -71,6 +71,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1"
+    "@intentius/chant": "^0.8.2"
   }
 }

--- a/lexicons/github-org/package.json
+++ b/lexicons/github-org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-github-org",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "GitHub org/repo governance lexicon for chant — desired-state config and reconciliation",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -49,8 +49,8 @@
     "prepack": "npm run build"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1",
-    "@intentius/chant-lexicon-github": "^0.8.1"
+    "@intentius/chant": "^0.8.2",
+    "@intentius/chant-lexicon-github": "^0.8.2"
   },
   "devDependencies": {
     "@intentius/chant": "*",

--- a/lexicons/github/package.json
+++ b/lexicons/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-github",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "GitHub Actions lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -61,6 +61,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1"
+    "@intentius/chant": "^0.8.2"
   }
 }

--- a/lexicons/gitlab/package.json
+++ b/lexicons/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-gitlab",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "GitLab CI lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -62,8 +62,8 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1",
-    "@intentius/chant-lexicon-github": "^0.8.1"
+    "@intentius/chant": "^0.8.2",
+    "@intentius/chant-lexicon-github": "^0.8.2"
   },
   "peerDependenciesMeta": {
     "@intentius/chant-lexicon-github": {

--- a/lexicons/helm/package.json
+++ b/lexicons/helm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-helm",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Helm chart lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -69,6 +69,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1"
+    "@intentius/chant": "^0.8.2"
   }
 }

--- a/lexicons/k8s/package.json
+++ b/lexicons/k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-k8s",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Kubernetes lexicon for chant — declarative IaC in TypeScript",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -70,6 +70,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1"
+    "@intentius/chant": "^0.8.2"
   }
 }

--- a/lexicons/temporal/package.json
+++ b/lexicons/temporal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant-lexicon-temporal",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Temporal lexicon for chant — server deployment, namespaces, search attributes, and schedules",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",
@@ -54,7 +54,7 @@
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && find dist -type f \\( -name \"*.js\" -o -name \"*.js.map\" \\) -delete"
   },
   "peerDependencies": {
-    "@intentius/chant": "^0.8.1"
+    "@intentius/chant": "^0.8.2"
   },
   "devDependencies": {
     "@intentius/chant": "*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentius/chant",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Declarative infrastructure-as-code toolkit — TypeScript on Node.js",
   "license": "Apache-2.0",
   "homepage": "https://intentius.io/chant",


### PR DESCRIPTION
Lockstep version bump to 0.8.2 across core + all lexicons (peers synced, peer-deps test green). Wires `@intentius/chant-lexicon-github-org` into `publish.yml` (prepack + publish, ordered after its `chant-lexicon-github` dependency) — the governance package is now functional end-to-end (config, App auth, diff, guardrails, runner, branch-protection cycle, dump, emitted pipeline, and the `chant-governance` CLI), so it's ready to ship. Merge then tag `chant-v0.8.2` to publish.