### PR TITLE
ci: unblock release — defer github-org first-publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,12 +96,12 @@ jobs:
           P=$(npm view @intentius/chant-lexicon-forgejo version 2>/dev/null || echo "none")
           [ "$V" = "$P" ] && echo "Already at $V, skipping" || npm publish --access public --provenance
 
-      - name: Publish @intentius/chant-lexicon-github-org
-        working-directory: lexicons/github-org
-        run: |
-          V=$(node -e "process.stdout.write(require('./package.json').version)")
-          P=$(npm view @intentius/chant-lexicon-github-org version 2>/dev/null || echo "none")
-          [ "$V" = "$P" ] && echo "Already at $V, skipping" || npm publish --access public --provenance
+# NOTE: @intentius/chant-lexicon-github-org is NOT published here yet. It is a new
+# package, and OIDC trusted publishing cannot bootstrap a package name that has no
+# trusted-publisher record on npm (first publish fails with ENEEDAUTH). It needs a
+# one-time bootstrap — configure trusted publishing for it on npmjs, or do a single
+# manual `npm publish` with an automation token — after which this step can be
+# re-added. Its build IS still verified via the prepack step in the test job.
 
       - name: Publish @intentius/chant-lexicon-k8s
         working-directory: lexicons/k8s


### PR DESCRIPTION
The 0.8.2 publish partially failed: github-org (a brand-new package) can't be published via OIDC trusted publishing on its first publish (ENEEDAUTH — no trusted-publisher record yet), and because it sat mid-order it blocked azure/k8s/gcp/helm/docker/temporal from publishing 0.8.2. This removes the github-org publish step (keeping its build check) so the rest of the ecosystem releases cleanly. github-org publish is re-added once bootstrapped on npm. After merge, re-run the publish workflow to push the stuck lexicons to 0.8.2.