### PR TITLE
fix(graph): emit $ref edges for cross-package AttrRefs (#511)

### DIFF
--- a/packages/core/src/graph-ir.test.ts
+++ b/packages/core/src/graph-ir.test.ts
@@ -42,6 +42,30 @@ describe("buildGraphIr", () => {
     });
   });
 
+  test("treats a foreign AttrRef (different @intentius/chant copy) as a ref, not an opaque intrinsic (#511)", () => {
+    // A lexicon built against a *separate* copy of chant produces AttrRefs that
+    // fail `instanceof AttrRef` here but carry the global-symbol brand + shape.
+    // (This is the pinhole install scenario; before #511 it flattened to
+    // `{$intrinsic}` with no edge.)
+    const vpc = decl({ lexicon: "aws", entityType: "Vpc" });
+    const foreignRef = {
+      [Symbol.for("chant.intrinsic")]: true,
+      parent: new WeakRef(vpc),
+      attribute: "VpcId",
+      _setLogicalName() {}, // shape utils.isAttrRefLike duck-types on
+      getLogicalName: () => undefined, // resolves via object identity in the reverse map
+    };
+    const sg = decl({ lexicon: "aws", entityType: "SecurityGroup", props: { VpcId: foreignRef } });
+    const entities = new Map<string, Declarable>([
+      ["vpc", vpc],
+      ["sg", sg],
+    ]);
+
+    const ir = buildGraphIr(entities);
+    expect(ir.edges).toEqual([{ from: "sg", to: "vpc", kind: "ref", viaAttr: "VpcId" }]);
+    expect(ir.nodes.find((n) => n.id === "sg")!.attrs).toEqual({ VpcId: { $ref: "vpc.VpcId" } });
+  });
+
   test("excludes property-kind declarables and keeps resources", () => {
     const resource = decl({ lexicon: "k8s", entityType: "Deployment" });
     const prop = decl({ lexicon: "k8s", entityType: "Probe", kind: "property" as const });

--- a/packages/core/src/graph-ir.ts
+++ b/packages/core/src/graph-ir.ts
@@ -1,5 +1,6 @@
 import { relative, isAbsolute } from "node:path";
 import { AttrRef } from "./attrref";
+import { isAttrRefLike } from "./utils";
 import { type Declarable, isDeclarable } from "./declarable";
 import { isLexiconOutput } from "./lexicon-output";
 import { getProvenance } from "./provenance";
@@ -113,7 +114,11 @@ function project(value: unknown, seen: Set<unknown>, reverse: Map<object, string
   if (t === "string" || t === "number" || t === "boolean") return value;
   if (t !== "object") return undefined; // functions, symbols, undefined
 
-  if (value instanceof AttrRef) {
+  // Duck-type, not `instanceof`: a lexicon built against a different copy of
+  // `@intentius/chant` produces AttrRefs that fail `instanceof AttrRef` but carry
+  // the same shape. Without this, a real cross-resource reference falls through to
+  // the intrinsic branch below and is silently flattened to `{$intrinsic}` (#511).
+  if (isAttrRefLike(value)) {
     const to = refTarget(value, reverse);
     return { $ref: to ? `${to}.${value.attribute}` : value.attribute } satisfies AttrRefEnvelope;
   }
@@ -192,7 +197,7 @@ function collectEdges(
   const seen = new Set<unknown>();
   const visit = (value: unknown, viaAttr: string): void => {
     if (value === null || typeof value !== "object") return;
-    if (value instanceof AttrRef) {
+    if (isAttrRefLike(value)) {
       const to = refTarget(value, reverse);
       if (to && to !== from && nodeIds.has(to)) {
         edges.push({ from, to, kind: "ref", viaAttr });


### PR DESCRIPTION
Closes #511.

## Symptom
`chant graph --format ir` produced **0 edges** for any realistic project whose resources wire together through output attributes — an ALB's `Subnets` consuming `subnet.SubnetId`, a security group's `VpcId`, etc. Those references serialized as opaque `{"$intrinsic":true}` with no source-node link, so the graph had no edges and every such project rendered as disconnected nodes.

## Root cause
`AttrRef implements Intrinsic` — it carries `INTRINSIC_MARKER`. `graph-ir.ts` told an AttrRef apart from a generic intrinsic with `value instanceof AttrRef`. That `instanceof` fails across the **dual-package hazard**: when npm installs separate copies of `@intentius/chant` (one for the CLI, one bundled with a lexicon), the lexicon-created AttrRef is not `instanceof` the CLI's `AttrRef` class. It then fell through to the intrinsic branch → `{$intrinsic}`, no edge.

In-repo, workspace dedup collapses chant to one module instance, so `instanceof` worked and the bug was invisible. It only manifested for downstream consumers like **pinhole** that install chant as a published package next to a lexicon.

I confirmed the mechanism with a probe against `examples/gitlab-aws-alb-infra`: `sharedAlb.Subnets[0]` is a fully-resolved AttrRef (`attribute=SubnetId`, parent resolves to `networkPublicSubnet1`) that *also* carries `INTRINSIC_MARKER` — exactly the value that `instanceof` misclassifies across packages.

## Fix
Detect AttrRefs in `project()` and `collectEdges()` with the existing **`utils.isAttrRefLike`** duck-type — already used elsewhere in core for this same hazard — instead of `instanceof`. A foreign AttrRef resolves its producer through the reverse object-identity map and emits the `$ref` envelope + ref edge.

## Tests
`tsc` clean; core suite **1873 passing**, aws lexicon **716 passing**. New regression test constructs a *foreign* AttrRef (branded + same shape, deliberately not `instanceof` core's class) and asserts it yields `{$ref: "vpc.VpcId"}` and a `{from:"sg", to:"vpc", kind:"ref", viaAttr:"VpcId"}` edge — it fails on the old `instanceof` path.

## Downstream
Unblocks INTENTIUS/pinhole#36 / the containment view rendering real AWS infra. Needs a chant release + pinhole dep bump to land for pinhole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)