### PR TITLE
fix(github-org): committed CLI bin launcher so the bin survives packing (#488)

### DIFF
--- a/lexicons/github-org/bin/chant-governance.js
+++ b/lexicons/github-org/bin/chant-governance.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * chant-governance bin launcher.
+ *
+ * This file is checked into git so it exists at npm pack-validation time
+ * (before `prepack` / `build` runs). It loads the built dist/cli.js — which
+ * is produced by `prepack` before the tarball is assembled — and calls the
+ * exported `run()` function with the process argv.
+ *
+ * Why a launcher instead of pointing `bin` at `dist/cli.js` directly:
+ *   npm validates `bin` paths BEFORE `prepack` runs. At that moment dist/cli.js
+ *   does not exist, so npm strips the bin entry. A committed launcher that
+ *   exists at pack time survives validation; dist/cli.js is still built and
+ *   included in the tarball by prepack.
+ */
+
+import(new URL("../dist/cli.js", import.meta.url).href).then((mod) => {
+  return mod.run(process.argv.slice(2));
+}).catch((err) => {
+  process.stderr.write(`chant-governance: fatal: ${err?.message ?? err}\n`);
+  process.exit(3);
+});

--- a/lexicons/github-org/package.json
+++ b/lexicons/github-org/package.json
@@ -23,9 +23,10 @@
   ],
   "type": "module",
   "bin": {
-    "chant-governance": "./dist/cli.js"
+    "chant-governance": "./bin/chant-governance.js"
   },
   "files": [
+    "bin/",
     "src/",
     "dist/"
   ],

--- a/lexicons/github-org/src/cli.ts
+++ b/lexicons/github-org/src/cli.ts
@@ -251,8 +251,7 @@ function buildClient(args: ReconcileArgs) {
 // Main
 // ---------------------------------------------------------------------------
 
-async function main() {
-  const argv = process.argv.slice(2);
+async function main(argv: string[] = process.argv.slice(2)) {
 
   // Top-level subcommand dispatch.
   const subcommand = argv[0];
@@ -648,6 +647,18 @@ function printUsage() {
       "",
     ].join("\n"),
   );
+}
+
+/**
+ * Public entry point for programmatic invocation.
+ *
+ * Accepts the raw argv array (everything after the binary name, i.e.
+ * `process.argv.slice(2)`). Called by the committed bin launcher
+ * `bin/chant-governance.js` so that the launcher can `import` this module
+ * and invoke the CLI without being the ESM `import.meta.url` entrypoint.
+ */
+export async function run(argv: string[]): Promise<void> {
+  await main(argv);
 }
 
 // Run only when invoked as the entrypoint (the installed `bin`), not when this


### PR DESCRIPTION
## Summary

- npm validates `bin` paths **before** `prepack` runs, so `dist/cli.js` doesn't exist at pack time and npm strips the `chant-governance` bin entry with "No bin file found at dist/cli.js … was invalid and removed"
- Add `bin/chant-governance.js` (checked into git, 931 B, ESM launcher with `#!/usr/bin/env node`) that `import()`s the built `../dist/cli.js` and calls the exported `run(argv)` function
- Export `run(argv: string[])` from `cli.ts` by making `main()` accept an optional argv parameter (defaults to `process.argv.slice(2)` — existing direct-entrypoint behavior unchanged)
- Point `package.json` `bin` at `./bin/chant-governance.js`; add `bin/` to `files`

## Evidence

**npm pack — bin retained (no "invalid and removed" warning):**
```
npm notice 📦  @intentius/chant-lexicon-github-org@0.8.2
npm notice 931B  bin/chant-governance.js        ← launcher in tarball
npm notice 24.0kB dist/cli.js                   ← built output in tarball
```

**Launcher executes the CLI:**
```
$ node lexicons/github-org/bin/chant-governance.js --help
Usage: chant-governance <subcommand> [flags]
...
EXIT: 0

$ node lexicons/github-org/bin/chant-governance.js reconcile --help
chant-governance: error: unknown flag: --help
EXIT: 2   ← reaches parser; correct exit code
```

**tsc:** `npx tsc --noEmit -p lexicons/github-org/tsconfig.json` → clean (exit 0)

**vitest:** 195 tests across 9 files — all pass

## Test plan

- [x] `npm run --prefix lexicons/github-org build` succeeds, `dist/cli.js` exists
- [x] `cd lexicons/github-org && npm pack --dry-run` — tarball contains `bin/chant-governance.js` and `dist/cli.js`; no "invalid and removed" warning in output
- [x] `node lexicons/github-org/bin/chant-governance.js --help` exits 0, prints usage
- [x] `node lexicons/github-org/bin/chant-governance.js reconcile --help` exits 2 (reaches arg parser)
- [x] `npx tsc --noEmit -p lexicons/github-org/tsconfig.json` clean
- [x] `npx vitest run lexicons/github-org` — 195/195 pass

Closes the code-fix half of #488. OIDC bootstrap (publishing) is a separate user action per the issue.