### PR TITLE
feat(graph): lenses to focus the graph IR (--lens lexicon|stack|blast)

### DIFF
--- a/packages/core/src/cli/handlers/graph.ts
+++ b/packages/core/src/cli/handlers/graph.ts
@@ -4,6 +4,7 @@ import { discover } from "../../discovery/index";
 import { partitionByLexicon, computeStackGraph } from "../../build";
 import { buildGraphIr, type GraphIR } from "../../graph-ir";
 import { applyDetail, type DetailLevel } from "../../graph-detail";
+import { applyLens, parseLens } from "../../graph-lens";
 import { toMermaid } from "../../graph-mermaid";
 import { toDot } from "../../graph-dot";
 import { GraphvizLayout } from "../../graph-layout";
@@ -63,7 +64,18 @@ async function runGraphView(
     return 1;
   }
 
-  const ir: GraphIR = applyDetail(buildGraphIr(result.entities, projectPath), level as DetailLevel);
+  // Build the base IR, focus with a lens (declarable-level, most precise), then
+  // apply the detail tier — so e.g. blast:<resource> works before any collapse.
+  let ir: GraphIR = buildGraphIr(result.entities, projectPath);
+  if (ctx.args.lens) {
+    try {
+      ir = applyLens(ir, parseLens(ctx.args.lens, { up: ctx.args.up, down: ctx.args.down }));
+    } catch (err) {
+      console.error(formatError({ message: err instanceof Error ? err.message : String(err) }));
+      return 1;
+    }
+  }
+  ir = applyDetail(ir, level as DetailLevel);
 
   switch (format) {
     case "mermaid":

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -128,6 +128,12 @@ export function parseArgs(args: string[]): ParsedArgs {
       result.stacks = true;
     } else if (arg === "--detail") {
       result.detail = Number(args[++i]);
+    } else if (arg === "--lens") {
+      result.lens = args[++i];
+    } else if (arg === "--up") {
+      result.up = true;
+    } else if (arg === "--down") {
+      result.down = true;
     } else if (arg === "--base") {
       result.base = args[++i];
     } else if (arg === "--head") {
@@ -196,7 +202,8 @@ Ops:
                         --format ir|mermaid|dot|layout for the lint-gated graph IR,
                         a Mermaid flowchart, Graphviz DOT, or node positions
                         (layout needs graphviz);
-                        --detail 0..3: stacks|composites|declarables|attributes)
+                        --detail 0..3: stacks|composites|declarables|attributes;
+                        --lens lexicon:<n>|stack:<n>|blast:<node> (--up/--down))
 
 Lifecycle (alias: lc):
   lifecycle snapshot <env>  Query API, save metadata to orphan branch

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -59,6 +59,12 @@ export interface ParsedArgs {
   stacks?: boolean;
   /** `chant graph --format ir --detail <0..3>` — graph IR detail tier */
   detail?: number;
+  /** `chant graph --lens <kind>:<target>` — focus the graph IR on a slice */
+  lens?: string;
+  /** `chant graph --lens blast:<node> --up` — include upstream producers */
+  up?: boolean;
+  /** `chant graph --lens blast:<node> --down` — include downstream dependents */
+  down?: boolean;
   /** `chant lifecycle affected --base <ref>` — base git ref to diff against */
   base?: string;
   /** `chant lifecycle affected --head <ref>` — head git ref (default: working tree) */

--- a/packages/core/src/graph-lens.test.ts
+++ b/packages/core/src/graph-lens.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from "vitest";
+import { parseLens, applyLens } from "./graph-lens";
+import type { GraphIR } from "./graph-ir";
+
+// vpc <- subnet <- cluster (gcp), cluster <- pod (k8s). A linear dependency
+// chain crossing two lexicons.
+const ir: GraphIR = {
+  nodes: [
+    { id: "vpc", kind: "Vpc", lexicon: "gcp", attrs: {} },
+    { id: "subnet", kind: "Subnet", lexicon: "gcp", attrs: {} },
+    { id: "cluster", kind: "GkeCluster", lexicon: "gcp", attrs: {} },
+    { id: "pod", kind: "Pod", lexicon: "k8s", attrs: {} },
+  ],
+  edges: [
+    { from: "subnet", to: "vpc", kind: "ref", viaAttr: "network" },
+    { from: "cluster", to: "subnet", kind: "ref", viaAttr: "subnetwork" },
+    { from: "pod", to: "cluster", kind: "ref", viaAttr: "cluster" },
+  ],
+  groups: { byLexicon: { gcp: ["cluster", "subnet", "vpc"], k8s: ["pod"] } },
+};
+
+describe("parseLens", () => {
+  test("parses kind:target", () => {
+    expect(parseLens("lexicon:gcp")).toMatchObject({ kind: "lexicon", target: "gcp" });
+  });
+  test("blast defaults to both directions", () => {
+    expect(parseLens("blast:cluster")).toMatchObject({ up: true, down: true });
+  });
+  test("blast honours --up / --down", () => {
+    expect(parseLens("blast:cluster", { up: true })).toMatchObject({ up: true, down: false });
+  });
+  test("rejects malformed and unknown lenses", () => {
+    expect(() => parseLens("gcp")).toThrow();
+    expect(() => parseLens("bogus:x")).toThrow();
+  });
+});
+
+describe("applyLens", () => {
+  test("lexicon: keeps only that lexicon's nodes and internal edges", () => {
+    const out = applyLens(ir, parseLens("lexicon:gcp"));
+    expect(out.nodes.map((n) => n.id).sort()).toEqual(["cluster", "subnet", "vpc"]);
+    // cross-lexicon pod→cluster edge dropped; gcp-internal edges kept
+    expect(out.edges.map((e) => `${e.from}->${e.to}`).sort()).toEqual([
+      "cluster->subnet",
+      "subnet->vpc",
+    ]);
+    expect(out.groups.byLexicon).toEqual({ gcp: ["cluster", "subnet", "vpc"] });
+  });
+
+  test("lexicon: count matches the byLexicon partition", () => {
+    const out = applyLens(ir, parseLens("lexicon:gcp"));
+    expect(out.nodes.length).toBe(ir.groups.byLexicon!.gcp.length);
+  });
+
+  test("blast --up returns the producer chain above a node", () => {
+    const out = applyLens(ir, parseLens("blast:cluster", { up: true }));
+    expect(out.nodes.map((n) => n.id).sort()).toEqual(["cluster", "subnet", "vpc"]);
+  });
+
+  test("blast --down returns the dependents below a node", () => {
+    const out = applyLens(ir, parseLens("blast:cluster", { down: true }));
+    expect(out.nodes.map((n) => n.id).sort()).toEqual(["cluster", "pod"]);
+  });
+
+  test("blast both returns the whole connected chain", () => {
+    const out = applyLens(ir, parseLens("blast:cluster"));
+    expect(out.nodes.map((n) => n.id).sort()).toEqual(["cluster", "pod", "subnet", "vpc"]);
+  });
+
+  test("blast on a leaf returns just its chain", () => {
+    const out = applyLens(ir, parseLens("blast:vpc", { up: true }));
+    expect(out.nodes.map((n) => n.id)).toEqual(["vpc"]); // vpc depends on nothing
+    expect(out.edges).toEqual([]);
+  });
+
+  test("throws when the target matches nothing", () => {
+    expect(() => applyLens(ir, parseLens("lexicon:aws"))).toThrow();
+    expect(() => applyLens(ir, parseLens("blast:ghost"))).toThrow();
+  });
+});

--- a/packages/core/src/graph-lens.ts
+++ b/packages/core/src/graph-lens.ts
@@ -1,0 +1,127 @@
+import type { GraphIR, IRNode, IREdge } from "./graph-ir";
+
+/**
+ * Lenses — focus the graph IR on a slice without touching the source. Pure
+ * IR → IR filters, composable with detail tiers (apply a lens, then view the
+ * result at any `--detail`). See issue #495 / epic #492.
+ *
+ * - `lexicon:<name>` — only nodes in a lexicon
+ * - `stack:<name>`   — only one stack's nodes (stacks map to lexicon partitions today)
+ * - `blast:<nodeId>` — the transitive neighbourhood of a node: what it depends
+ *   on (`--up`), what depends on it (`--down`), or both (default)
+ *
+ * Every lens drops edges that would dangle and rebuilds group metadata from the
+ * surviving nodes, so the result is always a self-consistent graph.
+ */
+export interface LensSpec {
+  kind: "lexicon" | "stack" | "blast";
+  target: string;
+  /** blast: include upstream producers (what the node depends on). */
+  up: boolean;
+  /** blast: include downstream dependents (what depends on the node). */
+  down: boolean;
+}
+
+const KINDS = new Set(["lexicon", "stack", "blast"]);
+
+/** Parse a `--lens` spec. Throws a descriptive Error on a malformed spec. */
+export function parseLens(spec: string, opts: { up?: boolean; down?: boolean } = {}): LensSpec {
+  const colon = spec.indexOf(":");
+  if (colon <= 0 || colon === spec.length - 1) {
+    throw new Error(`Invalid --lens "${spec}". Expected <kind>:<target>, e.g. lexicon:gcp or blast:vpc.`);
+  }
+  const kind = spec.slice(0, colon);
+  const target = spec.slice(colon + 1);
+  if (!KINDS.has(kind)) {
+    throw new Error(`Unknown lens "${kind}". Expected one of: ${[...KINDS].join(", ")}.`);
+  }
+  // For blast, default to both directions when neither flag is given.
+  const both = !opts.up && !opts.down;
+  return {
+    kind: kind as LensSpec["kind"],
+    target,
+    up: opts.up ?? both,
+    down: opts.down ?? both,
+  };
+}
+
+/** Apply a lens to the IR. Throws a descriptive Error when the target matches nothing. */
+export function applyLens(ir: GraphIR, lens: LensSpec): GraphIR {
+  const keep =
+    lens.kind === "blast" ? blastSet(ir, lens) : partitionSet(ir, lens);
+  return subgraph(ir, keep);
+}
+
+/** Node ids for a lexicon/stack lens. */
+function partitionSet(ir: GraphIR, lens: LensSpec): Set<string> {
+  if (lens.kind === "stack") {
+    const members = ir.groups.byStack?.[lens.target] ?? ir.groups.byLexicon?.[lens.target];
+    if (members && members.length) return new Set(members);
+    // Fall through to a direct scan if groups are absent.
+  }
+  const keep = new Set<string>();
+  for (const n of ir.nodes) if (n.lexicon === lens.target) keep.add(n.id);
+  if (keep.size === 0) {
+    throw new Error(`No nodes match lens ${lens.kind}:${lens.target}.`);
+  }
+  return keep;
+}
+
+/** Node ids in the transitive neighbourhood of a node. */
+function blastSet(ir: GraphIR, lens: LensSpec): Set<string> {
+  if (!ir.nodes.some((n) => n.id === lens.target)) {
+    throw new Error(`No node "${lens.target}" for lens blast:${lens.target}.`);
+  }
+  const out = new Map<string, string[]>(); // from -> [to]  (depends-on)
+  const inc = new Map<string, string[]>(); // to -> [from]  (depended-on-by)
+  const push = (m: Map<string, string[]>, k: string, v: string): void => {
+    const arr = m.get(k);
+    if (arr) arr.push(v);
+    else m.set(k, [v]);
+  };
+  for (const e of ir.edges) {
+    push(out, e.from, e.to);
+    push(inc, e.to, e.from);
+  }
+  const keep = new Set<string>([lens.target]);
+  if (lens.up) walk(lens.target, out, keep);
+  if (lens.down) walk(lens.target, inc, keep);
+  return keep;
+}
+
+function walk(start: string, adj: Map<string, string[]>, keep: Set<string>): void {
+  const stack = [start];
+  while (stack.length) {
+    const cur = stack.pop()!;
+    for (const next of adj.get(cur) ?? []) {
+      if (!keep.has(next)) {
+        keep.add(next);
+        stack.push(next);
+      }
+    }
+  }
+}
+
+/** Restrict the IR to a node set: keep internal edges, rebuild groups. */
+function subgraph(ir: GraphIR, keep: Set<string>): GraphIR {
+  const nodes: IRNode[] = ir.nodes.filter((n) => keep.has(n.id));
+  const edges: IREdge[] = ir.edges.filter((e) => keep.has(e.from) && keep.has(e.to));
+
+  const byLexicon: Record<string, string[]> = {};
+  const byComposite: Record<string, string[]> = {};
+  for (const n of nodes) {
+    (byLexicon[n.lexicon] ??= []).push(n.id);
+    if (n.compositeInstance) (byComposite[n.compositeInstance] ??= []).push(n.id);
+  }
+  const groups: GraphIR["groups"] = {};
+  if (Object.keys(byLexicon).length) groups.byLexicon = sortGroups(byLexicon);
+  if (Object.keys(byComposite).length) groups.byComposite = sortGroups(byComposite);
+
+  return { nodes, edges, groups };
+}
+
+function sortGroups(rec: Record<string, string[]>): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const k of Object.keys(rec).sort()) out[k] = rec[k].sort();
+  return out;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export * from "./graph-detail";
 export * from "./graph-mermaid";
 export * from "./graph-dot";
 export * from "./graph-layout";
+export * from "./graph-lens";
 export * from "./detectLexicon";
 export * from "./lint/parser";
 export * from "./lint/rule";


### PR DESCRIPTION
Closes #495 (env lens split to #505). Part of epic #492. Builds on #493/#494.

## What

Focus lenses for `chant graph --format …` — pure IR → IR filters, composable with detail tiers:

- **`lexicon:<name>`** — only that lexicon's nodes
- **`stack:<name>`** — only one stack's nodes (stacks map to lexicon partitions today)
- **`blast:<node>`** — the transitive neighbourhood of a node: producers it depends on (`--up`), dependents that depend on it (`--down`), or both (default)

## Notes

- The lens is applied to the **base (declarable) IR before `--detail`**, so `blast:<resource>` works on real nodes before any composite collapse, and you can then view the focused slice at any detail level.
- Every lens drops edges that would dangle and rebuilds group metadata from the surviving nodes — the result is always self-consistent.
- Malformed / unknown / no-match targets give a clear error and non-zero exit.

## Deferred: `env:` lens → #505

The `env:<name>` lens from #495 is deferred. Unlike the others, env-membership isn't in the IR — it needs per-node environment/policy activation from the build layer (`chant build --env`). Filed as #505 so the pure-filter lenses can land now. `--lens env:*` currently returns a clear "unknown lens" error.

## Testing

- 11 new tests in `graph-lens.test.ts`: parse (kind:target, blast direction defaults/flags, malformed/unknown), and apply (lexicon subset + count vs `byLexicon`, blast up/down/both, blast on a leaf, no-match throws).
- Verified end-to-end: lens composes with `--format mermaid`; no-match and bad-spec produce errors.
- Full core suite green except the pre-existing `import.test.ts` failures (missing `lexicons/aws/dist`, unrelated). tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)