### PR TITLE
feat(graph): emit lint-gated entity-graph IR (chant graph --format ir)

### DIFF
--- a/packages/core/src/cli/handlers/graph.ts
+++ b/packages/core/src/cli/handlers/graph.ts
@@ -2,17 +2,52 @@ import { resolve } from "node:path";
 import { discoverOps } from "../../op/discover";
 import { discover } from "../../discovery/index";
 import { partitionByLexicon, computeStackGraph } from "../../build";
+import { buildGraphIr } from "../../graph-ir";
+import { lintCommand } from "../commands/lint";
 import { formatError, formatWarning, formatBold } from "../format";
 import type { CommandContext } from "../registry";
 
 /**
  * `chant graph` — the Op dependency graph by default; `--stacks` renders the
  * cross-stack apply-ordering graph (edges, order, waves) chant computes from
- * cross-lexicon references.
+ * cross-lexicon references; `--format ir` emits the full entity-graph IR
+ * (lint-gated) for diagram painters and the agentic diagrammer (#493).
  */
 export async function runGraph(ctx: CommandContext): Promise<number> {
+  if (ctx.args.format === "ir") return runGraphIr(ctx);
   if (ctx.args.stacks) return runStackGraph(ctx);
   return runOpGraph();
+}
+
+/**
+ * `chant graph --format ir` — emit the graph IR as JSON. Lint-gated: the IR is a
+ * representation of valid infra, so we refuse to emit it for source that does
+ * not pass lint (EVL + lexicon rules). Non-zero exit on discovery errors.
+ */
+async function runGraphIr(ctx: CommandContext): Promise<number> {
+  const projectPath = resolve(ctx.args.path === "." ? "." : ctx.args.path);
+
+  // Gate: only emit an IR for lint-clean source.
+  const lint = await lintCommand({ path: ctx.args.path, format: "stylish" });
+  if (!lint.success) {
+    console.error(
+      formatError({
+        message:
+          "Refusing to emit graph IR: source has lint errors. Run `chant lint` and fix them first.",
+      }),
+    );
+    return 1;
+  }
+
+  const result = await discover(projectPath);
+  if (result.errors.length > 0) {
+    for (const e of result.errors) console.error(formatError({ message: e.message }));
+    return 1;
+  }
+
+  const ir = buildGraphIr(result.entities, projectPath);
+  console.log(JSON.stringify(ir, null, 2));
+  return 0;
 }
 
 async function runOpGraph(): Promise<number> {

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -190,7 +190,8 @@ Ops:
   run cancel <name>     Cancel the active workflow run (requires --force)
   run log <name>        Show run history for an Op
 
-  graph                 Show Op dependency graph (--stacks for cross-stack order)
+  graph                 Show Op dependency graph (--stacks for cross-stack order,
+                        --format ir for the lint-gated entity-graph IR)
 
 Lifecycle (alias: lc):
   lifecycle snapshot <env>  Query API, save metadata to orphan branch

--- a/packages/core/src/graph-ir.test.ts
+++ b/packages/core/src/graph-ir.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect } from "vitest";
+import { buildGraphIr } from "./graph-ir";
+import { DECLARABLE_MARKER, type Declarable } from "./declarable";
+import { AttrRef } from "./attrref";
+import { resolveAttrRefs } from "./discovery/resolve";
+import { setProvenance } from "./provenance";
+
+function decl<T extends object>(base: T): Declarable & T {
+  return { [DECLARABLE_MARKER]: true, ...base } as Declarable & T;
+}
+
+describe("buildGraphIr", () => {
+  test("emits a node per resource with kind, lexicon, and scrubbed attrs", () => {
+    const vpc = decl({ lexicon: "gcp", entityType: "Vpc", props: { autoCreateSubnetworks: false } });
+    const entities = new Map<string, Declarable>([["vpc", vpc]]);
+    resolveAttrRefs(entities);
+
+    const ir = buildGraphIr(entities);
+    expect(ir.nodes).toHaveLength(1);
+    expect(ir.nodes[0]).toMatchObject({ id: "vpc", kind: "Vpc", lexicon: "gcp" });
+    // `props` is flattened into attrs (field reads as the property, not props.x).
+    expect(ir.nodes[0].attrs).toEqual({ autoCreateSubnetworks: false });
+    // Framework fields are scrubbed out of attrs.
+    expect(ir.nodes[0].attrs).not.toHaveProperty("lexicon");
+    expect(ir.nodes[0].attrs).not.toHaveProperty("entityType");
+  });
+
+  test("derives ref edges labelled with the consumer property", () => {
+    const vpc = decl({ lexicon: "gcp", entityType: "Vpc" });
+    const subnet = decl({ lexicon: "gcp", entityType: "Subnet", props: { network: new AttrRef(vpc, "id") } });
+    const entities = new Map<string, Declarable>([
+      ["vpc", vpc],
+      ["subnet", subnet],
+    ]);
+    resolveAttrRefs(entities);
+
+    const ir = buildGraphIr(entities);
+    expect(ir.edges).toEqual([{ from: "subnet", to: "vpc", kind: "ref", viaAttr: "network" }]);
+    // The ref also appears in the consumer's attrs as an auditable envelope.
+    expect(ir.nodes.find((n) => n.id === "subnet")!.attrs).toEqual({
+      network: { $ref: "vpc.id" },
+    });
+  });
+
+  test("excludes property-kind declarables and keeps resources", () => {
+    const resource = decl({ lexicon: "k8s", entityType: "Deployment" });
+    const prop = decl({ lexicon: "k8s", entityType: "Probe", kind: "property" as const });
+    const entities = new Map<string, Declarable>([
+      ["dep", resource],
+      ["probe", prop],
+    ]);
+    resolveAttrRefs(entities);
+
+    const ir = buildGraphIr(entities);
+    expect(ir.nodes.map((n) => n.id)).toEqual(["dep"]);
+  });
+
+  test("populates compositeParent and byComposite from provenance", () => {
+    const sts = decl({ lexicon: "k8s", entityType: "StatefulSet" });
+    const svc = decl({ lexicon: "k8s", entityType: "Service" });
+    setProvenance(sts, { composite: "CockroachDbCluster", sourceFile: "/proj/src/db.ts" });
+    setProvenance(svc, { composite: "CockroachDbCluster", sourceFile: "/proj/src/db.ts" });
+    const entities = new Map<string, Declarable>([
+      ["dbSts", sts],
+      ["dbSvc", svc],
+    ]);
+    resolveAttrRefs(entities);
+
+    const ir = buildGraphIr(entities, "/proj");
+    expect(ir.nodes.every((n) => n.compositeParent === "CockroachDbCluster")).toBe(true);
+    expect(ir.groups.byComposite).toEqual({ CockroachDbCluster: ["dbSts", "dbSvc"] });
+    // Source file is relativized to the project root.
+    expect(ir.nodes[0].sourceLoc).toEqual({ file: "src/db.ts" });
+  });
+
+  test("reads non-enumerable props like real lexicon entities", () => {
+    // Real lexicon resources define lexicon/entityType/props as non-enumerable,
+    // so Object.entries(entity) is empty — attrs and edges must come from props.
+    const vpc = decl({ lexicon: "gcp", entityType: "Vpc" });
+    const subnet = { [DECLARABLE_MARKER]: true } as Declarable & { props: unknown };
+    Object.defineProperties(subnet, {
+      lexicon: { value: "gcp", enumerable: false },
+      entityType: { value: "Subnet", enumerable: false },
+      props: { value: { cidr: "10.0.0.0/16", network: new AttrRef(vpc, "id") }, enumerable: false },
+    });
+    const entities = new Map<string, Declarable>([
+      ["vpc", vpc],
+      ["subnet", subnet],
+    ]);
+    resolveAttrRefs(entities);
+
+    const ir = buildGraphIr(entities);
+    const subnetNode = ir.nodes.find((n) => n.id === "subnet")!;
+    expect(subnetNode.attrs).toEqual({ cidr: "10.0.0.0/16", network: { $ref: "vpc.id" } });
+    expect(ir.edges).toEqual([{ from: "subnet", to: "vpc", kind: "ref", viaAttr: "network" }]);
+  });
+
+  test("groups nodes by lexicon and is deterministic", () => {
+    const a = decl({ lexicon: "gcp", entityType: "Vpc" });
+    const b = decl({ lexicon: "k8s", entityType: "Namespace" });
+    const c = decl({ lexicon: "gcp", entityType: "Subnet" });
+    const entities = new Map<string, Declarable>([
+      ["zeta", c],
+      ["alpha", a],
+      ["mid", b],
+    ]);
+    resolveAttrRefs(entities);
+
+    const ir = buildGraphIr(entities);
+    expect(ir.nodes.map((n) => n.id)).toEqual(["alpha", "mid", "zeta"]); // sorted
+    expect(ir.groups.byLexicon).toEqual({ gcp: ["alpha", "zeta"], k8s: ["mid"] });
+
+    // Same input (different insertion order) yields identical IR.
+    const reordered = new Map<string, Declarable>([
+      ["alpha", a],
+      ["mid", b],
+      ["zeta", c],
+    ]);
+    resolveAttrRefs(reordered);
+    expect(JSON.stringify(buildGraphIr(reordered))).toEqual(JSON.stringify(ir));
+  });
+});

--- a/packages/core/src/graph-ir.ts
+++ b/packages/core/src/graph-ir.ts
@@ -1,0 +1,278 @@
+import { relative, isAbsolute } from "node:path";
+import { AttrRef } from "./attrref";
+import { type Declarable, isDeclarable } from "./declarable";
+import { isLexiconOutput } from "./lexicon-output";
+import { getProvenance } from "./provenance";
+import { INTRINSIC_MARKER } from "./intrinsic";
+
+/**
+ * Graph IR — the engine-neutral, lint-gated representation of a project's
+ * resolved infrastructure graph. Painters (mermaid, graphviz, custom SVG) and
+ * the agentic diagrammer consume this; it is a pure function of lint-clean
+ * source. Every node traces to the file that declared it; every edge is a real
+ * cross-resource reference (AttrRef).
+ *
+ * Emitted by `chant graph --format ir`. See issue #493 / epic #492.
+ */
+
+/** Where in the source a node came from. Entity-level (file), not a line map. */
+export interface SourceLoc {
+  /** Path of the declaring file, relative to the project root when possible. */
+  file: string;
+  /**
+   * Line number, when available. Provenance is entity-level today, so this is
+   * usually absent — reserved for a future source map.
+   */
+  line?: number;
+}
+
+/** A reference in an attribute projection: `<producer>.<attribute>`. */
+export interface AttrRefEnvelope {
+  $ref: string;
+}
+
+/** One resource in the graph. */
+export interface IRNode {
+  /** Logical name (the export name, or composite-expanded name). */
+  id: string;
+  /** Resource type, e.g. "GkeCluster". */
+  kind: string;
+  /** Lexicon the resource belongs to, e.g. "gcp". */
+  lexicon: string;
+  /**
+   * Name of the composite that expanded this node, when it came from one.
+   * Composite-type-level today (e.g. "CockroachDbCluster"); instance-level
+   * grouping is a detail-tier concern (#494).
+   */
+  compositeParent?: string;
+  /** Literal/const/ref-resolved props. References appear as `{ $ref }`. */
+  attrs: Record<string, unknown>;
+  /** Where the node was declared. */
+  sourceLoc?: SourceLoc;
+}
+
+/** A directed dependency: `from` references an attribute of `to`. */
+export interface IREdge {
+  from: string;
+  to: string;
+  /** "ref" for an AttrRef-derived edge. */
+  kind: "ref";
+  /** The consumer-side property the reference flows through, when derivable. */
+  viaAttr?: string;
+}
+
+/** Grouping metadata for cluster/subgraph rendering. Maps group name -> node ids. */
+export interface IRGroups {
+  byLexicon?: Record<string, string[]>;
+  byComposite?: Record<string, string[]>;
+  /** Reserved for stack grouping (#494). */
+  byStack?: Record<string, string[]>;
+}
+
+/** The full graph IR for a project at the default (declarable) detail level. */
+export interface GraphIR {
+  nodes: IRNode[];
+  edges: IREdge[];
+  groups: IRGroups;
+}
+
+/** A node is anything that serializes to a resource — not a property or output. */
+function isNodeEntity(entity: Declarable): boolean {
+  if (isLexiconOutput(entity)) return false;
+  if (entity.kind === "property") return false;
+  return true;
+}
+
+function relFile(file: string | undefined, projectPath?: string): string | undefined {
+  if (!file) return undefined;
+  if (projectPath && isAbsolute(file)) {
+    const rel = relative(projectPath, file);
+    return rel.startsWith("..") ? file : rel;
+  }
+  return file;
+}
+
+/** Resolve the producer (logical name) an AttrRef points at. */
+function refTarget(ref: AttrRef, reverse: Map<object, string>): string | undefined {
+  // Nested refs (under `props`) aren't assigned a logical name by resolveAttrRefs,
+  // which only resolves top-level own props — so fall back to the parent's name.
+  const parent = ref.parent.deref();
+  return ref.getLogicalName() ?? (parent ? reverse.get(parent) : undefined);
+}
+
+/** Project a value into a JSON-safe, scrubbed form. References become `{ $ref }`. */
+function project(value: unknown, seen: Set<unknown>, reverse: Map<object, string>): unknown {
+  if (value === null) return null;
+  const t = typeof value;
+  if (t === "string" || t === "number" || t === "boolean") return value;
+  if (t !== "object") return undefined; // functions, symbols, undefined
+
+  if (value instanceof AttrRef) {
+    const to = refTarget(value, reverse);
+    return { $ref: to ? `${to}.${value.attribute}` : value.attribute } satisfies AttrRefEnvelope;
+  }
+  // Other intrinsics (interpolations, pseudo-parameters): mark, don't inline.
+  if ((value as Record<symbol, unknown>)[INTRINSIC_MARKER] === true) {
+    return { $intrinsic: true };
+  }
+
+  if (seen.has(value)) return undefined; // break cycles
+  seen.add(value);
+
+  // Nested declarables (e.g. an inlined property-kind resource) keep their
+  // config in a non-enumerable `props` bag, like top-level nodes — project that.
+  if (isDeclarable(value)) {
+    const out = projectConfig(value, seen, reverse);
+    seen.delete(value);
+    return out;
+  }
+
+  if (Array.isArray(value)) {
+    const out = value.map((v) => project(v, seen, reverse)).filter((v) => v !== undefined);
+    seen.delete(value);
+    return out;
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    const p = project(v, seen, reverse);
+    if (p !== undefined) out[k] = p;
+  }
+  seen.delete(value);
+  return out;
+}
+
+const SKIP_KEYS = new Set(["lexicon", "entityType", "kind", "attributes", "Ref"]);
+
+/** The config bag of a node, paired with each key. Lexicon entities keep their
+ * declared props in a (usually non-enumerable) `props` object; simpler entities
+ * carry config as enumerable own properties. We surface both, flattening `props`
+ * so a field reads as e.g. `network`, not `props.network`. */
+function configRoots(entity: Declarable): Array<[string, unknown]> {
+  const out: Array<[string, unknown]> = [];
+  for (const [k, v] of Object.entries(entity)) {
+    if (SKIP_KEYS.has(k) || k === "props") continue;
+    out.push([k, v]);
+  }
+  const props = (entity as unknown as { props?: unknown }).props;
+  if (props && typeof props === "object" && !Array.isArray(props)) {
+    for (const [k, v] of Object.entries(props as Record<string, unknown>)) out.push([k, v]);
+  }
+  return out;
+}
+
+/** Project a declarable's config bag (flattened props + enumerable own props). */
+function projectConfig(
+  entity: Declarable,
+  seen: Set<unknown>,
+  reverse: Map<object, string>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of configRoots(entity)) {
+    const p = project(v, seen, reverse);
+    if (p !== undefined) out[k] = p;
+  }
+  return out;
+}
+
+/** Collect ref edges from one node, labelling each with its consumer property. */
+function collectEdges(
+  entity: Declarable,
+  from: string,
+  nodeIds: Set<string>,
+  reverse: Map<object, string>,
+): IREdge[] {
+  const edges: IREdge[] = [];
+  const seen = new Set<unknown>();
+  const visit = (value: unknown, viaAttr: string): void => {
+    if (value === null || typeof value !== "object") return;
+    if (value instanceof AttrRef) {
+      const to = refTarget(value, reverse);
+      if (to && to !== from && nodeIds.has(to)) {
+        edges.push({ from, to, kind: "ref", viaAttr });
+      }
+      return;
+    }
+    if ((value as Record<symbol, unknown>)[INTRINSIC_MARKER] === true) return;
+    if (seen.has(value)) return;
+    seen.add(value);
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, viaAttr);
+      return;
+    }
+    for (const v of Object.values(value as Record<string, unknown>)) visit(v, viaAttr);
+  };
+  for (const [k, v] of configRoots(entity)) visit(v, k);
+  return edges;
+}
+
+/** Stable key for deduping and sorting an edge. */
+function edgeKey(e: IREdge): string {
+  return `${e.from}\0${e.to}\0${e.viaAttr ?? ""}`;
+}
+
+/**
+ * Build the graph IR from resolved entities (the output of `discover`). Pure and
+ * deterministic: nodes and edges are sorted, so the same source yields identical
+ * IR. `projectPath` relativizes source-file paths for portable output.
+ */
+export function buildGraphIr(
+  entities: Map<string, Declarable>,
+  projectPath?: string,
+): GraphIR {
+  // Reverse lookup for producers whose AttrRef logical name wasn't resolved.
+  const reverse = new Map<object, string>();
+  for (const [name, entity] of entities) reverse.set(entity, name);
+
+  const nodeIds = new Set<string>();
+  for (const [name, entity] of entities) {
+    if (isNodeEntity(entity)) nodeIds.add(name);
+  }
+
+  const nodes: IRNode[] = [];
+  const byLexicon: Record<string, string[]> = {};
+  const byComposite: Record<string, string[]> = {};
+
+  for (const [name, entity] of entities) {
+    if (!nodeIds.has(name)) continue;
+    const prov = getProvenance(entity);
+    const node: IRNode = {
+      id: name,
+      kind: entity.entityType,
+      lexicon: entity.lexicon,
+      attrs: projectConfig(entity, new Set(), reverse),
+    };
+    if (prov?.composite) node.compositeParent = prov.composite;
+    const file = relFile(prov?.sourceFile, projectPath);
+    if (file) node.sourceLoc = { file };
+    nodes.push(node);
+
+    (byLexicon[entity.lexicon] ??= []).push(name);
+    if (prov?.composite) (byComposite[prov.composite] ??= []).push(name);
+  }
+
+  const edgeMap = new Map<string, IREdge>();
+  for (const [name, entity] of entities) {
+    if (!nodeIds.has(name)) continue;
+    for (const e of collectEdges(entity, name, nodeIds, reverse)) {
+      edgeMap.set(edgeKey(e), e);
+    }
+  }
+
+  nodes.sort((a, b) => a.id.localeCompare(b.id));
+  const edges = [...edgeMap.values()].sort((a, b) => edgeKey(a).localeCompare(edgeKey(b)));
+  for (const ids of Object.values(byLexicon)) ids.sort();
+  for (const ids of Object.values(byComposite)) ids.sort();
+
+  const groups: IRGroups = {};
+  if (Object.keys(byLexicon).length) groups.byLexicon = sortKeys(byLexicon);
+  if (Object.keys(byComposite).length) groups.byComposite = sortKeys(byComposite);
+
+  return { nodes, edges, groups };
+}
+
+function sortKeys(rec: Record<string, string[]>): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const k of Object.keys(rec).sort()) out[k] = rec[k];
+  return out;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export * from "./discovery/graph";
 export * from "./discovery/index";
 export * from "./discovery/cache";
 export * from "./build";
+export * from "./graph-ir";
 export * from "./detectLexicon";
 export * from "./lint/parser";
 export * from "./lint/rule";


### PR DESCRIPTION
Closes #493. Part of epic #492.

## What

Adds `buildGraphIr()` and `chant graph --format ir` — the deterministic, lint-gated graph IR that diagram painters and the agentic diagrammer (pinhole, #498) consume. The IR is a pure function of lint-clean source; every node traces to a source file and every edge is a real cross-resource reference.

## IR shape

- **nodes** — `id`, `kind`, `lexicon`, optional `compositeParent`, scrubbed `attrs`, `sourceLoc`
- **edges** — real AttrRef references, labelled with the consumer-side property (`viaAttr`)
- **groups** — `byLexicon` and `byComposite`

References are projected as `{ $ref: "producer.attribute" }`; other intrinsics are marked, not inlined.

## Notes

- Reuses existing discovery/resolve/provenance — no recomputation of the graph.
- Reads **non-enumerable** lexicon props (the real entity shape) and inlines nested declarables, so `attrs` is fully populated for real lexicons.
- **Lint-gated**: refuses to emit for source with lint errors (EVL + lexicon rules).
- **Deterministic**: nodes/edges/groups sorted; identical output across runs (verified).
- IR type exported from `@intentius/chant` so downstream tools import it instead of mirroring it.

## Testing

- 6 new unit tests in `graph-ir.test.ts`, including a regression test for non-enumerable props.
- Existing graph-handler tests pass; tsc + eslint clean.
- Verified end-to-end on a real gitlab project: nodes, attrs, `byLexicon`, lint-refusal, byte-identical repeat runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)