### PR TITLE
feat(graph): surface cross-stack exports in the IR (#513)

### DIFF
--- a/packages/core/src/graph-ir.test.ts
+++ b/packages/core/src/graph-ir.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "vitest";
 import { buildGraphIr } from "./graph-ir";
 import { DECLARABLE_MARKER, type Declarable } from "./declarable";
 import { AttrRef } from "./attrref";
+import { LexiconOutput } from "./lexicon-output";
 import { resolveAttrRefs } from "./discovery/resolve";
 import { setProvenance } from "./provenance";
 
@@ -64,6 +65,20 @@ describe("buildGraphIr", () => {
     const ir = buildGraphIr(entities);
     expect(ir.edges).toEqual([{ from: "sg", to: "vpc", kind: "ref", viaAttr: "VpcId" }]);
     expect(ir.nodes.find((n) => n.id === "sg")!.attrs).toEqual({ VpcId: { $ref: "vpc.VpcId" } });
+  });
+
+  test("surfaces cross-stack exports with the producing node, not as nodes (#513)", () => {
+    const cluster = decl({ lexicon: "aws", entityType: "AWS::ECS::Cluster" });
+    const out = new LexiconOutput(new AttrRef(cluster, "Arn"), "ClusterArn");
+    const entities = new Map<string, Declarable>([
+      ["cluster", cluster],
+      ["clusterArn", out as unknown as Declarable],
+    ]);
+    resolveAttrRefs(entities);
+
+    const ir = buildGraphIr(entities);
+    expect(ir.nodes.map((n) => n.id)).toEqual(["cluster"]); // the output itself is not a node
+    expect(ir.exports).toEqual([{ name: "ClusterArn", node: "cluster", attr: "Arn" }]);
   });
 
   test("excludes property-kind declarables and keeps resources", () => {

--- a/packages/core/src/graph-ir.ts
+++ b/packages/core/src/graph-ir.ts
@@ -2,7 +2,7 @@ import { relative, isAbsolute } from "node:path";
 import { AttrRef } from "./attrref";
 import { isAttrRefLike } from "./utils";
 import { type Declarable, isDeclarable } from "./declarable";
-import { isLexiconOutput } from "./lexicon-output";
+import { isLexiconOutput, type LexiconOutput } from "./lexicon-output";
 import { getProvenance } from "./provenance";
 import { INTRINSIC_MARKER } from "./intrinsic";
 
@@ -78,11 +78,26 @@ export interface IRGroups {
   byStack?: Record<string, string[]>;
 }
 
+/** A cross-stack export this stack publishes (a `stackOutput`/`output`): its
+ * name (the matching key another stack imports by) and the node that produces it. */
+export interface IRExport {
+  /** Output name — the cross-stack handle (e.g. "ClusterArn"). */
+  name: string;
+  /** Logical name of the producing node, when resolvable. */
+  node?: string;
+  /** Producer-side attribute the output reads (e.g. "Arn"). */
+  attr?: string;
+}
+
 /** The full graph IR for a project at the default (declarable) detail level. */
 export interface GraphIR {
   nodes: IRNode[];
   edges: IREdge[];
   groups: IRGroups;
+  /** Outputs this stack publishes for other stacks to import. Imports are already
+   * nodes (`AWS::CloudFormation::Parameter` etc.); a viewer matches an import's
+   * name to an export's name to draw the cross-stack edge to its producer (#513). */
+  exports?: IRExport[];
 }
 
 /** A node is anything that serializes to a resource — not a property or output. */
@@ -291,7 +306,24 @@ export function buildGraphIr(
   if (Object.keys(byComposite).length) groups.byComposite = sortKeys(byComposite);
   if (Object.keys(byStack).length) groups.byStack = sortKeys(byStack);
 
-  return { nodes, edges, groups };
+  // Cross-stack exports: a stack's `output(ref, name)` LexiconOutputs are dropped
+  // from the node set (they're not resources), but their name + producing node is
+  // the handle another stack imports by. Surface them so a viewer can draw the
+  // cross-stack edge (#513). Resolve the producer via the output's source entity.
+  const exports: IRExport[] = [];
+  for (const entity of entities.values()) {
+    if (!isLexiconOutput(entity)) continue;
+    const lo = entity as unknown as LexiconOutput;
+    if (!lo.outputName) continue;
+    const parent = lo._sourceParent?.deref();
+    const node = (parent ? reverse.get(parent) : undefined) ?? (lo.sourceEntity || undefined);
+    exports.push({ name: lo.outputName, ...(node ? { node } : {}), ...(lo.sourceAttribute ? { attr: lo.sourceAttribute } : {}) });
+  }
+  exports.sort((a, b) => a.name.localeCompare(b.name));
+
+  const ir: GraphIR = { nodes, edges, groups };
+  if (exports.length) ir.exports = exports;
+  return ir;
 }
 
 function sortKeys(rec: Record<string, string[]>): Record<string, string[]> {


### PR DESCRIPTION
The one thing chant is genuinely needed for, to draw cross-stack edges in a multi-stack diagram.

A stack's `output(ref, name)` LexiconOutputs are dropped from the node set (they're not resources), but their **name** is the handle another stack imports by, and their source is the **producing node**. `buildGraphIr` now emits `ir.exports`: `{ name, node, attr }` per output, resolving the producer via the output's `_sourceParent` identity.

**Imports need nothing new** — a consumed `Parameter` is already an IR node (`AWS::CloudFormation::Parameter`). So a viewer composing several stacks matches an import (Parameter node) name to an export name and draws the cross-stack edge to the export's producer.

## Verify
`tsc` clean; graph-ir tests pass (a `LexiconOutput` surfaces as an export `{name, node, attr}`, not a node). Probed the real example — `gitlab-aws-alb-infra` now carries `exports` like `{name:"ClusterArn", node:"sharedCluster", attr:"Arn"}`, `{name:"VpcId", node:"networkVpc", attr:"VpcId"}`, … — exactly the data pinhole matches against the api/ui Parameter nodes.

Composition stays in the viewer (pinhole#44); this is the minimal, general producer-side handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)