### PR TITLE
feat(graph): env-aware graph via --env re-evaluation (#505)

### DIFF
--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -5,6 +5,7 @@ import { formatSuccess, formatError } from "./format";
 import { loadPlugins, resolveProjectLexicons } from "./plugins";
 import { resolveCommand, type CommandDef, type ParsedArgs } from "./registry";
 import { loadChantConfig } from "../config";
+import { ENV_VAR, unknownEnvError } from "../env";
 import { initRuntime } from "../runtime-adapter";
 import { runBuild } from "./handlers/build";
 import { runLint } from "./handlers/lint";
@@ -242,7 +243,10 @@ Options:
                         - list: text (default) or json
                         - lint: stylish (default), json, or sarif
   -d, --lexicon <name>  Build only the specified lexicon (e.g. aws, gitlab)
-      --env <name>      Environment for organizational policy evaluation (build)
+      --env <name>      Active environment: sets CHANT_ENV so env-aware source
+                        re-evaluates for that environment (build + graph), and
+                        drives organizational policy. Must be in chant.config
+                        \`environments\` when declared.
   -t, --template <name> Init template (e.g. node-pipeline, docker-build)
   --skill <name>        Init: install only this skill from the lexicon
   --fix                 Auto-fix fixable issues (lint command)
@@ -369,14 +373,28 @@ async function main(): Promise<void> {
     process.exit(args.help ? 0 : 1);
   }
 
+  // `--env <name>` is a build-context switch for the whole invocation: set it
+  // *before* anything imports the project so env-aware source (and thus the graph
+  // / build) reflects that environment. Set early, before config import, since
+  // chant.config itself may branch on the env. (#505)
+  if (args.env) process.env[ENV_VAR] = args.env;
+
   // Initialize runtime adapter early — before plugins or commands run
   const projectPath0 = resolve(args.path === "." ? "." : args.path);
+  let loadedConfig;
   try {
-    await loadChantConfig(projectPath0);
+    loadedConfig = await loadChantConfig(projectPath0);
     initRuntime();
   } catch {
     // Config may not exist yet (e.g. `chant init`)
     initRuntime();
+  }
+
+  // Reject an --env that isn't among the project's declared `environments`.
+  const envErr = unknownEnvError(args.env, loadedConfig?.config.environments);
+  if (envErr) {
+    console.error(formatError({ message: envErr, hint: 'Declare it in chant.config `environments`, or omit --env.' }));
+    process.exit(1);
   }
 
   const match = resolveCommand(args, registry);

--- a/packages/core/src/cli/registry.ts
+++ b/packages/core/src/cli/registry.ts
@@ -53,7 +53,8 @@ export interface ParsedArgs {
   verbatim?: boolean;
   /** `chant lifecycle … --src <dir>` — build root override for lifecycle commands */
   src?: string;
-  /** `chant build --env <name>` — environment for organizational policy evaluation */
+  /** `--env <name>` — active environment: sets CHANT_ENV so env-aware source
+   * re-evaluates for that environment (`build` + `graph`), and drives policy. */
   env?: string;
   /** `chant graph --stacks` — render the cross-stack apply-ordering graph */
   stacks?: boolean;

--- a/packages/core/src/env.test.ts
+++ b/packages/core/src/env.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from "vitest";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { env, unknownEnvError, ENV_VAR } from "./env";
+import { discover } from "./discovery/index";
+
+const withEnv = async (value: string | undefined, fn: () => void | Promise<void>): Promise<void> => {
+  const prev = process.env[ENV_VAR];
+  try {
+    if (value === undefined) delete process.env[ENV_VAR];
+    else process.env[ENV_VAR] = value;
+    await fn();
+  } finally {
+    if (prev === undefined) delete process.env[ENV_VAR];
+    else process.env[ENV_VAR] = prev;
+  }
+};
+
+describe("env()", () => {
+  test("reads CHANT_ENV, with a fallback", async () => {
+    await withEnv(undefined, () => {
+      expect(env()).toBeUndefined();
+      expect(env("dev")).toBe("dev");
+    });
+    await withEnv("prod", () => {
+      expect(env()).toBe("prod");
+      expect(env("dev")).toBe("prod");
+    });
+  });
+});
+
+describe("unknownEnvError", () => {
+  test("accepts a declared env, and any env when none are declared", () => {
+    expect(unknownEnvError("prod", ["dev", "prod"])).toBeUndefined();
+    expect(unknownEnvError("prod", undefined)).toBeUndefined();
+    expect(unknownEnvError("prod", [])).toBeUndefined();
+    expect(unknownEnvError(undefined, ["dev"])).toBeUndefined();
+  });
+  test("rejects an undeclared env with a clear message", () => {
+    expect(unknownEnvError("stage", ["dev", "prod"])).toMatch(/Unknown environment "stage".*dev, prod/);
+  });
+});
+
+describe("env-aware discovery (#505)", () => {
+  // Env is a build-context switch: the same source, discovered under a different
+  // CHANT_ENV, yields a different entity set (here a prod-only resource).
+  const src = `
+    export const base = { entityType: "Base", [Symbol.for("chant.declarable")]: true };
+    export const prodOnly = process.env.CHANT_ENV === "prod"
+      ? { entityType: "ProdOnly", [Symbol.for("chant.declarable")]: true }
+      : undefined;
+  `;
+
+  test("re-evaluates the project under the active environment", async () => {
+    // Distinct dirs → distinct module URLs → fresh import per env (import() caches by path).
+    const prodDir = join(tmpdir(), `chant-env-prod-${Date.now()}-${Math.random()}`);
+    const devDir = join(tmpdir(), `chant-env-dev-${Date.now()}-${Math.random()}`);
+    await mkdir(prodDir, { recursive: true });
+    await mkdir(devDir, { recursive: true });
+    await writeFile(join(prodDir, "app.ts"), src);
+    await writeFile(join(devDir, "app.ts"), src);
+    try {
+      let prod!: Awaited<ReturnType<typeof discover>>;
+      let dev!: Awaited<ReturnType<typeof discover>>;
+      await withEnv("prod", async () => { prod = await discover(prodDir); });
+      await withEnv("dev", async () => { dev = await discover(devDir); });
+      expect(prod.entities.has("base")).toBe(true);
+      expect(dev.entities.has("base")).toBe(true);
+      expect(prod.entities.has("prodOnly")).toBe(true); // present under prod
+      expect(dev.entities.has("prodOnly")).toBe(false); // absent under dev
+    } finally {
+      await rm(prodDir, { recursive: true, force: true });
+      await rm(devDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -1,0 +1,39 @@
+/**
+ * Active environment for a chant run (#505).
+ *
+ * `chant graph --env prod` / `chant build --env prod` set {@link ENV_VAR} before
+ * the project is discovered, so env-aware source can branch on it — producing an
+ * environment-specific graph (or build). Environments in chant are **build-context
+ * switches**, not a resource filter: there is no per-node env membership, so an
+ * "env view" comes from *re-evaluating* the project under the environment, exactly
+ * as a deploy of that environment would. Author env-aware source by branching on
+ * {@link env}:
+ *
+ * ```ts
+ * import { env } from "@intentius/chant";
+ * const replicas = env() === "prod" ? 5 : 1;
+ * ```
+ *
+ * Run `chant graph --env prod` and `chant graph --env dev` to get the two graphs;
+ * pinhole renders/diffs them to show environment drift (INTENTIUS/pinhole#3).
+ */
+
+/** The environment variable the CLI sets from `--env`. */
+export const ENV_VAR = "CHANT_ENV";
+
+/** The active environment for this run (from `--env`), or `fallback` if none. */
+export function env(fallback?: string): string | undefined {
+  return process.env[ENV_VAR] ?? fallback;
+}
+
+/**
+ * Validate a requested environment against the project's declared `environments`
+ * (`chant.config`). Returns an error message for an unknown env, or `undefined`
+ * when it's valid (or when the project declares no environments, in which case
+ * any name is accepted).
+ */
+export function unknownEnvError(requested: string | undefined, declared: string[] | undefined): string | undefined {
+  if (!requested || !declared || declared.length === 0) return undefined;
+  if (declared.includes(requested)) return undefined;
+  return `Unknown environment "${requested}". Declared environments: ${declared.join(", ")}.`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export * from "./discovery/graph";
 export * from "./discovery/index";
 export * from "./discovery/cache";
 export * from "./build";
+export * from "./env";
 export * from "./graph-ir";
 export * from "./graph-detail";
 export * from "./graph-mermaid";


### PR DESCRIPTION
## Why the lens became a re-eval

#505 asked for an `env:<name>` graph lens. But investigating, chant has **no per-node environment membership** — `--env` was only a policy-evaluation string, the graph never saw it, and resources aren't filtered by env. There's nothing in the IR to filter on, so a pure IR→IR env lens can't exist. Environments in chant are **build-context switches** (user code branches on the env), so that's what this implements.

## What

`--env` now sets `CHANT_ENV` before the project is discovered, so env-aware source re-evaluates for that environment and `chant graph --env <name>` yields an environment-specific graph.

- **`env.ts`** — `ENV_VAR` (`CHANT_ENV`), `env(fallback?)` for source to branch on, `unknownEnvError` validation; exported from the package.
- **main.ts** sets `process.env.CHANT_ENV` from `--env` *before* config load / discover (modules import once, so it must precede the first import), and rejects an `--env` not in the project's declared `environments` (clear error, exit 1).
- Applies to **build + graph** alike; composable with `--detail` and the other lenses.

## Unblocks pinhole#3

Run `chant graph --env dev` and `--env prod`, diff the two graphs → environment drift.

## Verified end to end

Fixture with `db = env() === "prod" ? RdsPostgres(...) : undefined`:
- `graph --env prod` → `db, net`
- `graph --env dev` → `net`
- `graph --env bogus` → exit 1, "Unknown environment 'bogus'. Declared environments: dev, prod."

tsc clean; **1878 core tests pass** (+4 new: `env()`, validation, env-aware discovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)