### PR TITLE
docs+test: cover the graph IR / diagram features

### DIFF
--- a/docs/src/content/docs/cli/graph.mdx
+++ b/docs/src/content/docs/cli/graph.mdx
@@ -1,23 +1,87 @@
 ---
 title: "chant graph"
-description: Print the Op dependency graph
+description: Print the Op graph, the cross-stack apply order, or the infra graph as IR, Mermaid, DOT, or layout positions
 ---
 
 ## Synopsis
 
 ```
 chant graph [path] [--stacks] [--json]
+chant graph [path] --format ir|mermaid|dot|layout [--detail 0..3] [--lens <kind>:<target>] [--up] [--down]
 ```
 
 ## Description
 
-`chant graph` discovers all `*.op.ts` files under the given path and prints the dependency edges declared via the `depends` field of each Op.
+`chant graph` has three modes:
 
-If no Ops declare dependencies the output is `No Op dependencies`. If no `*.op.ts` files are found the output is `No Ops found`.
+- **default** — the Op dependency graph (edges from each Op's `depends` field).
+- **`--stacks`** — the cross-stack apply-ordering graph.
+- **`--format ir|mermaid|dot|layout`** — the **infrastructure graph** chant resolves during synthesis, emitted for diagrams. This is the graph of your declared resources and the references between them.
+
+The infra-graph formats are a pure function of lint-clean source — every node traces to a source file, every edge is a real cross-resource reference. They are **lint-gated**: chant refuses to emit a graph for source that does not pass `chant lint`, because the graph represents valid infrastructure.
+
+## Infra graph: `--format`
+
+```bash
+chant graph ./infra --format mermaid   # paste-able Mermaid flowchart (renders in GitHub)
+chant graph ./infra --format ir        # the graph IR as JSON (the contract for tools)
+chant graph ./infra --format dot       # Graphviz DOT (render with `dot -Tsvg`)
+chant graph ./infra --format layout    # node positions from Graphviz (needs `dot`)
+```
+
+| Format | Output | Needs |
+|--------|--------|-------|
+| `mermaid` | A Mermaid `flowchart` with one subgraph per lexicon. The **zero-install default** — renders in GitHub, docs, and browsers. | nothing |
+| `ir` | The graph IR as JSON: `nodes` (id, kind, lexicon, attrs, sourceLoc, composite info), `edges` (real references, labelled with the consumer property), and `groups`. The stable contract downstream diagram tools consume. | nothing |
+| `dot` | Graphviz DOT text, with lexicon clusters and labelled edges. Render directly with `dot -Tsvg`, or feed to a layout engine. | nothing to produce; `dot` to render |
+| `layout` | Node positions from a layout engine: `{ width, height, nodes: [{id, x, y}] }`. For a custom painter that does its own drawing (Graphviz for layout only). | `dot` (`brew install graphviz`) |
+
+If `dot` is not installed, `--format layout` exits non-zero with an install hint and points you at `--format mermaid`, which needs no native dependency.
+
+## Detail tiers: `--detail 0..3`
+
+The detail dial controls how much of the graph each format shows. It is a transform over the same IR, so it works with every `--format`.
+
+| Level | Name | Shows |
+|-------|------|-------|
+| `0` | stacks | one node per lexicon; edges are cross-lexicon dependencies |
+| `1` | composites | each composite instance collapsed to a single node |
+| `2` | declarables | every resource (the default) |
+| `3` | attributes | declarables, plus the referenced attribute on each edge |
+
+```bash
+chant graph ./infra --format mermaid --detail 0   # high-level: lexicons only
+chant graph ./infra --format mermaid --detail 1   # composites as single nodes
+chant graph ./infra --format ir --detail 3        # every resource + attribute-level edges
+```
+
+A handful of composites at `--detail 2` expands to every resource they declare — you describe a few, the graph shows the whole set. Turn the dial down to `0`/`1` for an overview.
+
+## Lenses: `--lens <kind>:<target>`
+
+Lenses focus the graph on a slice. They compose with `--detail` (the lens is applied first, then the detail tier).
+
+| Lens | Keeps |
+|------|-------|
+| `lexicon:<name>` | only that lexicon's nodes |
+| `stack:<name>` | only one stack's nodes (stacks map to lexicon partitions today) |
+| `blast:<node>` | the transitive neighbourhood of a node |
+
+For `blast:`, choose a direction (default is both):
+
+- `--up` — what the node depends on (its producers)
+- `--down` — what depends on the node (its dependents)
+
+```bash
+chant graph ./infra --format mermaid --lens lexicon:gcp
+chant graph ./infra --format mermaid --lens blast:vpc --down   # everything that depends on the VPC
+```
+
+A lens drops edges that would dangle and rebuilds group metadata, so the result is always a self-consistent graph. An unknown or no-match target exits non-zero with a clear message.
 
 ## `--stacks` — cross-stack apply order
 
-`chant graph --stacks [path]` renders the **cross-stack apply-ordering graph** instead of the Op graph. chant resolves cross-lexicon references during build (a resource in one stack referencing an attribute of a resource in another) and already knows the order — a stack that *exports* a value must apply before the stack that *imports* it. `--stacks` surfaces that as tool-agnostic data for your orchestrator (CI, an Op, a platform tool). chant **exposes** the order; it does not drive the apply.
+`chant graph --stacks [path]` renders the **cross-stack apply-ordering graph** instead. chant resolves cross-lexicon references during build and already knows the order — a stack that *exports* a value must apply before the stack that *imports* it. `--stacks` surfaces that as tool-agnostic data for your orchestrator. chant **exposes** the order; it does not drive the apply.
 
 ```bash
 chant graph --stacks ./infra
@@ -35,35 +99,26 @@ Dependencies (consumer → producer):
   k8s → aws
 ```
 
-## Usage
+## Op graph (default)
+
+With no format flag, `chant graph` discovers all `*.op.ts` files under the given path and prints the dependency edges declared via each Op's `depends` field.
 
 ```bash
-# Graph Ops in current directory
-chant graph
-
-# Graph Ops in a specific directory
-chant graph ./infra
+chant graph            # Ops in the current directory
+chant graph ./infra    # Ops in a specific directory
 ```
 
-## Output Format
-
-Each dependency is printed as one edge per line:
-
-```
-infra-bootstrap → alb-deploy
-infra-bootstrap → app-deploy
-```
-
-The format is `<dependency> → <dependent>`, meaning the left Op must complete before the right Op can run.
+Each dependency prints as one edge per line, `<dependency> → <dependent>` — the left Op must complete before the right Op can run. If no Ops declare dependencies the output is `No Op dependencies`; if no `*.op.ts` files are found, `No Ops found`.
 
 ## Exit Codes
 
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
-| 1 | Discovery errors, or (with `--stacks`) a dependency cycle |
+| 1 | Discovery errors; lint errors (infra-graph formats); a dependency cycle (`--stacks`); an invalid `--detail`/`--lens`; or a missing `dot` for `--format layout` |
 
 ## See Also
 
 - [Ops guide](/chant/guide/ops/) — define Op dependencies with `depends`
-- [`chant run`](/chant/cli/run/) — execute an Op workflow
+- [`chant lint`](/chant/cli/lint/) — the gate the infra-graph formats run first
+- [`chant build`](/chant/cli/build/) — synthesize the artifacts the graph describes

--- a/packages/core/src/cli/handlers/graph.test.ts
+++ b/packages/core/src/cli/handlers/graph.test.ts
@@ -1,9 +1,31 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import type { ParsedArgs } from "../registry";
+import { DECLARABLE_MARKER, type Declarable } from "../../declarable";
+import { AttrRef } from "../../attrref";
 
 const discoverOpsMock = vi.fn();
 vi.mock("../../op/discover", () => ({
   discoverOps: () => discoverOpsMock(),
+}));
+
+const discoverMock = vi.fn();
+vi.mock("../../discovery/index", () => ({
+  discover: () => discoverMock(),
+}));
+
+const lintMock = vi.fn();
+vi.mock("../commands/lint", () => ({
+  lintCommand: () => lintMock(),
+}));
+
+// Avoid shelling out to graphviz in tests; the format dispatch is what matters.
+const layoutMock = vi.fn();
+vi.mock("../../graph-layout", () => ({
+  GraphvizLayout: class {
+    layout() {
+      return layoutMock();
+    }
+  },
 }));
 
 const { runGraph } = await import("./graph");
@@ -20,6 +42,18 @@ function makeOp(name: string, depends: string[] = []): [string, { config: { name
   return [name, { config: { name, depends } }];
 }
 
+function decl<T extends object>(base: T): Declarable & T {
+  return { [DECLARABLE_MARKER]: true, ...base } as Declarable & T;
+}
+
+/** A small two-lexicon graph: vpc <- subnet (gcp), subnet <- pod (k8s). */
+function sampleEntities(): Map<string, Declarable> {
+  const vpc = decl({ lexicon: "gcp", entityType: "Vpc" });
+  const subnet = decl({ lexicon: "gcp", entityType: "Subnet", props: { network: new AttrRef(vpc, "id") } });
+  const pod = decl({ lexicon: "k8s", entityType: "Pod", props: { net: new AttrRef(subnet, "id") } });
+  return new Map<string, Declarable>([["vpc", vpc], ["subnet", subnet], ["pod", pod]]);
+}
+
 describe("runGraph", () => {
   let stdoutBuf: string[];
   let stderrBuf: string[];
@@ -30,62 +64,146 @@ describe("runGraph", () => {
     vi.spyOn(console, "log").mockImplementation((s: string) => { stdoutBuf.push(s); });
     vi.spyOn(console, "error").mockImplementation((s: string) => { stderrBuf.push(s); });
     discoverOpsMock.mockReset();
+    discoverMock.mockReset();
+    lintMock.mockReset();
+    layoutMock.mockReset();
   });
 
-  test("prints 'No Ops found' when discovery is empty", async () => {
-    discoverOpsMock.mockResolvedValue({ ops: new Map(), errors: [] });
-    const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
-    expect(exit).toBe(0);
-    expect(stdoutBuf.join("\n")).toContain("No Ops found");
-  });
-
-  test("prints 'No Op dependencies' when ops have no depends", async () => {
-    discoverOpsMock.mockResolvedValue({
-      ops: new Map([makeOp("solo")]),
-      errors: [],
+  describe("Op graph (default)", () => {
+    test("prints 'No Ops found' when discovery is empty", async () => {
+      discoverOpsMock.mockResolvedValue({ ops: new Map(), errors: [] });
+      const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
+      expect(exit).toBe(0);
+      expect(stdoutBuf.join("\n")).toContain("No Ops found");
     });
-    const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
-    expect(exit).toBe(0);
-    expect(stdoutBuf.join("\n")).toContain("No Op dependencies");
+
+    test("prints 'No Op dependencies' when ops have no depends", async () => {
+      discoverOpsMock.mockResolvedValue({ ops: new Map([makeOp("solo")]), errors: [] });
+      const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
+      expect(exit).toBe(0);
+      expect(stdoutBuf.join("\n")).toContain("No Op dependencies");
+    });
+
+    test("prints `dep -> name` edge per dependency", async () => {
+      discoverOpsMock.mockResolvedValue({
+        ops: new Map([makeOp("infra"), makeOp("app", ["infra"])]),
+        errors: [],
+      });
+      const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
+      expect(exit).toBe(0);
+      expect(stdoutBuf.join("\n")).toContain("infra → app");
+    });
+
+    test("handles multi-edge graphs", async () => {
+      discoverOpsMock.mockResolvedValue({
+        ops: new Map([makeOp("a"), makeOp("b", ["a"]), makeOp("c", ["a", "b"])]),
+        errors: [],
+      });
+      await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
+      const out = stdoutBuf.join("\n");
+      expect(out).toContain("a → b");
+      expect(out).toContain("a → c");
+      expect(out).toContain("b → c");
+    });
+
+    test("forwards discovery errors to stderr", async () => {
+      discoverOpsMock.mockResolvedValue({ ops: new Map(), errors: ["failed to parse ops/bad.op.ts"] });
+      const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
+      expect(exit).toBe(0);
+      expect(stderrBuf.join("\n")).toContain("failed to parse ops/bad.op.ts");
+    });
   });
 
-  test("prints `dep -> name` edge per dependency", async () => {
-    discoverOpsMock.mockResolvedValue({
-      ops: new Map([
-        makeOp("infra"),
-        makeOp("app", ["infra"]),
-      ]),
-      errors: [],
-    });
-    const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
-    expect(exit).toBe(0);
-    const out = stdoutBuf.join("\n");
-    expect(out).toContain("infra → app");
-  });
+  describe("graph IR views (--format ir|mermaid|dot|layout)", () => {
+    const lintClean = (): void => { lintMock.mockResolvedValue({ success: true }); };
+    const discovered = (): void => {
+      discoverMock.mockResolvedValue({ entities: sampleEntities(), errors: [], dependencies: new Map(), sourceFiles: [] });
+    };
 
-  test("handles multi-edge graphs", async () => {
-    discoverOpsMock.mockResolvedValue({
-      ops: new Map([
-        makeOp("a"),
-        makeOp("b", ["a"]),
-        makeOp("c", ["a", "b"]),
-      ]),
-      errors: [],
+    test("--format ir emits the graph IR as JSON", async () => {
+      lintClean(); discovered();
+      const exit = await runGraph({ args: makeArgs({ format: "ir" }), plugins: [], serializers: [] });
+      expect(exit).toBe(0);
+      const ir = JSON.parse(stdoutBuf.join("\n"));
+      expect(ir.nodes.map((n: { id: string }) => n.id).sort()).toEqual(["pod", "subnet", "vpc"]);
+      expect(ir.edges).toContainEqual({ from: "subnet", to: "vpc", kind: "ref", viaAttr: "network" });
     });
-    await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
-    const out = stdoutBuf.join("\n");
-    expect(out).toContain("a → b");
-    expect(out).toContain("a → c");
-    expect(out).toContain("b → c");
-  });
 
-  test("forwards discovery errors to stderr", async () => {
-    discoverOpsMock.mockResolvedValue({
-      ops: new Map(),
-      errors: ["failed to parse ops/bad.op.ts"],
+    test("lint gate: refuses to emit when source has lint errors", async () => {
+      lintMock.mockResolvedValue({ success: false });
+      const exit = await runGraph({ args: makeArgs({ format: "ir" }), plugins: [], serializers: [] });
+      expect(exit).toBe(1);
+      expect(stdoutBuf.join("\n")).toBe("");
+      expect(stderrBuf.join("\n")).toMatch(/lint errors/i);
+      expect(discoverMock).not.toHaveBeenCalled();
     });
-    const exit = await runGraph({ args: makeArgs(), plugins: [], serializers: [] });
-    expect(exit).toBe(0);
-    expect(stderrBuf.join("\n")).toContain("failed to parse ops/bad.op.ts");
+
+    test("--format mermaid emits a flowchart", async () => {
+      lintClean(); discovered();
+      const exit = await runGraph({ args: makeArgs({ format: "mermaid" }), plugins: [], serializers: [] });
+      expect(exit).toBe(0);
+      expect(stdoutBuf.join("\n")).toContain("flowchart TD");
+    });
+
+    test("--format dot emits a digraph", async () => {
+      lintClean(); discovered();
+      const exit = await runGraph({ args: makeArgs({ format: "dot" }), plugins: [], serializers: [] });
+      expect(exit).toBe(0);
+      expect(stdoutBuf.join("\n")).toContain("digraph chant {");
+    });
+
+    test("--format layout emits positions from the layout engine", async () => {
+      lintClean(); discovered();
+      layoutMock.mockResolvedValue({ width: 100, height: 50, nodes: [{ id: "vpc", x: 1, y: 2 }] });
+      const exit = await runGraph({ args: makeArgs({ format: "layout" }), plugins: [], serializers: [] });
+      expect(exit).toBe(0);
+      expect(JSON.parse(stdoutBuf.join("\n"))).toMatchObject({ width: 100, nodes: [{ id: "vpc", x: 1, y: 2 }] });
+    });
+
+    test("--format layout reports a clear error when the engine fails (e.g. dot missing)", async () => {
+      lintClean(); discovered();
+      layoutMock.mockRejectedValue(new Error("could not run 'dot'"));
+      const exit = await runGraph({ args: makeArgs({ format: "layout" }), plugins: [], serializers: [] });
+      expect(exit).toBe(1);
+      expect(stderrBuf.join("\n")).toContain("could not run 'dot'");
+    });
+
+    test("--detail 0 collapses to one node per lexicon", async () => {
+      lintClean(); discovered();
+      const exit = await runGraph({ args: makeArgs({ format: "ir", detail: 0 }), plugins: [], serializers: [] });
+      expect(exit).toBe(0);
+      const ir = JSON.parse(stdoutBuf.join("\n"));
+      expect(ir.nodes.map((n: { id: string }) => n.id).sort()).toEqual(["gcp", "k8s"]);
+    });
+
+    test("rejects an out-of-range --detail", async () => {
+      const exit = await runGraph({ args: makeArgs({ format: "ir", detail: 9 }), plugins: [], serializers: [] });
+      expect(exit).toBe(1);
+      expect(stderrBuf.join("\n")).toMatch(/detail/i);
+      expect(lintMock).not.toHaveBeenCalled();
+    });
+
+    test("--lens lexicon:gcp filters to that lexicon", async () => {
+      lintClean(); discovered();
+      const exit = await runGraph({ args: makeArgs({ format: "ir", lens: "lexicon:gcp" }), plugins: [], serializers: [] });
+      expect(exit).toBe(0);
+      const ir = JSON.parse(stdoutBuf.join("\n"));
+      expect(ir.nodes.map((n: { id: string }) => n.id).sort()).toEqual(["subnet", "vpc"]);
+    });
+
+    test("--lens with a bad spec errors out", async () => {
+      lintClean(); discovered();
+      const exit = await runGraph({ args: makeArgs({ format: "ir", lens: "nope" }), plugins: [], serializers: [] });
+      expect(exit).toBe(1);
+      expect(stderrBuf.join("\n")).toMatch(/lens/i);
+    });
+
+    test("--format ir forwards discovery errors and exits non-zero", async () => {
+      lintClean();
+      discoverMock.mockResolvedValue({ entities: new Map(), errors: [{ message: "boom" }], dependencies: new Map(), sourceFiles: [] });
+      const exit = await runGraph({ args: makeArgs({ format: "ir" }), plugins: [], serializers: [] });
+      expect(exit).toBe(1);
+      expect(stderrBuf.join("\n")).toContain("boom");
+    });
   });
 });

--- a/packages/core/src/cli/main.test.ts
+++ b/packages/core/src/cli/main.test.ts
@@ -72,6 +72,22 @@ describe("parseArgs", () => {
     expect(result.format).toBe("invalid"); // format is passed as-is to main
   });
 
+  test("parses graph --detail as a number", () => {
+    const result = parseArgs(["graph", "--format", "ir", "--detail", "1"]);
+    expect(result.detail).toBe(1);
+  });
+
+  test("parses graph --lens with a kind:target value", () => {
+    const result = parseArgs(["graph", "--format", "ir", "--lens", "blast:vpc"]);
+    expect(result.lens).toBe("blast:vpc");
+  });
+
+  test("parses graph --up and --down flags", () => {
+    const result = parseArgs(["graph", "--lens", "blast:vpc", "--up", "--down"]);
+    expect(result.up).toBe(true);
+    expect(result.down).toBe(true);
+  });
+
   test("combines multiple options", () => {
     const result = parseArgs([
       "build",


### PR DESCRIPTION
Part of epic #492. Closes the docs and integration-test gaps for the diagramming features shipped in #493–#497.

## Docs

Rewrote `cli/graph.mdx` (it only documented the Op graph + `--stacks`). Now covers:
- `--format ir|mermaid|dot|layout` — what each produces and what it needs (Mermaid is the zero-install default)
- `--detail 0..3` — stacks / composites / declarables / attributes
- `--lens lexicon|stack|blast` with `--up`/`--down`
- the lint gate, and a complete exit-code table

Verified the docs site builds clean (`npm --prefix docs run build`). Note: the `docs` workflow runs on main, not PRs — so this was checked locally to keep main green after merge.

## Tests

The pure transforms were already well covered; the **handler integration layer was not**. Added:
- **graph handler (+11)** — `--format ir|mermaid|dot|layout` dispatch, the **lint-gate refusal** (no output, exit 1, discovery not called), `--detail`/`--lens` wiring, and error paths: out-of-range `--detail`, bad `--lens`, layout-engine failure (mocked, e.g. missing `dot`), and discovery errors. Graphviz is mocked so no `dot` dependency in CI.
- **parseArgs (+3)** — `--detail`, `--lens`, `--up`/`--down`.

## Testing

- New: graph handler 5 → 16 tests; `parseArgs` +3.
- Full core suite green except the pre-existing `import.test.ts` failures (missing `lexicons/aws/dist` in a fresh checkout, unrelated). tsc + eslint clean. Docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)