### PR TITLE
feat(graph): Graphviz DOT emitter + layout-position export

### DIFF
--- a/packages/core/src/cli/handlers/graph.ts
+++ b/packages/core/src/cli/handlers/graph.ts
@@ -5,6 +5,8 @@ import { partitionByLexicon, computeStackGraph } from "../../build";
 import { buildGraphIr, type GraphIR } from "../../graph-ir";
 import { applyDetail, type DetailLevel } from "../../graph-detail";
 import { toMermaid } from "../../graph-mermaid";
+import { toDot } from "../../graph-dot";
+import { GraphvizLayout } from "../../graph-layout";
 import { lintCommand } from "../commands/lint";
 import { formatError, formatWarning, formatBold } from "../format";
 import type { CommandContext } from "../registry";
@@ -16,19 +18,25 @@ import type { CommandContext } from "../registry";
  * entity-graph IR (or a Mermaid flowchart of it) for diagrams (#493/#496).
  */
 export async function runGraph(ctx: CommandContext): Promise<number> {
-  if (ctx.args.format === "ir") return runGraphView(ctx, "ir");
-  if (ctx.args.format === "mermaid") return runGraphView(ctx, "mermaid");
+  const viewFormats = ["ir", "mermaid", "dot", "layout"] as const;
+  if ((viewFormats as readonly string[]).includes(ctx.args.format)) {
+    return runGraphView(ctx, ctx.args.format as (typeof viewFormats)[number]);
+  }
   if (ctx.args.stacks) return runStackGraph(ctx);
   return runOpGraph();
 }
 
 /**
- * `chant graph --format ir|mermaid` — build the graph IR (honouring `--detail`)
- * and emit it as JSON or a Mermaid flowchart. Lint-gated: the IR represents
- * valid infra, so we refuse to emit for source that does not pass lint (EVL +
- * lexicon rules). Non-zero exit on discovery errors.
+ * `chant graph --format ir|mermaid|dot|layout` — build the graph IR (honouring
+ * `--detail`) and emit it as JSON, a Mermaid flowchart, Graphviz DOT, or node
+ * positions from a layout engine. Lint-gated: the IR represents valid infra, so
+ * we refuse to emit for source that does not pass lint. Non-zero on discovery
+ * errors, or on a missing `dot` for `--format layout`.
  */
-async function runGraphView(ctx: CommandContext, format: "ir" | "mermaid"): Promise<number> {
+async function runGraphView(
+  ctx: CommandContext,
+  format: "ir" | "mermaid" | "dot" | "layout",
+): Promise<number> {
   const projectPath = resolve(ctx.args.path === "." ? "." : ctx.args.path);
 
   const level = ctx.args.detail ?? 2;
@@ -56,8 +64,28 @@ async function runGraphView(ctx: CommandContext, format: "ir" | "mermaid"): Prom
   }
 
   const ir: GraphIR = applyDetail(buildGraphIr(result.entities, projectPath), level as DetailLevel);
-  console.log(format === "mermaid" ? toMermaid(ir) : JSON.stringify(ir, null, 2));
-  return 0;
+
+  switch (format) {
+    case "mermaid":
+      console.log(toMermaid(ir));
+      return 0;
+    case "dot":
+      console.log(toDot(ir));
+      return 0;
+    case "layout":
+      try {
+        const layout = await new GraphvizLayout().layout(toDot(ir));
+        console.log(JSON.stringify(layout, null, 2));
+        return 0;
+      } catch (err) {
+        console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+        return 1;
+      }
+    case "ir":
+    default:
+      console.log(JSON.stringify(ir, null, 2));
+      return 0;
+  }
 }
 
 async function runOpGraph(): Promise<number> {

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -193,8 +193,9 @@ Ops:
   run log <name>        Show run history for an Op
 
   graph                 Show Op dependency graph (--stacks for cross-stack order,
-                        --format ir|mermaid for the lint-gated entity-graph IR
-                        or a Mermaid flowchart of it;
+                        --format ir|mermaid|dot|layout for the lint-gated graph IR,
+                        a Mermaid flowchart, Graphviz DOT, or node positions
+                        (layout needs graphviz);
                         --detail 0..3: stacks|composites|declarables|attributes)
 
 Lifecycle (alias: lc):

--- a/packages/core/src/graph-dot.test.ts
+++ b/packages/core/src/graph-dot.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "vitest";
+import { toDot } from "./graph-dot";
+import { parseDotJson } from "./graph-layout";
+import type { GraphIR } from "./graph-ir";
+
+const ir: GraphIR = {
+  nodes: [
+    { id: "vpc", kind: "Vpc", lexicon: "gcp", attrs: {} },
+    { id: "subnet", kind: "Subnet", lexicon: "gcp", attrs: {} },
+    { id: "ns", kind: "Namespace", lexicon: "k8s", attrs: {} },
+  ],
+  edges: [
+    { from: "subnet", to: "vpc", kind: "ref", viaAttr: "network" },
+    { from: "ns", to: "subnet", kind: "ref", viaAttr: "subnet", toAttr: "selfLink" },
+  ],
+  groups: { byLexicon: { gcp: ["subnet", "vpc"], k8s: ["ns"] } },
+};
+
+describe("toDot", () => {
+  test("emits a digraph with lexicon clusters, nodes, and labelled edges", () => {
+    const dot = toDot(ir);
+    expect(dot).toContain("digraph chant {");
+    expect(dot).toContain('subgraph "cluster_gcp" {');
+    expect(dot).toContain('label="gcp";');
+    expect(dot).toContain('"vpc" [label="vpc\\nVpc"];');
+    expect(dot).toContain('"subnet" -> "vpc" [label="network"];');
+    expect(dot).toContain('"ns" -> "subnet" [label="subnet → selfLink"];');
+  });
+
+  test("is deterministic", () => {
+    expect(toDot(ir)).toEqual(toDot(ir));
+  });
+
+  test("places ungrouped nodes at the top level", () => {
+    const dot = toDot({
+      nodes: [{ id: "loner", kind: "Thing", lexicon: "x", attrs: {} }],
+      edges: [],
+      groups: {},
+    });
+    expect(dot).toContain('"loner" [label="loner\\nThing"];');
+    expect(dot).not.toContain("subgraph");
+  });
+});
+
+describe("parseDotJson", () => {
+  test("parses bounding box and node positions, sorted by id", () => {
+    const json = JSON.stringify({
+      bb: "0,0,200,300",
+      objects: [
+        { name: "vpc", pos: "100,280" },
+        { name: "subnet", pos: "100,20" },
+      ],
+    });
+    const layout = parseDotJson(json);
+    expect(layout).toEqual({
+      width: 200,
+      height: 300,
+      nodes: [
+        { id: "subnet", x: 100, y: 20 },
+        { id: "vpc", x: 100, y: 280 },
+      ],
+    });
+  });
+
+  test("throws on a malformed bounding box", () => {
+    expect(() => parseDotJson(JSON.stringify({ bb: "0,0", objects: [] }))).toThrow();
+  });
+});

--- a/packages/core/src/graph-dot.ts
+++ b/packages/core/src/graph-dot.ts
@@ -1,0 +1,58 @@
+import type { GraphIR, IRNode, IREdge } from "./graph-ir";
+
+/**
+ * Render the graph IR as Graphviz DOT. Pure text — no `dot` needed to produce
+ * it. Two consumers: render directly with `dot -Tsvg` (mingrammer-style), or
+ * feed it to a layout engine for node positions that a custom painter draws
+ * (the rackattack pattern; see {@link toLayout}). See issue #497 / epic #492.
+ *
+ * Consumes whatever IR it is given, so `--detail` (and future `--lens`) flow
+ * through for free.
+ */
+export function toDot(ir: GraphIR): string {
+  const lines: string[] = ["digraph chant {", "  rankdir=TB;", '  node [shape=box];'];
+
+  const byLexicon = ir.groups.byLexicon;
+  const grouped = new Set<string>();
+  if (byLexicon) {
+    for (const [lexicon, members] of Object.entries(byLexicon)) {
+      lines.push(`  subgraph ${q(`cluster_${lexicon}`)} {`);
+      lines.push(`    label=${q(lexicon)};`);
+      for (const id of members) {
+        const node = ir.nodes.find((n) => n.id === id);
+        if (!node) continue;
+        grouped.add(id);
+        lines.push(`    ${nodeLine(node)}`);
+      }
+      lines.push("  }");
+    }
+  }
+  for (const node of ir.nodes) {
+    if (grouped.has(node.id)) continue;
+    lines.push(`  ${nodeLine(node)}`);
+  }
+
+  for (const e of ir.edges) lines.push(`  ${edgeLine(e)}`);
+
+  lines.push("}");
+  return lines.join("\n") + "\n";
+}
+
+function nodeLine(node: IRNode): string {
+  const label = node.kind && node.kind !== node.id ? `${node.id}\n${node.kind}` : node.id;
+  return `${q(node.id)} [label=${q(label)}];`;
+}
+
+function edgeLine(e: IREdge): string {
+  const from = q(e.from);
+  const to = q(e.to);
+  const label = [e.viaAttr, e.toAttr].filter(Boolean).join(" → ");
+  return label ? `${from} -> ${to} [label=${q(label)}];` : `${from} -> ${to};`;
+}
+
+/** Quote a DOT identifier/label. Graphviz accepts any string in double quotes;
+ * a real newline becomes the DOT line-break escape. */
+function q(s: string): string {
+  const esc = s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+  return `"${esc}"`;
+}

--- a/packages/core/src/graph-layout.ts
+++ b/packages/core/src/graph-layout.ts
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+
+/**
+ * Layout-position export — node coordinates a custom painter consumes (the
+ * rackattack pattern: Graphviz lays out, the painter draws). Graphviz is used
+ * for LAYOUT ONLY; its rendering is discarded. See issue #497 / epic #492.
+ *
+ * The {@link LayoutEngine} interface exists so a pure-JS engine (elkjs/dagre)
+ * can drop in later for a zero-native-dependency path — closing the install gap
+ * so a painter can run without `dot`.
+ */
+
+/** A laid-out position in the engine's coordinate space. */
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/** Node positions plus the overall canvas size a painter needs. */
+export interface Layout {
+  /** Canvas width in the engine's coordinate space. */
+  width: number;
+  /** Canvas height in the engine's coordinate space. */
+  height: number;
+  /** Each node's centre position, ordered by id for deterministic output. */
+  nodes: Array<{ id: string } & Point>;
+}
+
+/** Turns DOT into node positions. The painter consumes the result; it never
+ * asks the engine to paint. */
+export interface LayoutEngine {
+  readonly name: string;
+  layout(dot: string): Promise<Layout>;
+}
+
+/** Layout via `dot -Tjson`. Requires Graphviz (`brew install graphviz`). */
+export class GraphvizLayout implements LayoutEngine {
+  readonly name = "graphviz";
+
+  async layout(dot: string): Promise<Layout> {
+    return parseDotJson(await runDot(dot));
+  }
+}
+
+function runDot(dot: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let proc;
+    try {
+      proc = spawn("dot", ["-Tjson"], { stdio: ["pipe", "pipe", "pipe"] });
+    } catch (err) {
+      reject(installHint(err));
+      return;
+    }
+    let out = "";
+    let errOut = "";
+    proc.stdout.on("data", (d) => (out += d));
+    proc.stderr.on("data", (d) => (errOut += d));
+    proc.on("error", (err) => reject(installHint(err)));
+    proc.on("close", (code) => {
+      if (code !== 0) reject(new Error(`dot exited ${code}: ${errOut.trim()}`));
+      else resolve(out);
+    });
+    proc.stdin.write(dot);
+    proc.stdin.end();
+  });
+}
+
+function installHint(err: unknown): Error {
+  const msg = err instanceof Error ? err.message : String(err);
+  return new Error(
+    `could not run 'dot' (${msg}). Graphviz is required for --format layout — ` +
+      `install it with 'brew install graphviz', or use --format mermaid, which needs no native dependency.`,
+  );
+}
+
+interface DotJson {
+  bb?: string;
+  objects?: Array<{ name?: string; pos?: string }>;
+}
+
+/** Parse `dot -Tjson` output into a {@link Layout}. Pure; exported for testing. */
+export function parseDotJson(json: string): Layout {
+  const parsed = JSON.parse(json) as DotJson;
+  const bb = (parsed.bb ?? "").split(",");
+  if (bb.length !== 4) throw new Error(`bad bounding box ${parsed.bb}`);
+  const width = num(bb[2]);
+  const height = num(bb[3]);
+  if (width === 0 || height === 0) throw new Error("zero graph bounds");
+
+  const nodes: Array<{ id: string } & Point> = [];
+  for (const o of parsed.objects ?? []) {
+    if (!o.name || !o.pos) continue;
+    const p = o.pos.split(",");
+    if (p.length !== 2) continue;
+    nodes.push({ id: o.name, x: num(p[0]), y: num(p[1]) });
+  }
+  nodes.sort((a, b) => a.id.localeCompare(b.id));
+  return { width, height, nodes };
+}
+
+function num(s: string): number {
+  const f = Number.parseFloat(s.trim());
+  return Number.isFinite(f) ? f : 0;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,8 @@ export * from "./build";
 export * from "./graph-ir";
 export * from "./graph-detail";
 export * from "./graph-mermaid";
+export * from "./graph-dot";
+export * from "./graph-layout";
 export * from "./detectLexicon";
 export * from "./lint/parser";
 export * from "./lint/rule";


### PR DESCRIPTION
Closes #497. Part of epic #492. Builds on #493/#494.

## What

Two graphviz outputs from the graph IR:

- **`--format dot`** — pure DOT text (no `dot` needed to produce it): lexicon clusters from IR groups, labelled edges, node labels. Render directly with `dot -Tsvg` (mingrammer-style), or feed it to a layout engine.
- **`--format layout`** — node positions via a `LayoutEngine`. `GraphvizLayout` shells to `dot -Tjson` (layout only, rendering discarded) and emits `{ width, height, nodes: [{id,x,y}] }` — exactly what a custom painter consumes (the rackattack pattern). pinhole can drop its locally reimplemented graphviz layout once this lands.

## Notes

- `LayoutEngine` is an interface so a pure-JS engine (elkjs/dagre) can drop in later for a zero-native-dependency path — closing the install gap so a painter can run without `dot`.
- Clear install hint when `dot` is missing, pointing at `--format mermaid` (the no-dependency alternative).
- Both honour `--detail` (and future `--lens`) since they consume the transformed IR. Deterministic output.

## Testing

- 5 new tests in `graph-dot.test.ts`: `toDot` (clusters/labels/edges, determinism, ungrouped nodes) and `parseDotJson` (positions sorted by id, malformed bb throws). Unit tests stay pure — no live `dot` dependency, so CI is unaffected.
- Verified end-to-end with graphviz installed: `--format dot` emits clustered DOT; `--format layout` returns parsed `{width,height,nodes}`.
- Full core suite green except the pre-existing `import.test.ts` failures (missing `lexicons/aws/dist` in a fresh checkout, unrelated). tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)