### PR TITLE
feat(graph): detail tiers for the graph IR (--detail 0..3)

### DIFF
--- a/packages/core/src/cli/handlers/graph.ts
+++ b/packages/core/src/cli/handlers/graph.ts
@@ -3,6 +3,7 @@ import { discoverOps } from "../../op/discover";
 import { discover } from "../../discovery/index";
 import { partitionByLexicon, computeStackGraph } from "../../build";
 import { buildGraphIr } from "../../graph-ir";
+import { applyDetail, type DetailLevel } from "../../graph-detail";
 import { lintCommand } from "../commands/lint";
 import { formatError, formatWarning, formatBold } from "../format";
 import type { CommandContext } from "../registry";
@@ -27,6 +28,12 @@ export async function runGraph(ctx: CommandContext): Promise<number> {
 async function runGraphIr(ctx: CommandContext): Promise<number> {
   const projectPath = resolve(ctx.args.path === "." ? "." : ctx.args.path);
 
+  const level = ctx.args.detail ?? 2;
+  if (![0, 1, 2, 3].includes(level)) {
+    console.error(formatError({ message: `Invalid --detail ${level}. Expected 0, 1, 2, or 3.` }));
+    return 1;
+  }
+
   // Gate: only emit an IR for lint-clean source.
   const lint = await lintCommand({ path: ctx.args.path, format: "stylish" });
   if (!lint.success) {
@@ -45,7 +52,7 @@ async function runGraphIr(ctx: CommandContext): Promise<number> {
     return 1;
   }
 
-  const ir = buildGraphIr(result.entities, projectPath);
+  const ir = applyDetail(buildGraphIr(result.entities, projectPath), level as DetailLevel);
   console.log(JSON.stringify(ir, null, 2));
   return 0;
 }

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -126,6 +126,8 @@ export function parseArgs(args: string[]): ParsedArgs {
       result.theme = args[++i];
     } else if (arg === "--stacks") {
       result.stacks = true;
+    } else if (arg === "--detail") {
+      result.detail = Number(args[++i]);
     } else if (arg === "--base") {
       result.base = args[++i];
     } else if (arg === "--head") {
@@ -191,7 +193,8 @@ Ops:
   run log <name>        Show run history for an Op
 
   graph                 Show Op dependency graph (--stacks for cross-stack order,
-                        --format ir for the lint-gated entity-graph IR)
+                        --format ir for the lint-gated entity-graph IR;
+                        --detail 0..3: stacks|composites|declarables|attributes)
 
 Lifecycle (alias: lc):
   lifecycle snapshot <env>  Query API, save metadata to orphan branch

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -57,6 +57,8 @@ export interface ParsedArgs {
   env?: string;
   /** `chant graph --stacks` — render the cross-stack apply-ordering graph */
   stacks?: boolean;
+  /** `chant graph --format ir --detail <0..3>` — graph IR detail tier */
+  detail?: number;
   /** `chant lifecycle affected --base <ref>` — base git ref to diff against */
   base?: string;
   /** `chant lifecycle affected --head <ref>` — head git ref (default: working tree) */

--- a/packages/core/src/discovery/collect.ts
+++ b/packages/core/src/discovery/collect.ts
@@ -58,7 +58,7 @@ export function collectEntities(
                   "resolution",
                 );
               }
-              setProvenance(entity, { sourceFile: file });
+              setProvenance(entity, { sourceFile: file, compositeInstance: indexedName });
               entities.set(expandedName, entity);
             }
           }
@@ -73,7 +73,7 @@ export function collectEntities(
               "resolution",
             );
           }
-          setProvenance(entity, { sourceFile: file });
+          setProvenance(entity, { sourceFile: file, compositeInstance: name });
           entities.set(expandedName, entity);
         }
       } else if (isLexiconOutput(value)) {

--- a/packages/core/src/graph-detail.test.ts
+++ b/packages/core/src/graph-detail.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from "vitest";
+import { applyDetail, DETAIL } from "./graph-detail";
+import type { GraphIR } from "./graph-ir";
+
+// A small graph: a gcp vpc/subnet pair plus a k8s namespace and deployment that
+// came from one composite instance ("db"), with the deployment referencing the
+// subnet across lexicons.
+const base: GraphIR = {
+  nodes: [
+    { id: "vpc", kind: "Vpc", lexicon: "gcp", attrs: {} },
+    { id: "subnet", kind: "Subnet", lexicon: "gcp", attrs: { network: { $ref: "vpc.id" } } },
+    {
+      id: "dbNamespace",
+      kind: "Namespace",
+      lexicon: "k8s",
+      compositeParent: "DbStack",
+      compositeInstance: "db",
+      attrs: {},
+    },
+    {
+      id: "dbDeployment",
+      kind: "Deployment",
+      lexicon: "k8s",
+      compositeParent: "DbStack",
+      compositeInstance: "db",
+      attrs: { subnet: { $ref: "subnet.selfLink" } },
+    },
+  ],
+  edges: [
+    { from: "subnet", to: "vpc", kind: "ref", viaAttr: "network" },
+    { from: "dbDeployment", to: "subnet", kind: "ref", viaAttr: "subnet" },
+  ],
+  groups: { byLexicon: { gcp: ["subnet", "vpc"], k8s: ["dbDeployment", "dbNamespace"] } },
+};
+
+describe("applyDetail", () => {
+  test("T2 (declarables) is the identity", () => {
+    expect(applyDetail(base, DETAIL.DECLARABLES)).toBe(base);
+  });
+
+  test("T0 (stacks) collapses to one node per lexicon with cross-lexicon edges", () => {
+    const ir = applyDetail(base, DETAIL.STACKS);
+    expect(ir.nodes.map((n) => n.id)).toEqual(["gcp", "k8s"]);
+    expect(ir.nodes.every((n) => n.kind === "stack")).toBe(true);
+    // subnet→vpc is intra-gcp (dropped); dbDeployment→subnet is k8s→gcp (kept).
+    expect(ir.edges).toEqual([{ from: "k8s", to: "gcp", kind: "ref" }]);
+  });
+
+  test("T1 (composites) collapses a composite instance to a single node", () => {
+    const ir = applyDetail(base, DETAIL.COMPOSITES);
+    expect(ir.nodes.map((n) => n.id).sort()).toEqual(["db", "subnet", "vpc"]);
+    const db = ir.nodes.find((n) => n.id === "db")!;
+    expect(db).toMatchObject({ kind: "DbStack", lexicon: "k8s", attrs: { members: 2 } });
+    // The composite's external ref is preserved, remapped to the composite node.
+    expect(ir.edges).toContainEqual({ from: "db", to: "subnet", kind: "ref" });
+    // The intra-gcp edge survives with its label.
+    expect(ir.edges).toContainEqual({ from: "subnet", to: "vpc", kind: "ref", viaAttr: "network" });
+  });
+
+  test("T1 node count is between T0 and T2", () => {
+    const t0 = applyDetail(base, DETAIL.STACKS).nodes.length;
+    const t1 = applyDetail(base, DETAIL.COMPOSITES).nodes.length;
+    const t2 = applyDetail(base, DETAIL.DECLARABLES).nodes.length;
+    expect(t0).toBeLessThan(t1);
+    expect(t1).toBeLessThan(t2);
+  });
+
+  test("T3 (attributes) annotates edges with the producer attribute", () => {
+    const ir = applyDetail(base, DETAIL.ATTRIBUTES);
+    expect(ir.edges).toContainEqual({ from: "subnet", to: "vpc", kind: "ref", viaAttr: "network", toAttr: "id" });
+    expect(ir.edges).toContainEqual({
+      from: "dbDeployment",
+      to: "subnet",
+      kind: "ref",
+      viaAttr: "subnet",
+      toAttr: "selfLink",
+    });
+  });
+});

--- a/packages/core/src/graph-detail.ts
+++ b/packages/core/src/graph-detail.ts
@@ -1,0 +1,149 @@
+import type { GraphIR, IRNode, IREdge } from "./graph-ir";
+
+/**
+ * Detail tiers — the diagram "detail dial". Each level is a pure IR → IR
+ * transform over the base graph IR (no re-discovery), so every emitter and the
+ * painter get them for free. See issue #494 / epic #492.
+ *
+ * - 0 STACKS      — one node per lexicon; edges are cross-lexicon dependencies
+ * - 1 COMPOSITES  — composite instances collapsed to a single node each
+ * - 2 DECLARABLES — every resource (the base produced by buildGraphIr)
+ * - 3 ATTRIBUTES  — declarables plus the producer attribute on each edge
+ */
+export type DetailLevel = 0 | 1 | 2 | 3;
+
+export const DETAIL = {
+  STACKS: 0,
+  COMPOSITES: 1,
+  DECLARABLES: 2,
+  ATTRIBUTES: 3,
+} as const;
+
+/** Apply a detail tier to the base (declarable-level) IR. */
+export function applyDetail(ir: GraphIR, level: DetailLevel): GraphIR {
+  switch (level) {
+    case 0:
+      return toStacks(ir);
+    case 1:
+      return toComposites(ir);
+    case 3:
+      return toAttributes(ir);
+    case 2:
+    default:
+      return ir;
+  }
+}
+
+function edgeSortKey(e: IREdge): string {
+  return `${e.from}\0${e.to}\0${e.viaAttr ?? ""}`;
+}
+
+function sortEdges(edges: IREdge[]): IREdge[] {
+  return edges.sort((a, b) => edgeSortKey(a).localeCompare(edgeSortKey(b)));
+}
+
+function byLexiconOf(nodes: IRNode[]): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const n of nodes) (out[n.lexicon] ??= []).push(n.id);
+  const sorted: Record<string, string[]> = {};
+  for (const k of Object.keys(out).sort()) sorted[k] = out[k].sort();
+  return sorted;
+}
+
+/** T0 — collapse every resource to its lexicon; edges become cross-lexicon deps. */
+function toStacks(ir: GraphIR): GraphIR {
+  const lexOf = new Map(ir.nodes.map((n) => [n.id, n.lexicon]));
+  const lexicons = [...new Set(ir.nodes.map((n) => n.lexicon))].sort();
+  const nodes: IRNode[] = lexicons.map((l) => ({ id: l, kind: "stack", lexicon: l, attrs: {} }));
+
+  const seen = new Map<string, IREdge>();
+  for (const e of ir.edges) {
+    const from = lexOf.get(e.from);
+    const to = lexOf.get(e.to);
+    if (!from || !to || from === to) continue;
+    const key = `${from}\0${to}`;
+    if (!seen.has(key)) seen.set(key, { from, to, kind: "ref" });
+  }
+  return { nodes, edges: sortEdges([...seen.values()]), groups: {} };
+}
+
+/** T1 — collapse each composite instance to one node; internal edges disappear. */
+function toComposites(ir: GraphIR): GraphIR {
+  const idMap = new Map<string, string>();
+  for (const n of ir.nodes) idMap.set(n.id, n.compositeInstance ?? n.id);
+
+  const instances = new Map<string, IRNode[]>();
+  const plain: IRNode[] = [];
+  for (const n of ir.nodes) {
+    if (n.compositeInstance) {
+      const arr = instances.get(n.compositeInstance) ?? [];
+      arr.push(n);
+      instances.set(n.compositeInstance, arr);
+    } else {
+      plain.push({ ...n });
+    }
+  }
+
+  const nodes: IRNode[] = [...plain];
+  for (const [inst, members] of instances) {
+    const types = new Set(members.map((m) => m.compositeParent).filter(Boolean) as string[]);
+    const lexicons = new Set(members.map((m) => m.lexicon));
+    nodes.push({
+      id: inst,
+      kind: types.size === 1 ? [...types][0] : "Composite",
+      lexicon: lexicons.size === 1 ? [...lexicons][0] : "multi",
+      attrs: { members: members.length },
+    });
+  }
+
+  const seen = new Map<string, IREdge>();
+  for (const e of ir.edges) {
+    const from = idMap.get(e.from) ?? e.from;
+    const to = idMap.get(e.to) ?? e.to;
+    if (from === to) continue; // edge internal to a composite
+    // A property label only makes sense when neither endpoint was collapsed.
+    const collapsed = from !== e.from || to !== e.to;
+    const edge: IREdge = collapsed
+      ? { from, to, kind: "ref" }
+      : { from, to, kind: "ref", viaAttr: e.viaAttr };
+    const key = `${from}\0${to}\0${edge.viaAttr ?? ""}`;
+    if (!seen.has(key)) seen.set(key, edge);
+  }
+
+  nodes.sort((a, b) => a.id.localeCompare(b.id));
+  return { nodes, edges: sortEdges([...seen.values()]), groups: { byLexicon: byLexiconOf(nodes) } };
+}
+
+/** T3 — annotate each edge with the producer attribute it references. */
+function toAttributes(ir: GraphIR): GraphIR {
+  const nodeById = new Map(ir.nodes.map((n) => [n.id, n]));
+  const edges = ir.edges.map((e) => {
+    const node = nodeById.get(e.from);
+    const toAttr = node ? findRefAttr(node.attrs, e.to) : undefined;
+    return toAttr ? { ...e, toAttr } : { ...e };
+  });
+  return { ...ir, edges };
+}
+
+/** Find the attribute in a `{ $ref: "producer.attribute" }` envelope under attrs. */
+function findRefAttr(attrs: Record<string, unknown>, producer: string): string | undefined {
+  let found: string | undefined;
+  const visit = (v: unknown): void => {
+    if (found !== undefined || v === null || typeof v !== "object") return;
+    if (Array.isArray(v)) {
+      for (const item of v) visit(item);
+      return;
+    }
+    const ref = (v as { $ref?: unknown }).$ref;
+    if (typeof ref === "string") {
+      const dot = ref.indexOf(".");
+      if (dot > 0 && ref.slice(0, dot) === producer) {
+        found = ref.slice(dot + 1);
+        return;
+      }
+    }
+    for (const val of Object.values(v as Record<string, unknown>)) visit(val);
+  };
+  visit(attrs);
+  return found;
+}

--- a/packages/core/src/graph-ir.ts
+++ b/packages/core/src/graph-ir.ts
@@ -40,11 +40,15 @@ export interface IRNode {
   /** Lexicon the resource belongs to, e.g. "gcp". */
   lexicon: string;
   /**
-   * Name of the composite that expanded this node, when it came from one.
-   * Composite-type-level today (e.g. "CockroachDbCluster"); instance-level
-   * grouping is a detail-tier concern (#494).
+   * Name of the composite *type* that expanded this node, when it came from one
+   * (e.g. "CockroachDbCluster").
    */
   compositeParent?: string;
+  /**
+   * The composite *instance* (export name) this node belongs to — shared by every
+   * node from the same composite call. Detail tiers collapse on this (#494).
+   */
+  compositeInstance?: string;
   /** Literal/const/ref-resolved props. References appear as `{ $ref }`. */
   attrs: Record<string, unknown>;
   /** Where the node was declared. */
@@ -59,6 +63,8 @@ export interface IREdge {
   kind: "ref";
   /** The consumer-side property the reference flows through, when derivable. */
   viaAttr?: string;
+  /** The producer-side attribute referenced (e.g. "id"). Added at detail T3. */
+  toAttr?: string;
 }
 
 /** Grouping metadata for cluster/subgraph rendering. Maps group name -> node ids. */
@@ -243,6 +249,7 @@ export function buildGraphIr(
       attrs: projectConfig(entity, new Set(), reverse),
     };
     if (prov?.composite) node.compositeParent = prov.composite;
+    if (prov?.compositeInstance) node.compositeInstance = prov.compositeInstance;
     const file = relFile(prov?.sourceFile, projectPath);
     if (file) node.sourceLoc = { file };
     nodes.push(node);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export * from "./discovery/index";
 export * from "./discovery/cache";
 export * from "./build";
 export * from "./graph-ir";
+export * from "./graph-detail";
 export * from "./detectLexicon";
 export * from "./lint/parser";
 export * from "./lint/rule";

--- a/packages/core/src/provenance.ts
+++ b/packages/core/src/provenance.ts
@@ -15,8 +15,15 @@ const PROVENANCE = Symbol.for("chant.provenance");
 export interface EntityProvenance {
   /** Absolute path of the source file that declared (or exported) the entity. */
   sourceFile?: string;
-  /** The composite that expanded this entity, when it came from one. */
+  /** The composite (type) that expanded this entity, when it came from one. */
   composite?: string;
+  /**
+   * The composite *instance* this entity belongs to — the export name of the
+   * top-level composite, shared by every member it expanded to. Distinguishes
+   * two instances of the same composite type, which `composite` cannot. Used to
+   * collapse a composite to a single node at coarse diagram detail levels (#494).
+   */
+  compositeInstance?: string;
 }
 
 /**
@@ -30,6 +37,7 @@ export function setProvenance(entity: object, prov: EntityProvenance): void {
   if (existing) {
     existing.sourceFile ??= prov.sourceFile;
     existing.composite ??= prov.composite;
+    existing.compositeInstance ??= prov.compositeInstance;
     return;
   }
   Object.defineProperty(entity, PROVENANCE, {


### PR DESCRIPTION
Closes #494. Part of epic #492. Builds on #493.

## What

Adds the diagram **detail dial** — `chant graph --format ir --detail <0..3>` — as pure IR → IR transforms over the base graph IR. No re-discovery, so every emitter and the painter (pinhole, #498) inherit the tiers for free. This is the "describe a few, see all the pieces / turn it down" control.

- **T0 stacks** — one node per lexicon; edges become cross-lexicon dependencies
- **T1 composites** — collapse each composite instance to a single node; internal edges disappear, external refs remap to the composite node
- **T2 declarables** — the base produced by `buildGraphIr` (identity)
- **T3 attributes** — annotate each edge with the producer attribute referenced (`toAttr`)

## Composite-instance identity

T1 collapses by composite *instance*, not type — two `CockroachDbCluster` instances stay distinct. `compositeParent` (from #493) only carries the type, so this records the composite instance (the export name, shared by every expanded member) in provenance during expansion and surfaces it as `IRNode.compositeInstance`.

## Notes

- Tiers are deterministic (nodes/edges sorted) and inherit the #493 lint gate.
- `IREdge.toAttr` added (optional, populated only at T3).
- Verified end-to-end: a composite project collapses N member nodes to 1 at T1, to its lexicon at T0; `--detail 9` is rejected.

## Testing

- 5 new tests in `graph-detail.test.ts` (each tier + monotonic node counts T0<T1<T2).
- Full core suite green except the pre-existing `import.test.ts` failures (missing `lexicons/aws/dist` in a fresh checkout, unrelated). tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)