### PR TITLE
feat(graph): Mermaid emitter (chant graph --format mermaid)

### DIFF
--- a/packages/core/src/cli/handlers/graph.ts
+++ b/packages/core/src/cli/handlers/graph.ts
@@ -2,8 +2,9 @@ import { resolve } from "node:path";
 import { discoverOps } from "../../op/discover";
 import { discover } from "../../discovery/index";
 import { partitionByLexicon, computeStackGraph } from "../../build";
-import { buildGraphIr } from "../../graph-ir";
+import { buildGraphIr, type GraphIR } from "../../graph-ir";
 import { applyDetail, type DetailLevel } from "../../graph-detail";
+import { toMermaid } from "../../graph-mermaid";
 import { lintCommand } from "../commands/lint";
 import { formatError, formatWarning, formatBold } from "../format";
 import type { CommandContext } from "../registry";
@@ -11,21 +12,23 @@ import type { CommandContext } from "../registry";
 /**
  * `chant graph` — the Op dependency graph by default; `--stacks` renders the
  * cross-stack apply-ordering graph (edges, order, waves) chant computes from
- * cross-lexicon references; `--format ir` emits the full entity-graph IR
- * (lint-gated) for diagram painters and the agentic diagrammer (#493).
+ * cross-lexicon references; `--format ir|mermaid` emits the lint-gated
+ * entity-graph IR (or a Mermaid flowchart of it) for diagrams (#493/#496).
  */
 export async function runGraph(ctx: CommandContext): Promise<number> {
-  if (ctx.args.format === "ir") return runGraphIr(ctx);
+  if (ctx.args.format === "ir") return runGraphView(ctx, "ir");
+  if (ctx.args.format === "mermaid") return runGraphView(ctx, "mermaid");
   if (ctx.args.stacks) return runStackGraph(ctx);
   return runOpGraph();
 }
 
 /**
- * `chant graph --format ir` — emit the graph IR as JSON. Lint-gated: the IR is a
- * representation of valid infra, so we refuse to emit it for source that does
- * not pass lint (EVL + lexicon rules). Non-zero exit on discovery errors.
+ * `chant graph --format ir|mermaid` — build the graph IR (honouring `--detail`)
+ * and emit it as JSON or a Mermaid flowchart. Lint-gated: the IR represents
+ * valid infra, so we refuse to emit for source that does not pass lint (EVL +
+ * lexicon rules). Non-zero exit on discovery errors.
  */
-async function runGraphIr(ctx: CommandContext): Promise<number> {
+async function runGraphView(ctx: CommandContext, format: "ir" | "mermaid"): Promise<number> {
   const projectPath = resolve(ctx.args.path === "." ? "." : ctx.args.path);
 
   const level = ctx.args.detail ?? 2;
@@ -34,13 +37,13 @@ async function runGraphIr(ctx: CommandContext): Promise<number> {
     return 1;
   }
 
-  // Gate: only emit an IR for lint-clean source.
+  // Gate: only emit for lint-clean source.
   const lint = await lintCommand({ path: ctx.args.path, format: "stylish" });
   if (!lint.success) {
     console.error(
       formatError({
         message:
-          "Refusing to emit graph IR: source has lint errors. Run `chant lint` and fix them first.",
+          "Refusing to emit graph: source has lint errors. Run `chant lint` and fix them first.",
       }),
     );
     return 1;
@@ -52,8 +55,8 @@ async function runGraphIr(ctx: CommandContext): Promise<number> {
     return 1;
   }
 
-  const ir = applyDetail(buildGraphIr(result.entities, projectPath), level as DetailLevel);
-  console.log(JSON.stringify(ir, null, 2));
+  const ir: GraphIR = applyDetail(buildGraphIr(result.entities, projectPath), level as DetailLevel);
+  console.log(format === "mermaid" ? toMermaid(ir) : JSON.stringify(ir, null, 2));
   return 0;
 }
 

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -193,7 +193,8 @@ Ops:
   run log <name>        Show run history for an Op
 
   graph                 Show Op dependency graph (--stacks for cross-stack order,
-                        --format ir for the lint-gated entity-graph IR;
+                        --format ir|mermaid for the lint-gated entity-graph IR
+                        or a Mermaid flowchart of it;
                         --detail 0..3: stacks|composites|declarables|attributes)
 
 Lifecycle (alias: lc):

--- a/packages/core/src/graph-mermaid.test.ts
+++ b/packages/core/src/graph-mermaid.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from "vitest";
+import { toMermaid } from "./graph-mermaid";
+import type { GraphIR } from "./graph-ir";
+
+const ir: GraphIR = {
+  nodes: [
+    { id: "vpc", kind: "Vpc", lexicon: "gcp", attrs: {} },
+    { id: "subnet", kind: "Subnet", lexicon: "gcp", attrs: {} },
+    { id: "ns", kind: "Namespace", lexicon: "k8s", attrs: {} },
+  ],
+  edges: [
+    { from: "subnet", to: "vpc", kind: "ref", viaAttr: "network" },
+    { from: "ns", to: "subnet", kind: "ref", viaAttr: "subnet", toAttr: "selfLink" },
+  ],
+  groups: { byLexicon: { gcp: ["subnet", "vpc"], k8s: ["ns"] } },
+};
+
+describe("toMermaid", () => {
+  test("renders a flowchart with lexicon subgraphs, nodes, and labelled edges", () => {
+    const out = toMermaid(ir);
+    expect(out).toContain("flowchart TD");
+    expect(out).toContain('subgraph lex_gcp["gcp"]');
+    expect(out).toContain('subgraph lex_k8s["k8s"]');
+    // node label = name + kind on two lines
+    expect(out).toContain('vpc["vpc<br/>Vpc"]');
+    // edge with consumer-property label
+    expect(out).toContain("subnet -->|\"network\"| vpc");
+    // T3 edge shows consumer → producer attribute
+    expect(out).toContain('ns -->|"subnet → selfLink"| subnet');
+  });
+
+  test("is deterministic", () => {
+    expect(toMermaid(ir)).toEqual(toMermaid(ir));
+  });
+
+  test("sanitizes ids that aren't Mermaid-safe but keeps the human label", () => {
+    const dirty: GraphIR = {
+      nodes: [
+        { id: "east/db-0", kind: "StatefulSet", lexicon: "k8s", attrs: {} },
+        { id: "east/db-1", kind: "StatefulSet", lexicon: "k8s", attrs: {} },
+      ],
+      edges: [{ from: "east/db-1", to: "east/db-0", kind: "ref" }],
+      groups: {},
+    };
+    const out = toMermaid(dirty);
+    // ids are sanitized and unique
+    expect(out).toContain('east_db_0["east/db-0<br/>StatefulSet"]');
+    expect(out).toContain('east_db_1["east/db-1<br/>StatefulSet"]');
+    expect(out).toContain("east_db_1 --> east_db_0");
+  });
+
+  test("places ungrouped nodes at the top level", () => {
+    const out = toMermaid({
+      nodes: [{ id: "loner", kind: "Thing", lexicon: "x", attrs: {} }],
+      edges: [],
+      groups: {},
+    });
+    expect(out).toContain('loner["loner<br/>Thing"]');
+    expect(out).not.toContain("subgraph");
+  });
+});

--- a/packages/core/src/graph-mermaid.ts
+++ b/packages/core/src/graph-mermaid.ts
@@ -1,0 +1,85 @@
+import type { GraphIR, IRNode, IREdge } from "./graph-ir";
+
+/**
+ * Render the graph IR as a Mermaid `flowchart`. Mermaid is the zero-install
+ * default — it renders in GitHub, docs, and browsers with no native dependency,
+ * so `chant graph --format mermaid` gives a diagram out of the box without the
+ * standalone painter. Lower fidelity than a custom painter, but portable.
+ *
+ * Consumes whatever IR it is given, so it honours `--detail` and `--lens` for
+ * free (those are IR → IR transforms). See issue #496 / epic #492.
+ *
+ * Known limits: Mermaid owns layout, so there is little control over node
+ * placement, and very large graphs get hard to read — that is the trade-off for
+ * zero-install portability. Reach for the graphviz/custom-painter path (#497,
+ * pinhole) when fidelity matters.
+ */
+export function toMermaid(ir: GraphIR): string {
+  const ids = new Map<string, string>(); // logical name -> mermaid-safe id
+  for (const n of ir.nodes) safeId(n.id, ids);
+
+  const lines: string[] = ["flowchart TD"];
+
+  // Cluster by lexicon when grouping is available; nodes outside any group fall
+  // through to the top level. byLexicon is sorted, so output is deterministic.
+  const byLexicon = ir.groups.byLexicon;
+  const grouped = new Set<string>();
+  if (byLexicon) {
+    for (const [lexicon, members] of Object.entries(byLexicon)) {
+      lines.push(`  subgraph ${safeId(`lex_${lexicon}`, ids)}[${quote(lexicon)}]`);
+      for (const id of members) {
+        const node = ir.nodes.find((n) => n.id === id);
+        if (!node) continue;
+        grouped.add(id);
+        lines.push(`    ${nodeLine(node, ids)}`);
+      }
+      lines.push("  end");
+    }
+  }
+  for (const node of ir.nodes) {
+    if (grouped.has(node.id)) continue;
+    lines.push(`  ${nodeLine(node, ids)}`);
+  }
+
+  for (const e of ir.edges) {
+    lines.push(`  ${edgeLine(e, ids)}`);
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+function nodeLine(node: IRNode, ids: Map<string, string>): string {
+  const id = safeId(node.id, ids);
+  const parts = [node.id];
+  if (node.kind && node.kind !== node.id) parts.push(node.kind);
+  return `${id}[${quote(parts.join("\n"))}]`;
+}
+
+function edgeLine(e: IREdge, ids: Map<string, string>): string {
+  const from = safeId(e.from, ids);
+  const to = safeId(e.to, ids);
+  const label = [e.viaAttr, e.toAttr].filter(Boolean).join(" → ");
+  return label ? `${from} -->|${quote(label)}| ${to}` : `${from} --> ${to}`;
+}
+
+/** Map an arbitrary logical name to a stable, unique Mermaid-safe node id. */
+function safeId(raw: string, ids: Map<string, string>): string {
+  const existing = ids.get(raw);
+  if (existing) return existing;
+  let base = raw.replace(/[^A-Za-z0-9_]/g, "_");
+  if (base === "" || /^[0-9]/.test(base)) base = `n_${base}`;
+  const taken = new Set(ids.values());
+  let candidate = base;
+  let i = 1;
+  while (taken.has(candidate)) candidate = `${base}_${i++}`;
+  ids.set(raw, candidate);
+  return candidate;
+}
+
+/** Quote a Mermaid label, escaping markup and turning newlines into <br/>. */
+function quote(text: string): string {
+  const esc = (s: string): string =>
+    s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const body = text.split("\n").map(esc).join("<br/>");
+  return `"${body}"`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export * from "./discovery/cache";
 export * from "./build";
 export * from "./graph-ir";
 export * from "./graph-detail";
+export * from "./graph-mermaid";
 export * from "./detectLexicon";
 export * from "./lint/parser";
 export * from "./lint/rule";


### PR DESCRIPTION
Closes #496. Part of epic #492. Builds on #493/#494.

## What

`chant graph --format mermaid` renders the graph IR as a Mermaid `flowchart` — the **zero-install diagram default**. It renders in GitHub, docs, and browsers with no native dependency, so you get a diagram out of the box without the standalone painter (pinhole). Lower fidelity than a custom painter, but portable.

- Lexicon subgraphs from IR groups; ungrouped nodes at the top level
- Edges labelled with the consumer property (and the producer attribute at detail T3)
- Node ids sanitized + uniquified for Mermaid; the human name is kept as the label
- Consumes the transformed IR, so `--detail` (and future `--lens`, #495) flow through for free

## Notes

- Refactors the graph handler to share the lint-gated IR build between `--format ir` and `--format mermaid`.
- Deterministic output (IR is already sorted).
- Known limits documented in the module: Mermaid owns layout, so little placement control and large graphs get dense — the trade-off for zero-install. Use the graphviz/custom-painter path (#497, pinhole) when fidelity matters.

## Testing

- 4 new tests in `graph-mermaid.test.ts` (subgraphs/labels, determinism, id sanitization, ungrouped nodes).
- Verified end-to-end: a composite project renders `ciBuild`/`ciTest` at T2 and collapses to `ci`/`Pipeline` at `--detail 1`.
- Full core suite green except the pre-existing `import.test.ts` failures (missing `lexicons/aws/dist` in a fresh checkout, unrelated). tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)