### PR TITLE
feat(graph): populate groups.byStack from the lexicon partition (#513 phase 1)

### DIFF
--- a/packages/core/src/graph-ir.test.ts
+++ b/packages/core/src/graph-ir.test.ts
@@ -133,6 +133,9 @@ describe("buildGraphIr", () => {
     const ir = buildGraphIr(entities);
     expect(ir.nodes.map((n) => n.id)).toEqual(["alpha", "mid", "zeta"]); // sorted
     expect(ir.groups.byLexicon).toEqual({ gcp: ["alpha", "zeta"], k8s: ["mid"] });
+    // byStack mirrors the lexicon partition today (each lexicon → one deployable
+    // stack); emitted as its own axis so consumers read stacks, not lexicons (#513).
+    expect(ir.groups.byStack).toEqual({ gcp: ["alpha", "zeta"], k8s: ["mid"] });
 
     // Same input (different insertion order) yields identical IR.
     const reordered = new Map<string, Declarable>([

--- a/packages/core/src/graph-ir.ts
+++ b/packages/core/src/graph-ir.ts
@@ -72,7 +72,9 @@ export interface IREdge {
 export interface IRGroups {
   byLexicon?: Record<string, string[]>;
   byComposite?: Record<string, string[]>;
-  /** Reserved for stack grouping (#494). */
+  /** Deployable-stack grouping (`stackName → nodeIds`). A stack is a lexicon
+   * partition today; #513 phase 2 regroups by nested child-project. Consumers
+   * (e.g. pinhole's boundary boxes) read this rather than inferring stacks. */
   byStack?: Record<string, string[]>;
 }
 
@@ -243,6 +245,7 @@ export function buildGraphIr(
   const nodes: IRNode[] = [];
   const byLexicon: Record<string, string[]> = {};
   const byComposite: Record<string, string[]> = {};
+  const byStack: Record<string, string[]> = {};
 
   for (const [name, entity] of entities) {
     if (!nodeIds.has(name)) continue;
@@ -260,6 +263,12 @@ export function buildGraphIr(
     nodes.push(node);
 
     (byLexicon[entity.lexicon] ??= []).push(name);
+    // A stack is a lexicon partition (each lexicon serialises to one deployable
+    // stack — a CloudFormation template, a CI config). `byStack` mirrors that
+    // today; #513 phase 2 will regroup it by nested child-project. It's a
+    // distinct axis from `byLexicon` (which is for provenance/colouring), so it's
+    // emitted separately even where the two currently coincide.
+    (byStack[entity.lexicon] ??= []).push(name);
     if (prov?.composite) (byComposite[prov.composite] ??= []).push(name);
   }
 
@@ -275,10 +284,12 @@ export function buildGraphIr(
   const edges = [...edgeMap.values()].sort((a, b) => edgeKey(a).localeCompare(edgeKey(b)));
   for (const ids of Object.values(byLexicon)) ids.sort();
   for (const ids of Object.values(byComposite)) ids.sort();
+  for (const ids of Object.values(byStack)) ids.sort();
 
   const groups: IRGroups = {};
   if (Object.keys(byLexicon).length) groups.byLexicon = sortKeys(byLexicon);
   if (Object.keys(byComposite).length) groups.byComposite = sortKeys(byComposite);
+  if (Object.keys(byStack).length) groups.byStack = sortKeys(byStack);
 
   return { nodes, edges, groups };
 }


### PR DESCRIPTION
Phase 1 of #513.

`IRGroups.byStack` was reserved but never emitted. A **stack is a lexicon partition** (each lexicon serialises to one deployable stack — a CloudFormation template, a CI config), so `buildGraphIr` now groups node ids by lexicon into `groups.byStack`, mirroring `partitionByLexicon`.

It's a distinct axis from `byLexicon` (provenance/colouring) even though the two coincide today — emitted separately so consumers read stacks directly, and so #513 **phase 2** can regroup `byStack` by nested child-project without touching `byLexicon`.

## Verify
`tsc` clean; graph-ir tests pass (asserts `byStack` mirrors the lexicon grouping). Probed the real example — `gitlab-aws-alb-infra` now emits `byStack: {aws: 25, gitlab: 1}`.

Unblocks the boundary-box rendering in INTENTIUS/pinhole#42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)