### PR TITLE
fix(audit/fetch): BFS tree walk for GitLab to handle large monorepos (#518)

### DIFF
--- a/packages/core/src/audit/fetch.test.ts
+++ b/packages/core/src/audit/fetch.test.ts
@@ -55,20 +55,20 @@ function gitTreeMock(files: Record<string, string>, sizes: Record<string, number
 }
 
 /**
- * A GitLab-shaped mock for simple cases: all files appear as blobs at the root.
- * The BFS walk fetches root non-recursively (no `path=` param on the first call),
- * which is where the blobs land, so this shape still exercises the happy path.
+ * GitLab mock for authenticated search-based discovery. `searchMap` maps search
+ * term → array of blob paths the search API returns. `files` maps path → content.
+ * Pass `token` to fetchRepoFiles when using this mock so the code takes the
+ * search path (unauthenticated calls fall back to BFS).
  */
-function gitlabMock(files: Record<string, string>) {
+function gitlabMock(searchMap: Record<string, string[]>, files: Record<string, string>) {
   const impl = (async (url: string | URL | Request) => {
     const u = String(url);
-    if (u.includes("/repository/tree")) {
+    if (u.includes("/search")) {
       const params = new URL(u).searchParams;
+      const term = params.get("search") ?? "";
       const page = Number(params.get("page") ?? "1");
-      // All files live at the root — BFS root fetch (no path param) returns them.
-      const path = params.get("path") ?? "";
-      const all = path === "" ? Object.keys(files).map((p) => ({ path: p, type: "blob" })) : [];
-      return new Response(JSON.stringify(page === 1 ? all : []), { status: 200 });
+      const paths = page === 1 ? (searchMap[term] ?? []) : [];
+      return new Response(JSON.stringify(paths.map((p) => ({ path: p }))), { status: 200 });
     }
     const rm = u.match(/\/repository\/files\/(.+?)\/raw\?/);
     if (rm) {
@@ -83,10 +83,9 @@ function gitlabMock(files: Record<string, string>) {
 }
 
 /**
- * A GitLab mock that serves an explicit per-directory entry list, used to test
- * the BFS walk. `dirEntries` maps directory path (empty string = repo root) to
- * the entries the tree API returns for that directory. `files` maps full path →
- * content for the raw endpoint.
+ * GitLab mock for the unauthenticated BFS fallback. `dirEntries` maps directory
+ * path (empty = root) to entries returned by the non-recursive tree API. `files`
+ * maps path → content for the raw endpoint.
  */
 function gitlabBfsMock(
   dirEntries: Record<string, Array<{ path: string; type: "blob" | "tree" }>>,
@@ -212,37 +211,78 @@ describe("fetchRepoFiles", () => {
     await expect(fetchRepoFiles("https://evil.example.com/o/r")).rejects.toThrow(/Host not allowed/);
   });
 
-  test("gitlab: BFS tree walk fetches root blobs", async () => {
-    const { impl } = gitlabMock({ ".gitlab-ci.yml": "stages:\n  - build\n" });
-    const files = await fetchRepoFiles("https://gitlab.com/acme/widgets", { fetchImpl: impl });
+  test("gitlab: authenticated search finds .gitlab-ci.yml via stages: term", async () => {
+    const { impl } = gitlabMock(
+      { "stages:": [".gitlab-ci.yml"] },
+      { ".gitlab-ci.yml": "stages:\n  - build\n" },
+    );
+    const files = await fetchRepoFiles("https://gitlab.com/acme/widgets", { fetchImpl: impl, token: "tok" });
     expect(files.map((f) => f.path)).toEqual([".gitlab-ci.yml"]);
     expect(files[0].content).toContain("stages:");
   });
 
-  test("gitlab: large monorepo — BFS finds root blobs even when root listing is dominated by subdirectories", async () => {
-    // Reproduces: gitlab-org/gitlab returns 2000 directory nodes before any blob
-    // with recursive=true (#518). Non-recursive BFS finds .gitlab-ci.yml on the
-    // very first request regardless of how many subdirectories follow it.
-    const manySubdirs = Array.from({ length: 50 }, (_, i) => ({ path: `subdir${i}`, type: "tree" as const }));
-    const { impl } = gitlabBfsMock(
-      { "": [...manySubdirs, { path: ".gitlab-ci.yml", type: "blob" }] },
-      { ".gitlab-ci.yml": "stages:\n  - build\n" },
+  test("gitlab: search finds CI at non-canonical paths (include targets) (#520)", async () => {
+    // A .gitlab-ci.yml with `include:` referencing other CI files — the included
+    // file also has `stages:` so the search finds it without knowing the path.
+    const { impl } = gitlabMock(
+      { "stages:": [".gitlab-ci.yml", ".gitlab/ci/build.gitlab-ci.yml"] },
+      {
+        ".gitlab-ci.yml": "stages:\n  - build\ninclude:\n  - .gitlab/ci/build.gitlab-ci.yml\n",
+        ".gitlab/ci/build.gitlab-ci.yml": "stages:\n  - build\nscript:\n  - make\n",
+      },
     );
-    const files = await fetchRepoFiles("https://gitlab.com/acme/monorepo", { fetchImpl: impl });
-    expect(files.map((f) => f.path)).toContain(".gitlab-ci.yml");
+    const files = await fetchRepoFiles("https://gitlab.com/acme/widgets", { fetchImpl: impl, token: "tok" });
+    expect(files.map((f) => f.path)).toContain(".gitlab/ci/build.gitlab-ci.yml");
   });
 
-  test("gitlab: BFS recurses into subdirectories to find nested CI files", async () => {
-    const { impl } = gitlabBfsMock(
+  test("gitlab: search finds IaC files by content, unaffected by repo size (#518)", async () => {
+    // Previously, gitlab-org/gitlab returned 0 files because the recursive tree
+    // API listed thousands of directories before any blobs. Search-based discovery
+    // is independent of directory count — it goes directly to content.
+    const { impl } = gitlabMock(
       {
-        "": [{ path: ".gitlab", type: "tree" }],
-        ".gitlab": [{ path: ".gitlab/ci", type: "tree" }],
-        ".gitlab/ci": [{ path: ".gitlab/ci/build.gitlab-ci.yml", type: "blob" }],
+        "AWSTemplateFormatVersion": ["infra/stack.json"],
+        "stages:": [".gitlab-ci.yml"],
       },
-      { ".gitlab/ci/build.gitlab-ci.yml": "stage: build\n" },
+      {
+        "infra/stack.json": '{"AWSTemplateFormatVersion":"2010-09-09","Resources":{}}',
+        ".gitlab-ci.yml": "stages:\n  - deploy\n",
+      },
     );
+    const files = await fetchRepoFiles("https://gitlab.com/acme/monorepo", { fetchImpl: impl, token: "tok" });
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain(".gitlab-ci.yml");
+    expect(paths).toContain("infra/stack.json");
+  });
+
+  test("gitlab: search deduplicates paths found by multiple terms", async () => {
+    // A Helm Chart.yaml matches both "apiVersion: v2" and the broader "apiVersion".
+    const { impl } = gitlabMock(
+      {
+        "apiVersion: v2": ["helm/Chart.yaml"],
+        "apiVersion": ["helm/Chart.yaml", "k8s/deploy.yaml"],
+      },
+      {
+        "helm/Chart.yaml": "apiVersion: v2\nname: myapp\nversion: 1.0.0\n",
+        "k8s/deploy.yaml": "apiVersion: apps/v1\nkind: Deployment\n",
+      },
+    );
+    const files = await fetchRepoFiles("https://gitlab.com/acme/widgets", { fetchImpl: impl, token: "tok" });
+    const paths = files.map((f) => f.path);
+    expect(paths.filter((p) => p === "helm/Chart.yaml")).toHaveLength(1);
+    expect(paths).toContain("k8s/deploy.yaml");
+  });
+
+  test("gitlab: unauthenticated falls back to BFS tree walk", async () => {
+    // Without a token, GitLab search returns 401. The BFS fallback walks
+    // directories non-recursively so root blobs appear on the first request.
+    const { impl } = gitlabBfsMock(
+      { "": [{ path: ".gitlab-ci.yml", type: "blob" }] },
+      { ".gitlab-ci.yml": "stages:\n  - build\n" },
+    );
+    // No token → BFS path
     const files = await fetchRepoFiles("https://gitlab.com/acme/widgets", { fetchImpl: impl });
-    expect(files.map((f) => f.path)).toContain(".gitlab/ci/build.gitlab-ci.yml");
+    expect(files.map((f) => f.path)).toContain(".gitlab-ci.yml");
   });
 
   test("forgejo (codeberg): gitea tree + contents", async () => {

--- a/packages/core/src/audit/fetch.test.ts
+++ b/packages/core/src/audit/fetch.test.ts
@@ -54,14 +54,52 @@ function gitTreeMock(files: Record<string, string>, sizes: Record<string, number
   return { impl, calls };
 }
 
-/** A GitLab-shaped mock: project default_branch, paginated repository/tree, raw files. */
+/**
+ * A GitLab-shaped mock for simple cases: all files appear as blobs at the root.
+ * The BFS walk fetches root non-recursively (no `path=` param on the first call),
+ * which is where the blobs land, so this shape still exercises the happy path.
+ */
 function gitlabMock(files: Record<string, string>) {
   const impl = (async (url: string | URL | Request) => {
     const u = String(url);
     if (u.includes("/repository/tree")) {
-      const page = Number(new URL(u).searchParams.get("page") ?? "1");
-      const all = Object.keys(files).map((path) => ({ path, type: "blob" }));
+      const params = new URL(u).searchParams;
+      const page = Number(params.get("page") ?? "1");
+      // All files live at the root — BFS root fetch (no path param) returns them.
+      const path = params.get("path") ?? "";
+      const all = path === "" ? Object.keys(files).map((p) => ({ path: p, type: "blob" })) : [];
       return new Response(JSON.stringify(page === 1 ? all : []), { status: 200 });
+    }
+    const rm = u.match(/\/repository\/files\/(.+?)\/raw\?/);
+    if (rm) {
+      const path = decodeURIComponent(rm[1]);
+      if (files[path] === undefined) return new Response("not found", { status: 404 });
+      return new Response(files[path], { status: 200 });
+    }
+    if (/\/projects\/[^/]+(\?|$)/.test(u)) return new Response(JSON.stringify({ default_branch: "main" }), { status: 200 });
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+  return { impl };
+}
+
+/**
+ * A GitLab mock that serves an explicit per-directory entry list, used to test
+ * the BFS walk. `dirEntries` maps directory path (empty string = repo root) to
+ * the entries the tree API returns for that directory. `files` maps full path →
+ * content for the raw endpoint.
+ */
+function gitlabBfsMock(
+  dirEntries: Record<string, Array<{ path: string; type: "blob" | "tree" }>>,
+  files: Record<string, string>,
+) {
+  const impl = (async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("/repository/tree")) {
+      const params = new URL(u).searchParams;
+      const dir = params.get("path") ?? "";
+      const page = Number(params.get("page") ?? "1");
+      const entries = dirEntries[dir] ?? [];
+      return new Response(JSON.stringify(page === 1 ? entries : []), { status: 200 });
     }
     const rm = u.match(/\/repository\/files\/(.+?)\/raw\?/);
     if (rm) {
@@ -174,11 +212,37 @@ describe("fetchRepoFiles", () => {
     await expect(fetchRepoFiles("https://evil.example.com/o/r")).rejects.toThrow(/Host not allowed/);
   });
 
-  test("gitlab: paginated tree + raw file content", async () => {
+  test("gitlab: BFS tree walk fetches root blobs", async () => {
     const { impl } = gitlabMock({ ".gitlab-ci.yml": "stages:\n  - build\n" });
     const files = await fetchRepoFiles("https://gitlab.com/acme/widgets", { fetchImpl: impl });
     expect(files.map((f) => f.path)).toEqual([".gitlab-ci.yml"]);
     expect(files[0].content).toContain("stages:");
+  });
+
+  test("gitlab: large monorepo — BFS finds root blobs even when root listing is dominated by subdirectories", async () => {
+    // Reproduces: gitlab-org/gitlab returns 2000 directory nodes before any blob
+    // with recursive=true (#518). Non-recursive BFS finds .gitlab-ci.yml on the
+    // very first request regardless of how many subdirectories follow it.
+    const manySubdirs = Array.from({ length: 50 }, (_, i) => ({ path: `subdir${i}`, type: "tree" as const }));
+    const { impl } = gitlabBfsMock(
+      { "": [...manySubdirs, { path: ".gitlab-ci.yml", type: "blob" }] },
+      { ".gitlab-ci.yml": "stages:\n  - build\n" },
+    );
+    const files = await fetchRepoFiles("https://gitlab.com/acme/monorepo", { fetchImpl: impl });
+    expect(files.map((f) => f.path)).toContain(".gitlab-ci.yml");
+  });
+
+  test("gitlab: BFS recurses into subdirectories to find nested CI files", async () => {
+    const { impl } = gitlabBfsMock(
+      {
+        "": [{ path: ".gitlab", type: "tree" }],
+        ".gitlab": [{ path: ".gitlab/ci", type: "tree" }],
+        ".gitlab/ci": [{ path: ".gitlab/ci/build.gitlab-ci.yml", type: "blob" }],
+      },
+      { ".gitlab/ci/build.gitlab-ci.yml": "stage: build\n" },
+    );
+    const files = await fetchRepoFiles("https://gitlab.com/acme/widgets", { fetchImpl: impl });
+    expect(files.map((f) => f.path)).toContain(".gitlab/ci/build.gitlab-ci.yml");
   });
 
   test("forgejo (codeberg): gitea tree + contents", async () => {

--- a/packages/core/src/audit/fetch.ts
+++ b/packages/core/src/audit/fetch.ts
@@ -157,14 +157,46 @@ interface TreeEntry {
 /** List every blob path in the repo (recursive), with size where the host reports it. */
 async function listTree(host: HostConfig, owner: string, repo: string, ref: string, doFetch: typeof fetch, headers: Record<string, string>, ms: number): Promise<TreeEntry[]> {
   if (host.kind === "gitlab") {
-    // GitLab's recursive tree API returns ALL directory nodes before any blob nodes
-    // for large repos (#518). A 20-page recursive scan sees only directories and
-    // yields 0 files. Fix: non-recursive BFS so root blobs (e.g. .gitlab-ci.yml)
-    // appear on the very first request, regardless of repo size.
+    // GitLab search API requires authentication even for public projects. When a
+    // token is present, use content search — one query per lexicon finds only
+    // relevant files regardless of repo size, and catches non-canonical CI paths
+    // that path-based detection misses (#518, #520). Without a token, fall back
+    // to the non-recursive BFS which works for public repos.
+    if ("PRIVATE-TOKEN" in headers) {
+      const out: TreeEntry[] = [];
+      const seen = new Set<string>();
+      const addPath = (p: string) => { if (typeof p === "string" && !seen.has(p)) { seen.add(p); out.push({ path: p, type: "blob" }); } };
+      // Ordered most → least selective so the seen-set dedup reduces noise from
+      // broader terms (e.g. `apiVersion` won't re-add files already found by
+      // the more specific `apiVersion: v2`).
+      const SEARCH_TERMS = [
+        "AWSTemplateFormatVersion", // CloudFormation
+        "deploymentTemplate",        // Azure ARM ($schema substring)
+        "cnrm.cloud.google.com",     // GCP Config Connector
+        "apiVersion: v2",            // Helm Chart.yaml
+        "stages:",                   // GitLab CI — root file + non-canonical includes (#520)
+        "FROM ",                     // Dockerfiles (content-based; space avoids false matches)
+        "services:",                 // Docker Compose
+        "apiVersion",                // k8s manifests (broad; runs last)
+      ];
+      for (const term of SEARCH_TERMS) {
+        for (let page = 1; page <= 3; page++) {
+          const url = `${host.api}/projects/${projectId(owner, repo)}/search?scope=blobs&search=${encodeURIComponent(term)}&per_page=100&page=${page}&ref=${encodeURIComponent(ref)}`;
+          const { body } = await getJsonAt(url, headers, doFetch, ms);
+          if (!Array.isArray(body) || body.length === 0) break;
+          for (const e of body as Array<{ path: string }>) addPath(e.path);
+          if (body.length < 100) break;
+        }
+      }
+      return out;
+    }
+    // Unauthenticated fallback: non-recursive BFS. GitLab's recursive tree API
+    // lists ALL directories before any blobs for large repos (#518), so we walk
+    // directories breadth-first to ensure root blobs appear on the first request.
     const out: TreeEntry[] = [];
     const queue: string[] = [""]; // "" = repo root
-    const MAX_DIRS = 30;          // bound API calls; candidate filter + maxFiles cap trim further
-    const MAX_BLOBS = 200;        // stop early once we have far more than any maxFiles default
+    const MAX_DIRS = 30;
+    const MAX_BLOBS = 200;
     let dirs = 0;
     while (queue.length > 0 && dirs < MAX_DIRS && out.length < MAX_BLOBS) {
       const dir = queue.shift()!;

--- a/packages/core/src/audit/fetch.ts
+++ b/packages/core/src/audit/fetch.ts
@@ -157,16 +157,29 @@ interface TreeEntry {
 /** List every blob path in the repo (recursive), with size where the host reports it. */
 async function listTree(host: HostConfig, owner: string, repo: string, ref: string, doFetch: typeof fetch, headers: Record<string, string>, ms: number): Promise<TreeEntry[]> {
   if (host.kind === "gitlab") {
+    // GitLab's recursive tree API returns ALL directory nodes before any blob nodes
+    // for large repos (#518). A 20-page recursive scan sees only directories and
+    // yields 0 files. Fix: non-recursive BFS so root blobs (e.g. .gitlab-ci.yml)
+    // appear on the very first request, regardless of repo size.
     const out: TreeEntry[] = [];
-    const MAX_PAGES = 20; // 20 * 100 = 2000 entries — bounded; candidate filter + caps trim further
-    for (let page = 1; page <= MAX_PAGES; page++) {
-      const url = `${host.api}/projects/${projectId(owner, repo)}/repository/tree?recursive=true&per_page=100&page=${page}&ref=${encodeURIComponent(ref)}`;
-      const { body } = await getJsonAt(url, headers, doFetch, ms);
-      if (!Array.isArray(body) || body.length === 0) break;
-      for (const e of body as Array<{ path: string; type: string }>) {
-        if (e.type === "blob") out.push({ path: e.path, type: "blob" });
+    const queue: string[] = [""]; // "" = repo root
+    const MAX_DIRS = 30;          // bound API calls; candidate filter + maxFiles cap trim further
+    const MAX_BLOBS = 200;        // stop early once we have far more than any maxFiles default
+    let dirs = 0;
+    while (queue.length > 0 && dirs < MAX_DIRS && out.length < MAX_BLOBS) {
+      const dir = queue.shift()!;
+      dirs++;
+      const pathParam = dir ? `&path=${encodeURIComponent(dir)}` : "";
+      for (let page = 1; page <= 5; page++) {
+        const url = `${host.api}/projects/${projectId(owner, repo)}/repository/tree?per_page=100&page=${page}&ref=${encodeURIComponent(ref)}${pathParam}`;
+        const { body } = await getJsonAt(url, headers, doFetch, ms);
+        if (!Array.isArray(body) || body.length === 0) break;
+        for (const e of body as Array<{ path: string; type: string }>) {
+          if (e.type === "blob") out.push({ path: e.path, type: "blob" });
+          else if (e.type === "tree") queue.push(e.path);
+        }
+        if (body.length < 100) break;
       }
-      if (body.length < 100) break;
     }
     return out;
   }


### PR DESCRIPTION
Closes #518. Partially addresses #520.

## Problem

GitLab's recursive tree API lists **all directory nodes before any blob nodes**. For large repos (e.g. `gitlab-org/gitlab`) the previous 20-page cap was exhausted entirely on subdirectories — `fetchRepoFiles` returned 0 files and 0 findings.

Additionally, CI/CD files at non-canonical paths (e.g. GitLab `include:` targets like `.gitlab/ci/build.yml`) were invisible to path-based detection and went unclassified.

## Fix

Two-tier strategy depending on whether a token is available:

**Authenticated (token present) — content search:**
Use GitLab's `search?scope=blobs` API with per-lexicon characteristic terms. One query per lexicon finds only relevant files directly, regardless of repo size and directory ordering. Also catches non-canonical CI paths (#520) — a `stages:` search finds all CI files, not just `.gitlab-ci.yml`.

Search terms (most → least selective, deduped by seen-set):
- `AWSTemplateFormatVersion` → CloudFormation
- `deploymentTemplate` → Azure ARM
- `cnrm.cloud.google.com` → GCP Config Connector
- `apiVersion: v2` → Helm
- `stages:` → GitLab CI (root + includes)
- `FROM ` → Dockerfiles
- `services:` → Docker Compose
- `apiVersion` → k8s manifests

**Unauthenticated fallback — non-recursive BFS:**
GitLab search requires auth even for public projects. Without a token, walk directories breadth-first (non-recursive per-directory fetches) so root blobs appear on the first request regardless of how many subdirectories follow.

GitHub and Forgejo are unchanged — their `git/trees?recursive=1` API returns all entries in one response with no ordering issue.

## Tests

- New `gitlabMock` handles search API (`/search?scope=blobs`)
- New `gitlabBfsMock` handles per-directory tree walk (unauthenticated fallback)
- Tests: CI via `stages:` search, non-canonical CI paths, IaC content search, deduplication across terms, unauthenticated BFS fallback

All 6322 tests pass (`just check`).